### PR TITLE
feat: add publish script to inline doc symlinks before packing

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "check-readme": "node scripts/update-readme.ts --check",
     "update-examples": "node scripts/update-examples.ts",
     "check-examples": "node scripts/update-examples.ts --check",
+    "pub": "./scripts/publish",
     "prepublishOnly": "pnpm build"
   },
   "prettier": "@tomer/prettier-config",

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+docs_dir="$script_dir/../docs"
+
+# Collect all symlinks in docs/
+declare -A symlinks
+
+while IFS= read -r -d '' link; do
+  symlinks["$link"]=$(readlink "$link")
+done < <(find "$docs_dir" -type l -print0)
+
+# Restore symlinks on exit (success or failure)
+restore_symlinks() {
+  for link in "${!symlinks[@]}"; do
+    rm -f "$link"
+    ln -s "${symlinks[$link]}" "$link"
+  done
+}
+trap restore_symlinks EXIT
+
+# Replace symlinks with real file copies so pnpm packs them
+for link in "${!symlinks[@]}"; do
+  link_dir=$(dirname "$link")
+  cp "$link_dir/${symlinks[$link]}" "${link}.tmp"
+  rm "$link"
+  mv "${link}.tmp" "$link"
+done
+
+pnpm publish "$@"


### PR DESCRIPTION
pnpm does not follow symlinks when packing, so the aliased docs in docs/languages/ (cpp.md, kotlin.md, typescript.md) were missing from published packages. The new scripts/publish script replaces symlinks with real file copies before packing and restores them via a trap on exit, keeping symlinks intact in the repository.

Closes #100