### PR TITLE
docs: state that a profiler's formats are the ones it writes

### DIFF
--- a/.claude/skills/new-format/SKILL.md
+++ b/.claude/skills/new-format/SKILL.md
@@ -38,8 +38,9 @@ $ARGUMENTS
    spec
 
 3. Enumerate the tools and runtimes that emit the format (the canonical tool,
-   other profilers that export it, tools we already support), then decide the
-   origin question:
+   other profilers that export it, tools we already support). A tool emits the
+   format when it writes the format itself, so leave out the tools that convert
+   another profiler's output into it. Then decide the origin question:
    - Note which existing origins need their `formats` expanded
    - Register each emitting tool or runtime we don't have yet as its own origin,
      even when its inputs carry no detectable markers (a markerless spec,

--- a/.claude/skills/new-input/SKILL.md
+++ b/.claude/skills/new-input/SKILL.md
@@ -31,6 +31,11 @@ If loaded from `/new-format`, skip step 1 and return to that workflow after step
      and follow its workflow first; input filenames carry the origin's
      registered ID, and every committed input must resolve to it
 
+   A profiler emits the formats it writes itself. A separate tool that rewrites
+   one of its outputs into a supported format converts, and a converted input
+   makes the language claim a format its ecosystem never writes. Treat it as a
+   missing format: STOP and load `/new-format`
+
 ## Generate
 
 2. Add or update workload scripts in `scripts/inputs/`, one per emitting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,16 @@ pnpm generate-inputs go ruby   # Limit to named workload scripts
 - When a derivation can't be type-enforced, guard it with a test that loops over
   the registry or the committed inputs so an omission fails the test
 
+### Inputs
+
+- A profiler emits the formats it writes itself. A separate tool that rewrites
+  one of its outputs into another format converts
+- Commit an input in a format its profiler emits. A converted input makes the
+  language claim a format its ecosystem never writes, since a language's formats
+  come from the `languages` of every registered converter
+- When a profiler emits no supported format, the format is missing. Implement it
+  (`/new-format`)
+
 ### Types
 
 - Name a discriminated union's discriminant `type`, never `kind`. This does not


### PR DESCRIPTION
A tool that rewrites another profiler's output converts, so the format it produces is not one the profiler emits, and a committed conversion would make the language claim a format its ecosystem never writes. The rule lives in CLAUDE.md and in the new-format and new-input skills, because the choice comes up for any language whose profilers are reachable through a converter.