### PR TITLE
refactor: drop provenance categorization from heap snapshots

### DIFF
--- a/src/formats/index.ts
+++ b/src/formats/index.ts
@@ -465,26 +465,25 @@ const makeFormattingProfileToMdOptions = (
     ? {
         ...options,
         baseURL: commonAncestorDirectoryURL(
-          collectOursInferableURLs(inputs, { ...options, baseURL: undefined }),
+          collectInferableURLs(inputs, { ...options, baseURL: undefined }),
         ),
       }
     : { ...options, baseURL }
 }
 
 /**
- * Collects the base-URL-inferable absolute URLs of {@link inputs}'
- * `ours`-categorized entries.
+ * Collects the base-URL-inferable absolute URLs of {@link inputs}' entries.
  *
  * Applies source maps first so the base is inferred from the locations
  * formatting will show.
  */
-const collectOursInferableURLs = (
+const collectInferableURLs = (
   inputs: AggregatedInput[],
   options: FormattingProfileToMdOptions,
 ): URL[] => {
   const urls: URL[] = []
-  const collect = (category: string, location: SourceLocation | undefined) => {
-    if (category !== `ours` || !location) {
+  const collect = (location: SourceLocation | undefined) => {
+    if (!location) {
       return
     }
     const mappedLocation = sourceMapSourceLocation(location, options)
@@ -497,12 +496,17 @@ const collectOursInferableURLs = (
     switch (input.type) {
       case `sampling-profile`:
         for (const func of input.functions) {
-          collect(func.category, func.location)
+          // Onky `ours`-categorized functions contribute, because a
+          // dependency's install path can be far outside the source tree and
+          // would raise the base to a shared root.
+          if (func.category === `ours`) {
+            collect(func.location)
+          }
         }
         break
       case `heap-snapshot`:
         for (const entity of [...input.constructors, ...input.closures]) {
-          collect(entity.category, entityLocation(entity))
+          collect(entityLocation(entity))
         }
         break
     }

--- a/src/formats/v8/heap-snapshot/index.test.ts
+++ b/src/formats/v8/heap-snapshot/index.test.ts
@@ -317,7 +317,7 @@ describe(`convert`, () => {
     ])
   })
 
-  test(`baseURL: 'auto' infers the base from ours locations and relativizes URL-shaped constructor names`, () => {
+  test(`baseURL: 'auto' infers the base from entity locations and relativizes URL-shaped constructor names`, () => {
     const snapshot = makeClosureSnapshot(
       `file:///home/user/project/lib/a.ts`,
       `file:///home/user/project/src/mod.js`,

--- a/src/modalities/heap-snapshot/aggregate.ts
+++ b/src/modalities/heap-snapshot/aggregate.ts
@@ -58,7 +58,6 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
 
   readonly #strings: AggregatedHeapSnapshotNode[] = []
 
-  readonly #entities: (AggregatedConstructor | AggregatedClosure)[]
   readonly #entries: ProfileEntry[]
 
   public constructor(snapshot: HeapSnapshot) {
@@ -116,8 +115,7 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
       nodeOrdinal++
     }
 
-    this.#entities = [...this.#constructors, ...this.#closures]
-    this.#entries = this.#entities.map(entity => ({
+    this.#entries = [...this.#constructors, ...this.#closures].map(entity => ({
       id: entity.id,
       name: entity.name,
       location: entityLocation(entity),
@@ -152,9 +150,6 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
         name,
         nameLocation,
         location,
-        // Categories are assigned after aggregation, in one pass over the full
-        // set of entities (see {@link HeapSnapshotAggregator.aggregate}).
-        category: ``,
         selfSize: 0,
         retainedSize: 0,
         instances: [],
@@ -195,9 +190,6 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
         id: nodeOrdinal,
         name,
         location,
-        // Categories are assigned after aggregation, in one pass over the full
-        // set of entities (see {@link HeapSnapshotAggregator.aggregate}).
-        category: ``,
         selfSize: 0,
         retainedSize: 0,
         largestInstanceId: nodeOrdinal,
@@ -232,16 +224,6 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
     options: AggregationProfileToMdOptions,
     context: ProfileToMdContext,
   ): AggregatedHeapSnapshot {
-    // Categorization runs after structural aggregation so it sees the full set
-    // of entities (the heap snapshot analog of the sampling profile pipeline's
-    // categorization; see {@link SamplingProfileAggregator}). Each entry's location
-    // falls back to its URL-shaped name (e.g. a V8 module namespace object) so
-    // those categorize by location too.
-    const categories = options.categorizeEntries(this.#entries, context)
-    for (let i = 0; i < this.#entities.length; i++) {
-      this.#entities[i]!.category = categories[i]!
-    }
-
     attributeCategoryRetainedSizes(
       this.#nodeOrdinalToRetainedSize,
       this.#immediateDominatorGraph,
@@ -533,9 +515,6 @@ export type AggregatedConstructor = AggregatedHeapSnapshotNode & {
   /** A human readable label for this constructor. */
   name: string
 
-  /** The category of code this constructor belongs to. */
-  category: string
-
   /** Instances of this constructor and their sizes. */
   instances: AggregatedHeapSnapshotNode[]
 }
@@ -543,9 +522,6 @@ export type AggregatedConstructor = AggregatedHeapSnapshotNode & {
 export type AggregatedClosure = AggregatedHeapSnapshotNode & {
   /** A human readable label for this closure. */
   name: string
-
-  /** The category of code this closure belongs to. */
-  category: string
 
   /** Node ordinal of the instance with the largest individual retained size. */
   largestInstanceId: number

--- a/src/modalities/heap-snapshot/testing.ts
+++ b/src/modalities/heap-snapshot/testing.ts
@@ -66,14 +66,12 @@ export const makeSourceLocation = (
 
 export const makeAggregatedConstructor = ({
   name,
-  category = `ours`,
   location,
   selfSize,
   retainedSize,
   instanceCount,
 }: {
   name: string
-  category?: string
   location?: SourceLocation
   selfSize: number
   retainedSize: number
@@ -82,7 +80,6 @@ export const makeAggregatedConstructor = ({
   type: `node`,
   id: 0,
   name,
-  category,
   location,
   selfSize,
   retainedSize,
@@ -97,14 +94,12 @@ export const makeAggregatedConstructor = ({
 
 export const makeAggregatedClosure = ({
   name,
-  category = `ours`,
   location,
   selfSize,
   retainedSize,
   instanceCount = 1,
 }: {
   name: string
-  category?: string
   location?: SourceLocation
   selfSize: number
   retainedSize: number
@@ -113,7 +108,6 @@ export const makeAggregatedClosure = ({
   type: `node`,
   id: 0,
   name,
-  category,
   location,
   selfSize,
   retainedSize,

--- a/src/options.test.ts
+++ b/src/options.test.ts
@@ -117,10 +117,9 @@ describe(`normalizeProfileToMdOptions`, () => {
   })
 })
 
-const makeSnapshotNode = (name: string, category = `ours`) =>
+const makeSnapshotNode = (name: string) =>
   makeAggregatedConstructor({
     name,
-    category,
     selfSize: 0,
     retainedSize: 0,
     instanceCount: 0,
@@ -262,11 +261,9 @@ describe(`isExternalImplementationDetailEntry`, () => {
     expect(isExternalImplementationDetailEntry(nativeCall!)).toBe(false)
   })
 
-  test(`returns false for a snapshot node regardless of category`, () => {
+  test(`returns false for a snapshot node`, () => {
     expect(
-      isExternalImplementationDetailEntry(
-        makeSnapshotNode(`Buffer`, `third-party`),
-      ),
+      isExternalImplementationDetailEntry(makeSnapshotNode(`Buffer`)),
     ).toBe(false)
   })
 })

--- a/src/options.ts
+++ b/src/options.ts
@@ -118,11 +118,8 @@ export type ProfileToMdOptions = {
    * `file://` URLs internally.
    *
    * A value of `'auto'` infers the base URL as the common ancestor directory
-   * of the input's `ours`-categorized entries with absolute locations (`file:`,
-   * `http(s):`, etc.), across all profiles of an input and across both sides
-   * of a diff. When those locations span multiple protocol/host origins, the
-   * origin with the most entries wins. Falls back to absolute paths when no
-   * entry qualifies.
+   * of the input's entries with absolute locations (`file:`, `http(s):`, etc.),
+   * across all profiles of an input and across both sides of a diff.
    *
    * A value of `null` leaves URLs absolute.
    *
@@ -173,6 +170,9 @@ export type ProfileToMdOptions = {
    * Called once per profile with all its {@link entries}. Receiving every entry
    * up front lets the categorizer decide from the full set rather than per
    * entry in isolation.
+   *
+   * Doesn't apply to heap snapshots because they record their own node
+   * categories.
    *
    * Defaults to {@link defaultCategorizeEntries}.
    */

--- a/src/origins/index.test.ts
+++ b/src/origins/index.test.ts
@@ -17,8 +17,8 @@ import type { Origin } from './index.ts'
 vi.setConfig({ testTimeout: 125_000 })
 
 /**
- * Echoes each input's resolved origin as the category of every entry, so a
- * profile's origin is observable through its entry categories.
+ * Echoes a profile's resolved origin as the category of every entry, so the
+ * origin `categorizeEntries` received is observable in the categories.
  */
 const echoOriginOptions = (): NormalizedProfileToMdOptions =>
   normalizeProfileToMdOptions({
@@ -38,21 +38,19 @@ if (inputFilenames.length > 0) {
     test.each(inputFilenames)(
       `%s resolves to its profiler's origin`,
       filename => {
-        const inputs = aggregateInput(readInput(filename), echoOriginOptions())
+        const inputs = aggregateInput(
+          readInput(filename),
+          normalizeProfileToMdOptions(),
+        )
 
-        // A modality is a property of each aggregated input, not of the format,
-        // so the test covers every committed input, asserting on each
-        // profile's functions and each snapshot's entities.
+        // A multi-profile input aggregates each profile under its own
+        // context, so each must resolve to the filename's origin. An input
+        // holding no profiling data aggregates to nothing and has no origin
+        // to check.
         const { origin } = parseExampleFilename(filename)
-        const unexpectedOrigins = inputs.flatMap(input => {
-          const entities =
-            input.type === `sampling-profile`
-              ? input.functions
-              : [...input.constructors, ...input.closures]
-          return entities
-            .map(entity => entity.category)
-            .filter(category => category !== origin)
-        })
+        const unexpectedOrigins = inputs
+          .map(input => input.context.origin)
+          .filter(resolved => resolved !== origin)
         expect(new Set(unexpectedOrigins)).toEqual(new Set())
       },
     )


### PR DESCRIPTION
The category on a snapshot's constructors and closures was never rendered, never filtered anything, and never reached diffing. Only `baseURL: 'auto'` read it, keeping the `ours`-categorized locations. That filter selects nothing in practice: in every committed snapshot each base-URL-inferable location is already `ours`, because the rest are engine classes with a `node:` URL or no location. Node's snapshot categorizes 3,791 entities to contribute 2 candidate URLs.

A snapshot now infers its base URL from all of its entity locations, which leaves every generated example unchanged. `categorizeEntries` no longer runs for a heap snapshot, so `--third-party` no longer shifts a snapshot's inferred base URL.