### PR TITLE
perf: allocate resolved stack arrays with new Array

### DIFF
--- a/src/formats/jfr/parse.ts
+++ b/src/formats/jfr/parse.ts
@@ -1155,7 +1155,10 @@ class ChunkResolver {
 
     // Merge identical stacks that recur across chunks by their resolved
     // (global) method indices and leaf line.
-    const methodIds = Array.from<number>({ length: frameCount })
+    // `new Array` over `Array.from({ length })`: the latter runs the iteration
+    // protocol per element, too slow for a call that runs per stack.
+    // eslint-disable-next-line unicorn/no-new-array
+    const methodIds = new Array<number>(frameCount)
     for (let i = 0; i < frameCount; i++) {
       methodIds[i] = this.#resolveMethod(
         (flat ? flat[i * 2] : objectFrames![i]!.method) as number,

--- a/src/formats/v8/heap-snapshot/parse.ts
+++ b/src/formats/v8/heap-snapshot/parse.ts
@@ -375,9 +375,10 @@ const computeNodeOrdinalToLocation = (
     fieldLayout,
   )
 
-  const nodeOrdinalToLocation = Array.from<SourceLocation>({
-    length: nodeCount,
-  })
+  // `new Array` over `Array.from({ length })`: the latter runs the iteration
+  // protocol per element, too slow at heap snapshot node counts.
+  // eslint-disable-next-line unicorn/no-new-array
+  const nodeOrdinalToLocation = new Array<SourceLocation>(nodeCount)
   // Cache `FileReference` per file path to avoid repeated construction.
   const fileLocationToRef = new Map<string, FileReference | null>()
   for (


### PR DESCRIPTION
Array.from({ length }) runs the iteration protocol per element, so it dominated JFR stack resolution (9.6s -> 7.9s on the largest JFR input).