### PR TITLE
refactor: rename frame concepts to stack frame

### DIFF
--- a/.claude/dimensions.md
+++ b/.claude/dimensions.md
@@ -15,11 +15,11 @@ Before writing code for it:
    - The **modality or modalities**, across formats → the modality's (e.g.
      `aggregate.ts`)
    - The **origin(s)**, across formats → the origin's code (e.g.
-     `OriginSpec.normalizeFrame`); multiple origins observing the same runtime
-     share the logic through a helper module (e.g. `src/origins/jvm.ts`), never
-     a merged spec
+     `OriginSpec.normalizeStackFrame`); multiple origins observing the same
+     runtime share the logic through a helper module (e.g.
+     `src/origins/jvm.ts`), never a merged spec
    - Specific **origin-format pairs** → the origin's code, checking the `format`
-     param (e.g. in `normalizeFrame`)
+     param (e.g. in `normalizeStackFrame`)
    - **Profiles generally** → the shared pipeline
 
 The classification is subjective and NOT about writing the logic in the fewest

--- a/.claude/skills/new-origin/SKILL.md
+++ b/.claude/skills/new-origin/SKILL.md
@@ -41,8 +41,8 @@ $ARGUMENTS
    - `categorizeEntry`: compose from the `src/origins/categorize.ts` helpers
      plus profiler-specific rules
    - `categorizeSnapshotConstructor` when the origin writes heap snapshots
-   - `normalizeFrame` when the profiler packs a frame's location into its name
-     (see `packedLocationNormalizer`)
+   - `normalizeStackFrame` when the profiler packs a frame's location into its
+     name (see `packedLocationNormalizer`)
    - `matchEntry` when the profiler bakes run-varying identifiers (build hashes,
      runtime addresses) into names or paths (see `matchEntryFromRules`)
 
@@ -52,11 +52,11 @@ $ARGUMENTS
    satisfy (e.g. Deno before Node, since Deno supports `node:` specifiers)
 
    Add a colocated `src/origins/specs/<origin>.test.ts` for the origin's own
-   logic: detection, `categorizeEntry`, and any `normalizeFrame` or `matchEntry`
-   rules. Build entries with the `absoluteEntry`/`relativeEntry` helpers from
-   `src/origins/testing.ts`, drive detection through its `determineOrigin`, and
-   test categorization against its exported `OriginSpec` (e.g.
-   `nodeOriginSpec.categorizeEntry`).
+   logic: detection, `categorizeEntry`, and any `normalizeStackFrame` or
+   `matchEntry` rules. Build entries with the `absoluteEntry`/`relativeEntry`
+   helpers from `src/origins/testing.ts`, drive detection through its
+   `determineOrigin`, and test categorization against its exported `OriginSpec`
+   (e.g. `nodeOriginSpec.categorizeEntry`).
 
    `src/origins/categorize.test.ts` holds only cross-origin invariants every
    origin must satisfy (looping over `origins`); touch it only if the new origin

--- a/src/formats/collapsed/index.test.ts
+++ b/src/formats/collapsed/index.test.ts
@@ -55,7 +55,7 @@ describe(`matches`, () => {
 describe(`convert`, () => {
   test(`tachyon "file:func:line" stacks: reversal and locations`, () => {
     // The `tid:` root frame marks the profile as tachyon, whose
-    // `normalizeFrame` splits the `file:func:line` shape, keeping the packed
+    // `normalizeStackFrame` splits the `file:func:line` shape, keeping the packed
     // line as the executing line. The duplicate `work` stack sums to 10.
     const md = convertBytesToMd(
       collapsedConverter,

--- a/src/formats/jfr/testing.ts
+++ b/src/formats/jfr/testing.ts
@@ -16,10 +16,10 @@ export type JfrTestMethod = {
 }
 
 /** A frame referencing a {@link JfrTestMethod} by index. */
-type JfrTestFrame = { method: number; line?: number }
+type JfrTestStackFrame = { method: number; line?: number }
 
 /** A call stack referenced by events by index. */
-export type JfrTestStack = { frames: JfrTestFrame[] }
+export type JfrTestStack = { frames: JfrTestStackFrame[] }
 
 /** An event referencing a {@link JfrTestStack} by index. */
 export type JfrTestEvent = {

--- a/src/formats/pprof/parse.ts
+++ b/src/formats/pprof/parse.ts
@@ -16,11 +16,11 @@ export const parsePprof = (bytes: Uint8Array): Profile[] => {
     profile,
     string,
   )
-  const { frames, frameIndexByFunctionId } = parseFunctionFrames(
+  const { frames, frameIndexByFunctionId } = parseFunctionStackFrames(
     profile,
     string,
   )
-  const framesByLocationId = resolveLocationFrames(
+  const framesByLocationId = resolveLocationStackFrames(
     profile,
     frameIndexByFunctionId,
   )
@@ -112,7 +112,7 @@ const parseSampleTypes = (
  * bytes, deterministically per value) so the per-sample lookups never build
  * key strings.
  */
-const parseFunctionFrames = (
+const parseFunctionStackFrames = (
   profile: PprofProto,
   string: StringReader,
 ): {
@@ -134,18 +134,18 @@ const parseFunctionFrames = (
   return { frames, frameIndexByFunctionId }
 }
 
-type LocationFrame = { frame: number; line: number }
+type LocationStackFrame = { frame: number; line: number }
 
 /**
  * Each location resolves to its frame indices and lines, dropping any frame
  * whose function is absent from the table (unsymbolized) rather than carrying
  * a dangling reference into aggregation.
  */
-const resolveLocationFrames = (
+const resolveLocationStackFrames = (
   profile: PprofProto,
   frameIndexByFunctionId: Map<number | bigint, number>,
-): Map<number | bigint, LocationFrame[]> => {
-  const framesByLocationId = new Map<number | bigint, LocationFrame[]>()
+): Map<number | bigint, LocationStackFrame[]> => {
+  const framesByLocationId = new Map<number | bigint, LocationStackFrame[]>()
   for (const location of profile.location) {
     framesByLocationId.set(
       location.id,
@@ -160,7 +160,7 @@ const resolveLocationFrames = (
 
 const parseSamples = (
   profile: PprofProto,
-  framesByLocationId: Map<number | bigint, LocationFrame[]>,
+  framesByLocationId: Map<number | bigint, LocationStackFrame[]>,
   metricValueIndices: number[],
   countValueIndex: number | undefined,
 ): Sample[] => {

--- a/src/formats/speedscope/parse.ts
+++ b/src/formats/speedscope/parse.ts
@@ -134,7 +134,7 @@ const exporterOriginHint = (
 // The `line`/`col` are read as the function's definition position, matching
 // speedscope's own importer, which keys each frames-array entry as a distinct
 // frame. Some profilers (py-spy, rbspy) instead emit one frame per *sampled*
-// line; their origins' `normalizeFrame` reinterprets the line as the executing
+// line; their origins' `normalizeStackFrame` reinterprets the line as the executing
 // line (see `normalizeSpeedscopeExecutingLine` in `src/origins/origin.ts`).
 const frameToStackFrame = (frame: SpeedscopeFrame): ProfileStackFrame => ({
   name: frame.name,

--- a/src/formats/systing/parse.ts
+++ b/src/formats/systing/parse.ts
@@ -164,7 +164,7 @@ class SystingProfileBuilder {
     switch (record[0]) {
       case `f`: {
         const [, id, name] = record as [string, number, string]
-        this.#addFrame(id, name)
+        this.#addStackFrame(id, name)
         break
       }
       case `s`: {
@@ -188,7 +188,7 @@ class SystingProfileBuilder {
     }
   }
 
-  #addFrame(id: number, name: string): void {
+  #addStackFrame(id: number, name: string): void {
     const index = this.#frames.length
     this.#frames.push({ name })
     this.#frameIndices.set(id, index)

--- a/src/formats/webkit-timeline-recording/index.test.ts
+++ b/src/formats/webkit-timeline-recording/index.test.ts
@@ -9,7 +9,7 @@ import { defaultShowEntry, normalizeProfileToMdOptions } from '../../options.ts'
 import { categoryTables, summaryLines } from '../../testing.ts'
 import { convertJsonToMd } from '../testing.ts'
 import { webkitTimelineRecordingConverter } from './index.ts'
-import { makeWebKitFrame, makeWebKitRecording } from './testing.ts'
+import { makeWebKitRecording, makeWebKitStackFrame } from './testing.ts'
 
 describe(`matches`, () => {
   test(`accepts valid recording`, () => {
@@ -69,12 +69,12 @@ describe(`convert`, () => {
       sampleStackTraces: [
         {
           stackFrames: [
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `work`,
               url: `file:///project/src/index.ts`,
               line: 10,
             }),
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `main`,
               url: `file:///project/src/index.ts`,
             }),
@@ -82,12 +82,12 @@ describe(`convert`, () => {
         },
         {
           stackFrames: [
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `work`,
               url: `file:///project/src/index.ts`,
               line: 10,
             }),
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `main`,
               url: `file:///project/src/index.ts`,
             }),
@@ -95,7 +95,7 @@ describe(`convert`, () => {
         },
         {
           stackFrames: [
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `main`,
               url: `file:///project/src/index.ts`,
             }),
@@ -158,7 +158,7 @@ describe(`convert`, () => {
         { stackFrames: [] },
         {
           stackFrames: [
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `main`,
               url: `file:///project/src/index.ts`,
             }),
@@ -219,11 +219,11 @@ describe(`convert`, () => {
       sampleStackTraces: [
         {
           stackFrames: [
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `factorial`,
               url: `file:///project/src/index.ts`,
             }),
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `factorial`,
               url: `file:///project/src/index.ts`,
             }),
@@ -231,7 +231,7 @@ describe(`convert`, () => {
         },
         {
           stackFrames: [
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `factorial`,
               url: `file:///project/src/index.ts`,
             }),
@@ -269,12 +269,12 @@ describe(`convert`, () => {
       sampleStackTraces: [
         {
           stackFrames: [
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `anon`,
               url: `https://example.com/app.js`,
               column: 244,
             }),
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `main`,
               url: `file:///project/src/index.ts`,
             }),
@@ -282,11 +282,11 @@ describe(`convert`, () => {
         },
         {
           stackFrames: [
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `thirdParty`,
               url: `file:///project/node_modules/lib/index.js`,
             }),
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `main`,
               url: `file:///project/src/index.ts`,
             }),
@@ -318,13 +318,13 @@ describe(`convert`, () => {
       sampleStackTraces: [
         {
           stackFrames: [
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `work`,
               url: `file:///project/src/index.ts`,
               line: 10,
               expressionLocation: { line: 12, column: 1 },
             }),
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `main`,
               url: `file:///project/src/index.ts`,
             }),
@@ -332,13 +332,13 @@ describe(`convert`, () => {
         },
         {
           stackFrames: [
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `work`,
               url: `file:///project/src/index.ts`,
               line: 10,
               expressionLocation: { line: 15, column: 1 },
             }),
-            makeWebKitFrame({
+            makeWebKitStackFrame({
               name: `main`,
               url: `file:///project/src/index.ts`,
             }),
@@ -382,12 +382,12 @@ describe(`options`, () => {
     sampleStackTraces: [
       {
         stackFrames: [
-          makeWebKitFrame({
+          makeWebKitStackFrame({
             name: `work`,
             url: `file:///project/src/index.ts`,
             line: 10,
           }),
-          makeWebKitFrame({
+          makeWebKitStackFrame({
             name: `main`,
             url: `file:///project/src/index.ts`,
           }),
@@ -395,12 +395,12 @@ describe(`options`, () => {
       },
       {
         stackFrames: [
-          makeWebKitFrame({
+          makeWebKitStackFrame({
             name: `work`,
             url: `file:///project/src/index.ts`,
             line: 10,
           }),
-          makeWebKitFrame({
+          makeWebKitStackFrame({
             name: `main`,
             url: `file:///project/src/index.ts`,
           }),
@@ -408,7 +408,7 @@ describe(`options`, () => {
       },
       {
         stackFrames: [
-          makeWebKitFrame({
+          makeWebKitStackFrame({
             name: `main`,
             url: `file:///project/src/index.ts`,
           }),

--- a/src/formats/webkit-timeline-recording/parse.ts
+++ b/src/formats/webkit-timeline-recording/parse.ts
@@ -65,7 +65,7 @@ export type WebKitTimelineRecording = {
 export const parseWebKitTimelineRecording = ({
   recording: { sampleStackTraces, sampleDurations },
 }: WebKitTimelineRecording): Profile[] => {
-  const { frames, intern } = createFrameInterner()
+  const { frames, intern } = createStackFrameInterner()
   const samples: Sample[] = []
   for (let index = 0; index < sampleStackTraces.length; index++) {
     const { stackFrames } = sampleStackTraces[index]!
@@ -88,7 +88,7 @@ export const parseWebKitTimelineRecording = ({
  * Frames are inlined per sample rather than in a shared table, so dedup them
  * by identity; a frame's index is its position in `frames`.
  */
-const createFrameInterner = (): {
+const createStackFrameInterner = (): {
   frames: ProfileStackFrame[]
   intern: (frame: WebKitStackFrame) => number
 } => {

--- a/src/formats/webkit-timeline-recording/testing.ts
+++ b/src/formats/webkit-timeline-recording/testing.ts
@@ -11,7 +11,7 @@ export const makeWebKitRecording = ({
   recording: { sampleStackTraces, sampleDurations },
 })
 
-export const makeWebKitFrame = ({
+export const makeWebKitStackFrame = ({
   name,
   url,
   line = 1,

--- a/src/modalities/profile/aggregate.ts
+++ b/src/modalities/profile/aggregate.ts
@@ -5,7 +5,7 @@ import type {
   AggregationProfileToMdOptions,
   ProfileToMdContext,
 } from '../../options.ts'
-import { normalizeFrameForContext } from '../../origins/index.ts'
+import { normalizeStackFrameForContext } from '../../origins/index.ts'
 import type { OriginDetector } from '../../origins/index.ts'
 import type { InputAggregator } from '../aggregator.ts'
 import type { Metric } from './metric.ts'
@@ -135,7 +135,7 @@ class ProfileStackFrameTable {
 
   #normalize(context: ProfileToMdContext): ProfileFunctionTable {
     return new ProfileFunctionTable(
-      this.#frames.map(frame => normalizeFrameForContext(frame, context)),
+      this.#frames.map(frame => normalizeStackFrameForContext(frame, context)),
     )
   }
 }
@@ -285,7 +285,7 @@ class SamplesAggregator {
     // intern to the same call stack while sampling different executing lines.
     //
     // When the sample has no explicit line, fall back to the leaf frame's
-    // sampled line, the one its origin's `normalizeFrame` derived so it
+    // sampled line, the one its origin's `normalizeStackFrame` derived so it
     // appears in the function's line breakdown.
     let leafLine = line
     if (leafLine === undefined) {

--- a/src/modalities/profile/type.ts
+++ b/src/modalities/profile/type.ts
@@ -52,7 +52,7 @@ export type Profile = {
  * {@link line} is the *executing* line and is used for the per-line breakdown,
  * not identity.
  *
- * A converter produces these raw; the resolved origin's `normalizeFrame` then
+ * A converter produces these raw; the resolved origin's `normalizeStackFrame` then
  * splits out the location and line for variants that pack them into the frame
  * string.
  */

--- a/src/origins/index.ts
+++ b/src/origins/index.ts
@@ -43,13 +43,13 @@ export const matchEntryForOrigin = (
   return spec.matchEntry?.(entry)
 }
 
-export const normalizeFrameForContext = (
+export const normalizeStackFrameForContext = (
   frame: ProfileStackFrame,
   { format, origin }: ProfileToMdContext,
 ): ProfileStackFrame | null => {
   const spec: OriginSpec = originToSpec.get(origin)!
-  const normalizedFrame = spec.normalizeFrame
-    ? spec.normalizeFrame(frame, format)
+  const normalizedFrame = spec.normalizeStackFrame
+    ? spec.normalizeStackFrame(frame, format)
     : frame
   if (!normalizedFrame) {
     return null

--- a/src/origins/jvm.ts
+++ b/src/origins/jvm.ts
@@ -49,7 +49,7 @@ export const categorizeJvmEntry = (
  * Whether a raw async-profiler frame name is in a JVM standard-library package,
  * before its `/`s become `.`s.
  */
-export const isJvmStdlibNameFrame = (name: string | undefined): boolean =>
+export const isJvmStdlibNameStackFrame = (name: string | undefined): boolean =>
   name !== undefined && JVM_STDLIB_PACKAGE.test(name)
 
 /** Categorizes Java standard-library and JDK-internal frames as `stdlib`. */
@@ -118,7 +118,7 @@ const GC_STUB = /^g1_(?:pre|post)_barrier_slow$/u
  * own stack walker mixes such native frames into JFR or collapsed output; JFR
  * written by the JDK's recorder carries Java-only stacks.
  */
-export const isNativeLibraryFrame = ({
+export const isNativeLibraryStackFrame = ({
   name,
   location,
 }: DeepReadonly<ProfileEntry>): boolean =>

--- a/src/origins/origin.ts
+++ b/src/origins/origin.ts
@@ -130,14 +130,14 @@ export type OriginSpec = {
    *
    * Defaults to the identity when omitted.
    */
-  normalizeFrame?: (
+  normalizeStackFrame?: (
     input: ProfileStackFrame,
     format: Format,
   ) => ProfileStackFrame | null
 }
 
 /**
- * Builds an {@link OriginSpec.normalizeFrame} for a profiler that packs a
+ * Builds an {@link OriginSpec.normalizeStackFrame} for a profiler that packs a
  * frame's function, file, and sampled line into its name, matched by
  * {@link regex}'s named groups `func`, `file`, and `line`.
  *

--- a/src/origins/specs/async-profiler.test.ts
+++ b/src/origins/specs/async-profiler.test.ts
@@ -51,11 +51,11 @@ describe(`detection`, () => {
   })
 })
 
-describe(`normalizeFrame`, () => {
-  const { normalizeFrame } = asyncProfilerOriginSpec
+describe(`normalizeStackFrame`, () => {
+  const { normalizeStackFrame } = asyncProfilerOriginSpec
 
   test(`turns the slashed class into a dotted location`, () => {
-    expect(normalizeFrame({ name: `java/util/HashMap.put` })).toEqual({
+    expect(normalizeStackFrame({ name: `java/util/HashMap.put` })).toEqual({
       name: `put`,
       location: { urlOrPath: `java.util.HashMap` },
     })
@@ -63,7 +63,7 @@ describe(`normalizeFrame`, () => {
 
   test(`handles a nested class and an <init> method`, () => {
     expect(
-      normalizeFrame({ name: `java/lang/System$Logger$Level.valueOf` }),
+      normalizeStackFrame({ name: `java/lang/System$Logger$Level.valueOf` }),
     ).toEqual({
       name: `valueOf`,
       location: { urlOrPath: `java.lang.System$Logger$Level` },
@@ -71,7 +71,7 @@ describe(`normalizeFrame`, () => {
   })
 
   test(`leaves a native (no-slash) frame location-less`, () => {
-    expect(normalizeFrame({ name: `Parker::park` })).toEqual({
+    expect(normalizeStackFrame({ name: `Parker::park` })).toEqual({
       name: `Parker::park`,
     })
   })

--- a/src/origins/specs/async-profiler.ts
+++ b/src/origins/specs/async-profiler.ts
@@ -1,8 +1,8 @@
 import {
   categorizeJvmEntry,
   hotspotStubCategory,
-  isJvmStdlibNameFrame,
-  isNativeLibraryFrame,
+  isJvmStdlibNameStackFrame,
+  isNativeLibraryStackFrame,
   jvmMatchEntry,
 } from '../jvm.ts'
 import type { OriginSpec } from '../origin.ts'
@@ -16,12 +16,12 @@ export const asyncProfilerOriginSpec = {
   // (collapsed), HotSpot code stubs, and native shared-library frames mixed
   // into Java stacks (JFR written by the JDK's recorder is Java-only).
   isMarkerEntry: entry =>
-    isJvmStdlibNameFrame(entry.name) ||
+    isJvmStdlibNameStackFrame(entry.name) ||
     hotspotStubCategory(entry) !== undefined ||
-    isNativeLibraryFrame(entry),
+    isNativeLibraryStackFrame(entry),
   categorizeEntry: categorizeJvmEntry,
   matchEntry: jvmMatchEntry,
-  normalizeFrame: input => {
+  normalizeStackFrame: input => {
     // A located (JFR) frame already carries its declaring class; only
     // collapsed names need splitting.
     if (input.location) {

--- a/src/origins/specs/dotnet-trace.test.ts
+++ b/src/origins/specs/dotnet-trace.test.ts
@@ -36,12 +36,12 @@ describe(`detection`, () => {
   })
 })
 
-describe(`normalizeFrame`, () => {
-  const { normalizeFrame } = dotnetTraceOriginSpec
+describe(`normalizeStackFrame`, () => {
+  const { normalizeStackFrame } = dotnetTraceOriginSpec
 
   test(`splits a managed frame into method name and declaring-type location`, () => {
     expect(
-      normalizeFrame({
+      normalizeStackFrame({
         name: `System.Private.CoreLib!System.AppContext.Setup(wchar**,wchar**,int32)`,
       }),
     ).toEqual({
@@ -52,7 +52,7 @@ describe(`normalizeFrame`, () => {
 
   test(`assembly casing doesn't affect the split (TraceEvent emits both)`, () => {
     expect(
-      normalizeFrame({
+      normalizeStackFrame({
         name: `system.private.corelib!System.AppContext.Setup(wchar**,wchar**,int32)`,
       }),
     ).toEqual({
@@ -63,7 +63,7 @@ describe(`normalizeFrame`, () => {
 
   test(`simplifies class parameter types to their simple names`, () => {
     expect(
-      normalizeFrame({
+      normalizeStackFrame({
         name: `System.Private.CoreLib!System.String.Concat(class System.String,class System.String)`,
       }),
     ).toEqual({
@@ -74,7 +74,7 @@ describe(`normalizeFrame`, () => {
 
   test(`drops value class modifiers and qualification from struct parameters`, () => {
     expect(
-      normalizeFrame({
+      normalizeStackFrame({
         name: `System.Private.CoreLib!System.Threading.Tasks.Task.Wait(int32,value class System.Threading.CancellationToken)`,
       }),
     ).toEqual({
@@ -85,7 +85,7 @@ describe(`normalizeFrame`, () => {
 
   test(`keeps generic and nested types intact in the location`, () => {
     expect(
-      normalizeFrame({
+      normalizeStackFrame({
         name: `System.Private.CoreLib!System.Collections.Generic.Dictionary\`2[System.__Canon,System.__Canon].FindValue(!0)`,
       }),
     ).toEqual({
@@ -98,7 +98,7 @@ describe(`normalizeFrame`, () => {
 
   test(`keeps a constructor's leading dot with the method name`, () => {
     expect(
-      normalizeFrame({
+      normalizeStackFrame({
         name: `System.Private.CoreLib!System.Diagnostics.Tracing.NativeRuntimeEventSource..ctor()`,
       }),
     ).toEqual({
@@ -111,7 +111,7 @@ describe(`normalizeFrame`, () => {
 
   test(`compiler-generated local functions keep their mangled method name`, () => {
     expect(
-      normalizeFrame({
+      normalizeStackFrame({
         name: `System.Console!System.Console.<get_Out>g__EnsureInitialized|26_0()`,
       }),
     ).toEqual({
@@ -127,23 +127,23 @@ describe(`normalizeFrame`, () => {
     `Thread (22921464)`,
     `CPU_TIME`,
   ])(`drops the %s pseudo-frame`, name => {
-    expect(normalizeFrame({ name })).toBeNull()
+    expect(normalizeStackFrame({ name })).toBeNull()
   })
 
   test(`keeps the unmanaged-time bucket as a location-less frame`, () => {
     const input = { name: `UNMANAGED_CODE_TIME` }
 
-    expect(normalizeFrame(input)).toBe(input)
+    expect(normalizeStackFrame(input)).toBe(input)
   })
 
   test(`leaves an unknown-assembly frame location-less`, () => {
     const input = { name: `?!?` }
 
-    expect(normalizeFrame(input)).toBe(input)
+    expect(normalizeStackFrame(input)).toBe(input)
   })
 
   test(`falls back to the lowercased assembly for a type-less function`, () => {
-    expect(normalizeFrame({ name: `Profile!main()` })).toEqual({
+    expect(normalizeStackFrame({ name: `Profile!main()` })).toEqual({
       name: `main()`,
       location: { urlOrPath: `profile` },
     })
@@ -155,7 +155,7 @@ describe(`normalizeFrame`, () => {
       location: { urlOrPath: `Program.cs` },
     }
 
-    expect(normalizeFrame(input)).toBe(input)
+    expect(normalizeStackFrame(input)).toBe(input)
   })
 })
 

--- a/src/origins/specs/dotnet-trace.ts
+++ b/src/origins/specs/dotnet-trace.ts
@@ -9,7 +9,7 @@ import type { OriginSpec } from '../origin.ts'
  * (produced by the TraceEvent library) packs a managed frame's whole identity
  * into its name as `Assembly!Namespace.Type.Method(signature)`.
  *
- * Its `normalizeFrame` splits that JFR-style: the namespace-qualified declaring
+ * Its `normalizeStackFrame` splits that JFR-style: the namespace-qualified declaring
  * type becomes the location and the method name with a simplified parameter
  * list the display name, keeping overloads distinguishable the way JFR's
  * `add(Object, Object[], int)` does. The assembly is dropped: TraceEvent emits
@@ -20,7 +20,7 @@ import type { OriginSpec } from '../origin.ts'
  * The export also wraps every call stack in pseudo-frames
  * (`Process64 Process(1234)…` \> `(Non-Activities)` \> `Threads` \> `Thread (…)`)
  * and buckets each sample's leaf time under a `CPU_TIME` marker, so
- * `normalizeFrame` drops those: they aren't functions, and dropping `CPU_TIME`
+ * `normalizeStackFrame` drops those: they aren't functions, and dropping `CPU_TIME`
  * returns each sample's self time to the method that was executing.
  * `UNMANAGED_CODE_TIME` stays: it's genuine native execution outside the
  * managed stack, kept as a location-less (`stdlib`) frame the way rbspy keeps
@@ -29,12 +29,12 @@ import type { OriginSpec } from '../origin.ts'
 export const dotnetTraceOriginSpec = {
   id: `dotnet-trace`,
   formats: [`speedscope`],
-  isMarkerEntry: entry => isDotnetTraceFrame(entry.name),
+  isMarkerEntry: entry => isDotnetTraceStackFrame(entry.name),
   categorizeEntry: entry =>
     dotnetNamespaceCategory(entry) ??
     locationlessStdlibCategory(entry) ??
     `ours`,
-  normalizeFrame: input => {
+  normalizeStackFrame: input => {
     if (input.location) {
       return input
     }
@@ -98,7 +98,7 @@ const simplifySignature = (signature: string): string =>
  * `Assembly!Method(signature)` managed frame or one of TraceEvent's time-bucket
  * markers.
  */
-const isDotnetTraceFrame = (name: string | undefined): boolean =>
+const isDotnetTraceStackFrame = (name: string | undefined): boolean =>
   name !== undefined &&
   (ASSEMBLY_BANG_METHOD.test(name) ||
     name === `CPU_TIME` ||
@@ -131,7 +131,7 @@ const THREAD_FRAME = /^Thread \(\d+\)$/u
 
 /**
  * Categorizes a frame by its declaring type (the location lifted out by
- * `normalizeFrame`): .NET runtime and framework namespaces are `stdlib`; any
+ * `normalizeStackFrame`): .NET runtime and framework namespaces are `stdlib`; any
  * other namespace is `ours`.
  *
  * NuGet dependencies (e.g. `Newtonsoft.Json`) carry no marker distinguishing

--- a/src/origins/specs/eflambe.test.ts
+++ b/src/origins/specs/eflambe.test.ts
@@ -28,18 +28,18 @@ describe(`detection`, () => {
   )
 })
 
-describe(`normalizeFrame`, () => {
-  const { normalizeFrame } = eflambeOriginSpec
+describe(`normalizeStackFrame`, () => {
+  const { normalizeStackFrame } = eflambeOriginSpec
 
   test(`lifts an Elixir module out of the name as the location, stripping the Elixir. prefix`, () => {
-    expect(normalizeFrame({ name: `Elixir.Jason:encode!/1` })).toEqual({
+    expect(normalizeStackFrame({ name: `Elixir.Jason:encode!/1` })).toEqual({
       name: `encode!/1`,
       location: { urlOrPath: `Jason` },
     })
   })
 
   test(`lifts an Erlang module out of the name as the location`, () => {
-    expect(normalizeFrame({ name: `lists:reverse/1` })).toEqual({
+    expect(normalizeStackFrame({ name: `lists:reverse/1` })).toEqual({
       name: `reverse/1`,
       location: { urlOrPath: `lists` },
     })
@@ -47,7 +47,7 @@ describe(`normalizeFrame`, () => {
 
   test(`splits on the first colon, keeping the rest of the name intact`, () => {
     expect(
-      normalizeFrame({ name: `json:-do_encode_map/2-lc$^0/1-0-/2` }),
+      normalizeStackFrame({ name: `json:-do_encode_map/2-lc$^0/1-0-/2` }),
     ).toEqual({
       name: `-do_encode_map/2-lc$^0/1-0-/2`,
       location: { urlOrPath: `json` },
@@ -55,7 +55,9 @@ describe(`normalizeFrame`, () => {
   })
 
   test(`leaves a colon-less process id frame unchanged`, () => {
-    expect(normalizeFrame({ name: `<0.94.0>` })).toEqual({ name: `<0.94.0>` })
+    expect(normalizeStackFrame({ name: `<0.94.0>` })).toEqual({
+      name: `<0.94.0>`,
+    })
   })
 
   test(`leaves an already-located frame unchanged`, () => {
@@ -63,7 +65,7 @@ describe(`normalizeFrame`, () => {
       name: `lists:reverse/1`,
       location: { urlOrPath: `lists.erl` },
     }
-    expect(normalizeFrame(input)).toBe(input)
+    expect(normalizeStackFrame(input)).toBe(input)
   })
 })
 
@@ -80,7 +82,7 @@ describe(`categorizeEntry`, () => {
   })
 
   // The module location arrives with the `Elixir.` prefix already stripped
-  // by `normalizeFrame`.
+  // by `normalizeStackFrame`.
   test.each([
     [`Enum`, `Elixir.Enum:reduce/3`],
     [`String`, `Elixir.String:split/2`],

--- a/src/origins/specs/eflambe.ts
+++ b/src/origins/specs/eflambe.ts
@@ -11,16 +11,16 @@ import type { OriginSpec } from '../origin.ts'
  * BEAM collapsed frames are `module:function/arity` (e.g. `lists:reverse/1`,
  * `Elixir.Enum:reduce/3`) with the module standing in for a source location,
  * rooted at a process id like `<0.94.0>`. Neither Erlang nor Elixir carries a
- * file path, so its `normalizeFrame` lifts the module out of the name to act as
+ * file path, so its `normalizeStackFrame` lifts the module out of the name to act as
  * the location, JFR-style.
  */
 export const eflambeOriginSpec = {
   id: `eflambe`,
   formats: [`collapsed`],
-  isMarkerEntry: entry => isBeamFrame(entry.name),
+  isMarkerEntry: entry => isBeamStackFrame(entry.name),
   categorizeEntry: entry =>
     beamModuleCategory(entry) ?? locationlessStdlibCategory(entry) ?? `ours`,
-  normalizeFrame: input => {
+  normalizeStackFrame: input => {
     // A located frame (e.g. from a structured format) already has everything it
     // needs; only a bare `module:function/arity` name needs splitting.
     if (input.location) {
@@ -55,7 +55,7 @@ export const eflambeOriginSpec = {
  * Whether a raw frame name is BEAM-shaped: an Elixir module, a process id, or an
  * Erlang `module:function/arity`.
  */
-const isBeamFrame = (name: string | undefined): boolean =>
+const isBeamStackFrame = (name: string | undefined): boolean =>
   name !== undefined &&
   (name.startsWith(`Elixir.`) ||
     BEAM_PROCESS_ID.test(name) ||
@@ -73,7 +73,7 @@ const ERLANG_MFA = /^[a-z]\w*:.+\/\d+$/u
 
 /**
  * Categorizes a frame by its BEAM module (the location lifted out by
- * `normalizeFrame`): OTP and Elixir-core modules, plus the `eflambe` profiler's
+ * `normalizeStackFrame`): OTP and Elixir-core modules, plus the `eflambe` profiler's
  * own frames, are `stdlib`; any other module is `ours`.
  *
  * Hex dependencies (e.g. `Elixir.Jason`) carry no marker distinguishing them
@@ -96,7 +96,7 @@ const isBeamStdlibModule = (module: string): boolean => {
   if (module.startsWith(`eflambe`)) {
     return true
   }
-  // `normalizeFrame` strips the `Elixir.` prefix, so an Elixir module is
+  // `normalizeStackFrame` strips the `Elixir.` prefix, so an Elixir module is
   // recognized by its capitalized first letter (Erlang atoms are lowercase).
   return /^[A-Z]/u.test(module)
     ? ELIXIR_CORE_MODULES.has(module)

--- a/src/origins/specs/node-pprof.test.ts
+++ b/src/origins/specs/node-pprof.test.ts
@@ -18,12 +18,12 @@ describe(`detection`, () => {
   })
 })
 
-describe(`normalizeFrame`, () => {
-  const { normalizeFrame } = nodePprofOriginSpec
+describe(`normalizeStackFrame`, () => {
+  const { normalizeStackFrame } = nodePprofOriginSpec
 
   test(`moves a dd-trace packed anonymous frame's position into the location`, () => {
     expect(
-      normalizeFrame({
+      normalizeStackFrame({
         name: `(anonymous:L#122135:C#9)`,
         location: { urlOrPath: `file:///app/src/index.js` },
       }),
@@ -43,7 +43,7 @@ describe(`normalizeFrame`, () => {
       location: { urlOrPath: `file:///app/src/index.js` },
     }
 
-    expect(normalizeFrame(input)).toBe(input)
+    expect(normalizeStackFrame(input)).toBe(input)
   })
 })
 

--- a/src/origins/specs/node-pprof.ts
+++ b/src/origins/specs/node-pprof.ts
@@ -19,7 +19,7 @@ export const nodePprofOriginSpec = {
     nodeModulesCategory(entry) ??
     protocolCategory(entry, `stdlib`, NODE_PROTOCOLS) ??
     `ours`,
-  normalizeFrame: input => {
+  normalizeStackFrame: input => {
     // `dd-trace` heap profiles pack an anonymous function's definition
     // position into its name as `(anonymous:L#122135:C#9)`; move it into the
     // location (which carries the file but no line) so the name formats as

--- a/src/origins/specs/pprof-jl.test.ts
+++ b/src/origins/specs/pprof-jl.test.ts
@@ -19,17 +19,17 @@ describe(`detection`, () => {
   })
 })
 
-describe(`normalizeFrame`, () => {
-  const { normalizeFrame } = pprofJlOriginSpec
+describe(`normalizeStackFrame`, () => {
+  const { normalizeStackFrame } = pprofJlOriginSpec
 
   test(`drops the allocation profiler's Alloc: pseudo-frame`, () => {
-    expect(normalizeFrame({ name: `Alloc: Vector{UInt8}` })).toBeNull()
+    expect(normalizeStackFrame({ name: `Alloc: Vector{UInt8}` })).toBeNull()
   })
 
   test(`leaves a regular frame unchanged`, () => {
     const input = { name: `+`, location: { urlOrPath: `int.jl` } }
 
-    expect(normalizeFrame(input)).toBe(input)
+    expect(normalizeStackFrame(input)).toBe(input)
   })
 })
 

--- a/src/origins/specs/pprof-jl.ts
+++ b/src/origins/specs/pprof-jl.ts
@@ -28,7 +28,7 @@ export const pprofJlOriginSpec = {
   // The allocation profiler wraps each sample in an `Alloc: <Type>` leaf
   // pseudo-frame. It isn't a function: dropping it returns each sample's
   // self value to the function that allocated.
-  normalizeFrame: input =>
+  normalizeStackFrame: input =>
     input.name?.startsWith(`Alloc: `) === true ? null : input,
 } as const satisfies OriginSpec
 

--- a/src/origins/specs/py-spy.test.ts
+++ b/src/origins/specs/py-spy.test.ts
@@ -40,12 +40,12 @@ describe(`detection`, () => {
   })
 })
 
-describe(`normalizeFrame`, () => {
-  const { normalizeFrame } = pySpyOriginSpec
+describe(`normalizeStackFrame`, () => {
+  const { normalizeStackFrame } = pySpyOriginSpec
 
   test(`splits the trailing (file:line) into a location and sampled line`, () => {
     expect(
-      normalizeFrame({ name: `parse (black/parsing.py:42)` }, `collapsed`),
+      normalizeStackFrame({ name: `parse (black/parsing.py:42)` }, `collapsed`),
     ).toEqual({
       name: `parse`,
       location: { urlOrPath: `black/parsing.py` },
@@ -55,7 +55,7 @@ describe(`normalizeFrame`, () => {
 
   test(`keeps a frozen-module location intact`, () => {
     expect(
-      normalizeFrame(
+      normalizeStackFrame(
         { name: `<module> (<frozen importlib._bootstrap>:1080)` },
         `collapsed`,
       ),
@@ -67,7 +67,7 @@ describe(`normalizeFrame`, () => {
   })
 
   test(`leaves a thread frame unchanged`, () => {
-    expect(normalizeFrame({ name: `tid:7` }, `collapsed`)).toEqual({
+    expect(normalizeStackFrame({ name: `tid:7` }, `collapsed`)).toEqual({
       name: `tid:7`,
     })
   })
@@ -76,7 +76,7 @@ describe(`normalizeFrame`, () => {
     // Py-spy's speedscope export emits one frame per sampled line; the line
     // must feed the line breakdown rather than the function's identity.
     expect(
-      normalizeFrame(
+      normalizeStackFrame(
         {
           name: `parse`,
           location: { urlOrPath: `black/parsing.py`, line: 42 },

--- a/src/origins/specs/py-spy.ts
+++ b/src/origins/specs/py-spy.ts
@@ -12,7 +12,7 @@ import type { OriginSpec } from '../origin.ts'
  */
 const FRAME = /^(?<func>.+) \((?<file>.+):(?<line>\d+)\)$/u
 
-const normalizePackedFrame = packedLocationNormalizer(FRAME)
+const normalizePackedStackFrame = packedLocationNormalizer(FRAME)
 
 export const pySpyOriginSpec = {
   id: `py-spy`,
@@ -30,6 +30,6 @@ export const pySpyOriginSpec = {
   // Py-spy emits one frame per sampled line in both shapes: packed into a
   // collapsed name, or as a located speedscope frame whose `line` needs
   // reinterpreting as the executing line.
-  normalizeFrame: (input, format) =>
-    normalizePackedFrame(normalizeSpeedscopeExecutingLine(input, format)),
+  normalizeStackFrame: (input, format) =>
+    normalizePackedStackFrame(normalizeSpeedscopeExecutingLine(input, format)),
 } as const satisfies OriginSpec

--- a/src/origins/specs/rbspy.test.ts
+++ b/src/origins/specs/rbspy.test.ts
@@ -37,12 +37,12 @@ describe(`detection`, () => {
   })
 })
 
-describe(`normalizeFrame`, () => {
-  const { normalizeFrame } = rbspyOriginSpec
+describe(`normalizeStackFrame`, () => {
+  const { normalizeStackFrame } = rbspyOriginSpec
 
   test(`splits a method's trailing file:line off the name`, () => {
     expect(
-      normalizeFrame({ name: `parse - /app/lib/foo.rb:12` }, `collapsed`),
+      normalizeStackFrame({ name: `parse - /app/lib/foo.rb:12` }, `collapsed`),
     ).toEqual({
       name: `parse`,
       location: { urlOrPath: `/app/lib/foo.rb` },
@@ -54,7 +54,7 @@ describe(`normalizeFrame`, () => {
     // The internal colon of `<module:AST>` must not be mistaken for the
     // file/line separator, which previously corrupted the name and path.
     expect(
-      normalizeFrame(
+      normalizeStackFrame(
         {
           name: `<module:AST> - /var/lib/gems/3.1.0/gems/parser-3.3.11.1/lib/parser.rb:28`,
         },
@@ -71,7 +71,7 @@ describe(`normalizeFrame`, () => {
 
   test(`a native frame keeps its name and stays location-less`, () => {
     expect(
-      normalizeFrame(
+      normalizeStackFrame(
         { name: `(unknown) [c function] - (unknown)` },
         `collapsed`,
       ),
@@ -79,7 +79,7 @@ describe(`normalizeFrame`, () => {
   })
 
   test(`leaves a frame without a separator unchanged`, () => {
-    expect(normalizeFrame({ name: `<main>` }, `collapsed`)).toEqual({
+    expect(normalizeStackFrame({ name: `<main>` }, `collapsed`)).toEqual({
       name: `<main>`,
     })
   })
@@ -88,7 +88,7 @@ describe(`normalizeFrame`, () => {
     // Rbspy's speedscope export emits one frame per sampled line; the line
     // must feed the line breakdown rather than the function's identity.
     expect(
-      normalizeFrame(
+      normalizeStackFrame(
         { name: `parse`, location: { urlOrPath: `/app/lib/foo.rb`, line: 12 } },
         `speedscope`,
       ),
@@ -105,12 +105,12 @@ describe(`normalizeFrame`, () => {
       name: `parse`,
       location: { urlOrPath: `/app/lib/foo.rb`, line: 12 },
     }
-    expect(normalizeFrame(input, `pprof`)).toBe(input)
+    expect(normalizeStackFrame(input, `pprof`)).toBe(input)
   })
 
   test(`leaves a located speedscope frame without a line unchanged`, () => {
     const input = { name: `parse - x`, location: { urlOrPath: `x.rb` } }
-    expect(normalizeFrame(input, `speedscope`)).toBe(input)
+    expect(normalizeStackFrame(input, `speedscope`)).toBe(input)
   })
 })
 

--- a/src/origins/specs/rbspy.ts
+++ b/src/origins/specs/rbspy.ts
@@ -10,7 +10,7 @@ import type { OriginSpec } from '../origin.ts'
  *
  * Its collapsed frames are `method - file:line` (e.g.
  * `parse - /app/lib/foo.rb:12`), with a `[c function]` marker for native
- * methods. Its `normalizeFrame` splits the trailing `file:line` off the method
+ * methods. Its `normalizeStackFrame` splits the trailing `file:line` off the method
  * name. Splitting on the *last* ` - ` keeps a
  * `<module:Foo>`-style method name (which contains its own colon) intact rather
  * than mistaking its colon for the file/line separator.
@@ -18,14 +18,14 @@ import type { OriginSpec } from '../origin.ts'
 export const rbspyOriginSpec = {
   id: `rbspy`,
   formats: [`collapsed`, `pprof`, `speedscope`],
-  isMarkerEntry: entry => isRbspyFrame(entry.name),
+  isMarkerEntry: entry => isRbspyStackFrame(entry.name),
   categorizeEntry: entry =>
     cFunctionCategory(entry) ??
     rubyGemCategory(entry) ??
     rubyStdlibCategory(entry) ??
     locationlessStdlibCategory(entry) ??
     `ours`,
-  normalizeFrame: (input, format) => {
+  normalizeStackFrame: (input, format) => {
     if (input.location) {
       // Rbspy's speedscope export also emits one frame per sampled line, with
       // the line carried in the location rather than packed into the name.
@@ -59,7 +59,7 @@ export const rbspyOriginSpec = {
  * profiles carry the location separately, leaving rbspy's `[c function]`
  * marker and the Ruby VM's `<main>`/`<top (required)>` toplevel frames bare.
  */
-const isRbspyFrame = (name: string | undefined): boolean =>
+const isRbspyStackFrame = (name: string | undefined): boolean =>
   name !== undefined &&
   (METHOD_FILE_LINE.test(name) ||
     name.includes(C_FUNCTION) ||

--- a/src/origins/specs/systing.test.ts
+++ b/src/origins/specs/systing.test.ts
@@ -32,12 +32,12 @@ describe(`detection`, () => {
   })
 })
 
-describe(`normalizeFrame`, () => {
-  const { normalizeFrame } = systingOriginSpec
+describe(`normalizeStackFrame`, () => {
+  const { normalizeStackFrame } = systingOriginSpec
 
   test(`splits a located frame, dropping the module and address`, () => {
     expect(
-      normalizeFrame({
+      normalizeStackFrame({
         name: `gamma_spin (nested [nested.c:9]) <0x56475007017d>`,
       }),
     ).toEqual({
@@ -49,7 +49,7 @@ describe(`normalizeFrame`, () => {
 
   test(`splits a line-less located frame`, () => {
     expect(
-      normalizeFrame({ name: `read_config (app [config.c]) <0x1234>` }),
+      normalizeStackFrame({ name: `read_config (app [config.c]) <0x1234>` }),
     ).toEqual({
       name: `read_config`,
       location: { urlOrPath: `config.c` },
@@ -61,7 +61,7 @@ describe(`normalizeFrame`, () => {
     // The label is the category signal, so it survives even when kernel
     // debuginfo gives the frame a source location.
     expect(
-      normalizeFrame({
+      normalizeStackFrame({
         name: `handle_mm_fault ([kernel] [memory.c:5432]) <0xffffffff96e00123>`,
       }),
     ).toEqual({
@@ -83,13 +83,13 @@ describe(`normalizeFrame`, () => {
   ])(
     `keeps the module, minus the address, for the source-less %s frame`,
     (name, expected) => {
-      expect(normalizeFrame({ name })).toEqual({ name: expected })
+      expect(normalizeStackFrame({ name })).toEqual({ name: expected })
     },
   )
 
   test(`keeps function names containing parentheses intact`, () => {
     expect(
-      normalizeFrame({
+      normalizeStackFrame({
         name: `std::vector<int>::push_back(int&&) (app [vector.h:123]) <0x1>`,
       }),
     ).toEqual({
@@ -101,7 +101,7 @@ describe(`normalizeFrame`, () => {
 
   test(`splits a Python frame's location`, () => {
     expect(
-      normalizeFrame({ name: `handle_request (python) [server.py:88]` }),
+      normalizeStackFrame({ name: `handle_request (python) [server.py:88]` }),
     ).toEqual({
       name: `handle_request`,
       location: { urlOrPath: `server.py` },
@@ -110,14 +110,14 @@ describe(`normalizeFrame`, () => {
   })
 
   test(`leaves an unpacked frame untouched`, () => {
-    expect(normalizeFrame({ name: `0x7f95bfdb6e12` })).toEqual({
+    expect(normalizeStackFrame({ name: `0x7f95bfdb6e12` })).toEqual({
       name: `0x7f95bfdb6e12`,
     })
   })
 
   test(`leaves an already-located frame untouched`, () => {
     expect(
-      normalizeFrame({ name: `located`, location: { urlOrPath: `a.c` } }),
+      normalizeStackFrame({ name: `located`, location: { urlOrPath: `a.c` } }),
     ).toEqual({ name: `located`, location: { urlOrPath: `a.c` } })
   })
 })

--- a/src/origins/specs/systing.ts
+++ b/src/origins/specs/systing.ts
@@ -23,9 +23,9 @@ export const systingOriginSpec = {
     // stripped binary as much as a system library) symbolizes without a
     // source location. `native` states exactly that.
     (entry.location ? `ours` : `native`),
-  normalizeFrame: input => {
+  normalizeStackFrame: input => {
     // A located frame can't be packed (systing always packs); guard anyway
-    // per the normalizeFrame contract.
+    // per the normalizeStackFrame contract.
     if (input.location) {
       return input
     }

--- a/src/origins/specs/tachyon.test.ts
+++ b/src/origins/specs/tachyon.test.ts
@@ -28,13 +28,13 @@ describe(`detection`, () => {
   })
 })
 
-describe(`normalizeFrame`, () => {
-  const { normalizeFrame } = tachyonOriginSpec
+describe(`normalizeStackFrame`, () => {
+  const { normalizeStackFrame } = tachyonOriginSpec
 
   test(`splits a file:func:line frame, keeping the line as the executing line`, () => {
     // The line stays out of the location so a function sampled at several
     // lines aggregates as one, with the lines feeding the per-line breakdown.
-    expect(normalizeFrame({ name: `script.py:fib:4` })).toEqual({
+    expect(normalizeStackFrame({ name: `script.py:fib:4` })).toEqual({
       name: `fib`,
       location: { urlOrPath: `script.py` },
       line: 4,
@@ -44,7 +44,7 @@ describe(`normalizeFrame`, () => {
   test.each([`C:\\proj\\app.py`, `D:/proj/app.py`])(
     `keeps the Windows drive-letter path %s whole instead of splitting on the drive colon`,
     path => {
-      expect(normalizeFrame({ name: `${path}:run:10` })).toEqual({
+      expect(normalizeStackFrame({ name: `${path}:run:10` })).toEqual({
         name: `run`,
         location: { urlOrPath: path },
         line: 10,
@@ -53,7 +53,7 @@ describe(`normalizeFrame`, () => {
   )
 
   test(`keeps a C++ namespaced function name intact`, () => {
-    expect(normalizeFrame({ name: `file.cpp:Foo::bar:42` })).toEqual({
+    expect(normalizeStackFrame({ name: `file.cpp:Foo::bar:42` })).toEqual({
       name: `Foo::bar`,
       location: { urlOrPath: `file.cpp` },
       line: 42,
@@ -61,7 +61,7 @@ describe(`normalizeFrame`, () => {
   })
 
   test(`leaves a single-colon thread frame as a plain name`, () => {
-    expect(normalizeFrame({ name: `tid:15522692` })).toEqual({
+    expect(normalizeStackFrame({ name: `tid:15522692` })).toEqual({
       name: `tid:15522692`,
     })
   })

--- a/src/origins/specs/tachyon.ts
+++ b/src/origins/specs/tachyon.ts
@@ -24,9 +24,9 @@ const TACHYON_FRAME =
 export const tachyonOriginSpec = {
   id: `tachyon`,
   formats: [`collapsed`],
-  isMarkerEntry: entry => isTachyonFrame(entry.name),
+  isMarkerEntry: entry => isTachyonStackFrame(entry.name),
   categorizeEntry: categorizeCPythonEntry,
-  normalizeFrame: packedLocationNormalizer(TACHYON_FRAME),
+  normalizeStackFrame: packedLocationNormalizer(TACHYON_FRAME),
 } as const satisfies OriginSpec
 
 /**
@@ -35,7 +35,7 @@ export const tachyonOriginSpec = {
  * `file:func:line` shape. A plain `file:func:line` frame is *not* a marker;
  * that shape is generic, so a marker-free folded stack stays `unknown`.
  */
-const isTachyonFrame = (name: string | undefined): boolean =>
+const isTachyonStackFrame = (name: string | undefined): boolean =>
   name !== undefined &&
   (/^tid:\d+$/u.test(name) ||
     (name.startsWith(`<frozen `) && TACHYON_FRAME.test(name)))


### PR DESCRIPTION
Stack frames are one of several frame-like things a modality can hold, so `normalizeFrame` and the helpers around it now say which frame they mean: `OriginSpec.normalizeStackFrame`, `normalizeStackFrameForContext`, and the per-origin and per-format predicates and interners.