### PR TITLE
fix: resolve a format with no matching origin to its canonical origin

### DIFF
--- a/.claude/skills/new-format/SKILL.md
+++ b/.claude/skills/new-format/SKILL.md
@@ -45,8 +45,14 @@ $ARGUMENTS
      even when its inputs carry no detectable markers (a markerless spec,
      `isMarkerEntry: () => false`); sharing another origin's spec would make a
      later behavioral split a breaking change
-   - Decide the format's `fallbackOrigin`: the origin of the format's defining
-     tool or runtime for single-runtime formats, else `unknown`
+   - Decide the format's `fallbackOrigin`: the format's canonical origin, the
+     tool or runtime whose definition of the format the other emitters write to
+     match (e.g. `valgrind` for callgrind, `chrome` for the V8 formats). A
+     format with several emitters still has a canonical origin. The canonical
+     emitter may have its own markers. Use `unknown` when the format is defined
+     by something that profiles nothing itself (e.g. the speedscope viewer,
+     FlameGraph's stack-collapsing scripts, the pprof project). Record the
+     reasoning in a comment above the field
 
 4. Confirm every modality the format captures is supported. If any is
    unsupported, STOP: explain the new modality and how it differs from the

--- a/.claude/skills/new-origin/SKILL.md
+++ b/.claude/skills/new-origin/SKILL.md
@@ -70,6 +70,16 @@ $ARGUMENTS
    elsewhere: give the origin a marker or a parser origin hint, or make the
    workload realistic enough to carry the origin's evidence
 
-4. Run the origin tests (`pnpm test src/origins/specs/<origin>.test.ts`,
+4. Revisit the `fallbackOrigin` of every format the new origin emits, in each
+   format's converter (in `src/formats/`). A format's fallback is its canonical
+   origin, the tool or runtime whose definition of the format the other emitters
+   write to match. It is `unknown` only when no emitting origin is canonical.
+   The fallback changes when the new origin is the format's canonical origin and
+   the format resolved to `unknown` because none was. It also changes when the
+   new origin is a second emitter of a format whose current fallback was never
+   the canonical origin. Update the comment above the field with the reasoning
+   either way
+
+5. Run the origin tests (`pnpm test src/origins/specs/<origin>.test.ts`,
    `pnpm test src/origins/categorize.test.ts`, and
    `pnpm test src/origins/index.test.ts`, one at a time) and fix failures

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,11 @@ pnpm generate-inputs go ruby   # Limit to named workload scripts
   Origins sharing runtime conventions share logic through helper modules (e.g.
   `src/origins/jvm.ts`), never a merged spec: a later behavioral split must not
   break published origin IDs
+- A format's `fallbackOrigin` is its canonical origin, the tool or runtime whose
+  definition of the format the other emitters write to match. It is `unknown`
+  when no emitting origin is canonical, because the format is defined by
+  something that profiles nothing itself (e.g. the speedscope viewer). When
+  adding an origin, revisit the fallback of every format it emits
 - NEVER add logic that requires editing another file when a new format or origin
   is added. Express per-format or per-origin behavior as data or functions in
   the registry to derive from everywhere else

--- a/src/formats/collapsed/index.ts
+++ b/src/formats/collapsed/index.ts
@@ -6,6 +6,8 @@ export const collapsedConverter = {
   title: `Collapsed stacks`,
   extension: `collapsed`,
   languages: [`elixir`, `java`, `python`, `ruby`],
+  // FlameGraph's stack-collapsing scripts define the format and profile nothing
+  // themselves, so no emitting origin is canonical.
   fallbackOrigin: `unknown`,
   type: `binary`,
   matches: matchesCollapsed,

--- a/src/formats/converter.ts
+++ b/src/formats/converter.ts
@@ -29,7 +29,9 @@ type FormatMeta = {
 
   /**
    * The origin to resolve to when no specific origin matches any input entry:
-   * the runtime origin for a single-runtime format, else `unknown`.
+   * the format's canonical origin, the tool or runtime whose definition of the
+   * format the other emitters write to match. `unknown` when no emitting origin
+   * is canonical.
    */
   fallbackOrigin: string
 }

--- a/src/formats/jsc-heap-snapshot/index.ts
+++ b/src/formats/jsc-heap-snapshot/index.ts
@@ -7,6 +7,8 @@ export const jscHeapSnapshotConverter = {
   title: `JSC heap snapshot`,
   extension: `jsc-heap-snapshot.json`,
   languages: [`javascript`],
+  // WebKit's Web Inspector defines the format, and Bun writes it to be openable
+  // there.
   fallbackOrigin: `safari`,
   type: `json`,
   matches: matchesJSCHeapSnapshot,

--- a/src/formats/pprof/index.ts
+++ b/src/formats/pprof/index.ts
@@ -7,6 +7,8 @@ export const pprofConverter = {
   title: `pprof`,
   extension: `pprof`,
   languages: [`c`, `go`, `javascript`, `julia`, `ruby`, `rust`, `zig`],
+  // The pprof project defines `profile.proto`, not the profilers that emit it,
+  // so no emitting origin is canonical.
   fallbackOrigin: `unknown`,
   type: `binary`,
   matches: matchesPprof,

--- a/src/formats/speedscope/index.ts
+++ b/src/formats/speedscope/index.ts
@@ -7,6 +7,9 @@ export const speedscopeConverter = {
   title: `Speedscope`,
   extension: `speedscope.json`,
   languages: [`csharp`, `php`, `python`, `ruby`],
+  // The speedscope viewer defines the format and profiles nothing itself, so no
+  // emitting origin is canonical. The parser detects emitters from the file's
+  // `exporter` field and sets an origin hint.
   fallbackOrigin: `unknown`,
   type: `json`,
   matches: matchesSpeedscope,

--- a/src/formats/v8/cpu-profile/index.ts
+++ b/src/formats/v8/cpu-profile/index.ts
@@ -7,7 +7,9 @@ export const v8CpuProfileConverter = {
   title: `V8 CPU profile`,
   extension: `cpuprofile`,
   languages: [`javascript`],
-  fallbackOrigin: `unknown`,
+  // Chrome DevTools defines the format, and the other V8 runtimes write it to
+  // be openable there.
+  fallbackOrigin: `chrome`,
   type: `json`,
   matches: matchesV8CpuProfile,
   parse: json => parseV8CpuProfile(json as V8CpuProfile),

--- a/src/formats/v8/heap-profile/index.ts
+++ b/src/formats/v8/heap-profile/index.ts
@@ -7,7 +7,9 @@ export const v8HeapProfileConverter = {
   title: `V8 heap profile`,
   extension: `heapprofile`,
   languages: [`javascript`],
-  fallbackOrigin: `node`,
+  // Chrome DevTools defines the format, and Node writes it to be openable
+  // there.
+  fallbackOrigin: `chrome`,
   type: `json`,
   matches: matchesV8HeapProfile,
   parse: json => parseV8HeapProfile(json as V8HeapProfile),

--- a/src/formats/v8/heap-snapshot/index.ts
+++ b/src/formats/v8/heap-snapshot/index.ts
@@ -11,7 +11,9 @@ export const v8HeapSnapshotConverter = {
     // Julia's `Profile` stdlib writes heap snapshots in this format natively.
     `julia`,
   ],
-  fallbackOrigin: `node`,
+  // Chrome DevTools defines the format, and the other emitters write it to be
+  // openable there.
+  fallbackOrigin: `chrome`,
   type: `json`,
   matches: matchesV8HeapSnapshot,
   parse: json => parseV8HeapSnapshot(json as V8HeapSnapshot),

--- a/src/origins/specs/bun.test.ts
+++ b/src/origins/specs/bun.test.ts
@@ -48,7 +48,11 @@ describe(`detection`, () => {
     expect(
       determineOrigin({
         format: `v8-heap-snapshot`,
-        entries: [relativeEntry(`FileSink`), relativeEntry(`NextTickQueue`)],
+        entries: [
+          relativeEntry(`FileSink`),
+          relativeEntry(`NextTickQueue`),
+          absoluteEntry(`Socket`, `file:///app/node_modules/ws/lib/socket.js`),
+        ],
       }),
     ).toBe(`node`)
   })

--- a/src/origins/specs/chrome.test.ts
+++ b/src/origins/specs/chrome.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest'
+import type { Format } from '../../formats/registry.ts'
 import { absoluteEntry, determineOrigin, relativeEntry } from '../testing.ts'
 import { chromeOriginSpec } from './chrome.ts'
 
@@ -60,6 +61,7 @@ describe(`detection`, () => {
         format: `v8-heap-snapshot`,
         entries: [
           absoluteEntry(`StyleEngine`, `file:///app/src/style-engine.ts`),
+          absoluteEntry(`Socket`, `file:///app/node_modules/ws/lib/socket.js`),
         ],
       }),
     ).toBe(`node`)
@@ -76,6 +78,13 @@ describe(`detection`, () => {
       }),
     ).toBe(`node`)
   })
+
+  test.each<Format>([`v8-cpu-profile`, `v8-heap-profile`, `v8-heap-snapshot`])(
+    `resolves %s to chrome when no entries match any origin`,
+    format => {
+      expect(determineOrigin({ format, entries: [] })).toBe(`chrome`)
+    },
+  )
 })
 
 describe(`categorizeEntry`, () => {

--- a/src/origins/specs/node.test.ts
+++ b/src/origins/specs/node.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from 'vitest'
-import type { Format } from '../../formats/registry.ts'
 import { absoluteEntry, determineOrigin, relativeEntry } from '../testing.ts'
 import { nodeOriginSpec } from './node.ts'
 
@@ -13,12 +12,14 @@ describe(`detection`, () => {
     ).toBe(`node`)
   })
 
-  test.each<Format>([`v8-heap-profile`, `v8-heap-snapshot`])(
-    `resolves %s to node when no entries match any origin`,
-    format => {
-      expect(determineOrigin({ format, entries: [] })).toBe(`node`)
-    },
-  )
+  test(`detects Node by a node_modules dependency`, () => {
+    expect(
+      determineOrigin({
+        format: `v8-cpu-profile`,
+        entries: [absoluteEntry(`f`, `file:///app/node_modules/x/index.js`)],
+      }),
+    ).toBe(`node`)
+  })
 })
 
 describe(`categorizeEntry`, () => {

--- a/src/origins/specs/profile-jl.test.ts
+++ b/src/origins/specs/profile-jl.test.ts
@@ -21,7 +21,7 @@ describe(`detection`, () => {
         format: `v8-heap-snapshot`,
         entries: [relativeEntry(`sum`, `/home/user/app/main.jl`)],
       }),
-    ).toBe(`node`)
+    ).toBe(`chrome`)
   })
 })
 

--- a/src/origins/specs/unknown.test.ts
+++ b/src/origins/specs/unknown.test.ts
@@ -12,7 +12,6 @@ describe(`detection`, () => {
     [`collapsed`, relativeEntry(`frame`)],
     [`collapsed`, relativeEntry(`frame`, `app.rb`)],
     [`speedscope`, relativeEntry(`frame`)],
-    [`v8-cpu-profile`, relativeEntry(`frame`)],
   ])(`a marker-free %s input falls back to unknown`, (format, entry) => {
     expect(determineOrigin({ format, entries: [entry] })).toBe(`unknown`)
   })
@@ -58,10 +57,10 @@ describe(`categorizeEntry`, () => {
   })
 
   test(`applies no runtime-specific knowledge`, () => {
-    // V8 regexp labels and node_modules both need a known runtime, yet appear
-    // in undetected profiles (e.g. Chrome profiles resolve to unknown). A
-    // `RegExp:` frame is `stdlib` only because it has no location, not because
-    // the label is recognized.
+    // V8 regexp labels and node_modules need a known runtime, yet appear in
+    // undetected profiles. A marker-free pprof profile from a JavaScript
+    // runtime, for example, resolves to unknown. A `RegExp:` frame is `stdlib`
+    // only because it has no location, not because the label is recognized.
     expect(categorizeEntry(relativeEntry(`RegExp: /a/`))).toBe(`stdlib`)
     expect(
       categorizeEntry(


### PR DESCRIPTION
A format's fallback origin was the runtime origin only for single-runtime formats, so a format several origins emit resolved to `unknown` even when one of them defines it. The fallback is now the format's canonical origin, the tool or runtime whose definition the other emitters write to match. Under that rule the V8 formats move from `unknown` and `node` to `chrome`. Each converter records the reasoning above the field.