### PR TITLE
perf: reuse the previous line's interned frames in collapsed parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,8 @@ pnpm generate-inputs go ruby   # Limit to named workload scripts
 - Prioritize runtime performance so large profiles process quickly
 - Use low overhead abstractions
 - NEVER use more than `O(n)` memory for a profile of size `n`
+- Preallocate an array of known length with `new Array(length)`, not
+  `Array.from({ length })`, which runs the iteration protocol per element
 
 ### Parsing
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,4 +3,12 @@ import config from '@tomer/eslint-config'
 export default [
   ...config,
   { ignores: [`skills/**/*`, `.claude/worktrees/**/*`] },
+  {
+    rules: {
+      // The parsing and aggregation hot paths preallocate arrays with
+      // `new Array(length)`. `Array.from({ length })`, the replacement this
+      // rule suggests, runs the iteration protocol per element.
+      'unicorn/no-new-array': `off`,
+    },
+  },
 ]

--- a/src/formats/collapsed/parse.ts
+++ b/src/formats/collapsed/parse.ts
@@ -23,25 +23,93 @@ export const parseCollapsedAsync = async (
   return builder.build()
 }
 
+/**
+ * A stack's text alongside the interned index of each of its frames, in
+ * root-to-leaf order.
+ */
+type InternedStack = {
+  readonly text: string
+  /** The positions of `text`'s `;` separators. */
+  readonly separators: readonly number[]
+  /** One index per frame, so one more than `separators`. */
+  readonly indices: readonly number[]
+}
+
 class CollapsedProfileBuilder {
   readonly #indexByFrame = new Map<string, number>()
   readonly #frames: StackFrame[] = []
   readonly #samples: Sample[] = []
 
+  // Consecutive lines commonly share a long stack prefix, so each shared
+  // leading frame reuses the previous line's interned index instead of
+  // re-slicing and re-hashing its name. Undefined until the first line with a
+  // stack.
+  #previousStack: InternedStack | undefined
+
   public addLine(line: string): void {
-    const stack = parseCollapsedLine(line)
-    if (!stack) {
+    const parsed = parseCollapsedLine(line)
+    if (!parsed) {
       return
+    }
+
+    // An empty stack is a stackless sample. Pass no frames so the aggregator
+    // attributes it to an anonymous function, not a lone empty frame.
+    const indices: readonly number[] =
+      parsed.stack === `` ? [] : this.#internStackFrames(parsed.stack)
+    // Collapsed stacks are root-to-leaf, but the aggregator requires
+    // callee-to-caller.
+    const frameCount = indices.length
+    const frameIndices = new Array<number>(frameCount)
+    for (let i = 0; i < frameCount; i++) {
+      frameIndices[i] = indices[frameCount - 1 - i]!
     }
 
     this.#samples.push({
       // Collapsed stacks carry only a unitless sample count, so the profile
       // has no metrics and ranks by count alone.
       values: [],
-      // Collapsed stacks are root-to-leaf, but we aggregate callee-to-caller.
-      frameIndices: stack.frames.map(frame => this.#intern(frame)).reverse(),
-      sampleCount: stack.count,
+      frameIndices,
+      sampleCount: parsed.count,
     })
+  }
+
+  /** Interns a stack's frames, returning their indices root-to-leaf. */
+  #internStackFrames(stack: string): readonly number[] {
+    const previous = this.#previousStack
+    let shared = 0
+    if (previous) {
+      const prefixLength = commonPrefixLength(stack, previous.text)
+      if (
+        prefixLength === stack.length &&
+        prefixLength === previous.text.length
+      ) {
+        return previous.indices
+      }
+
+      // A previous frame is shared when the common prefix covers its trailing
+      // `;`, so its text is identical.
+      while (
+        shared < previous.separators.length &&
+        previous.separators[shared]! < prefixLength
+      ) {
+        shared++
+      }
+    }
+
+    const indices = previous?.indices.slice(0, shared) ?? []
+    const separators = previous?.separators.slice(0, shared) ?? []
+
+    let start = shared === 0 ? 0 : separators[shared - 1]! + 1
+    let separator
+    while ((separator = stack.indexOf(`;`, start)) !== -1) {
+      indices.push(this.#intern(stack.slice(start, separator)))
+      separators.push(separator)
+      start = separator + 1
+    }
+    indices.push(this.#intern(stack.slice(start)))
+
+    this.#previousStack = { text: stack, separators, indices }
+    return indices
   }
 
   #intern(frame: string): number {
@@ -67,7 +135,27 @@ class CollapsedProfileBuilder {
 }
 
 /**
- * Parses one collapsed line into its raw frames and count, returning
+ * Returns the length of the strings' common prefix in code units.
+ *
+ * Code units, not code points: unit-wise equality never overstates the common
+ * prefix. A pair split at the boundary only understates it, so the frame
+ * containing the pair is interned again.
+ */
+const commonPrefixLength = (string1: string, string2: string): number => {
+  const minLength = Math.min(string1.length, string2.length)
+  let length = 0
+  while (
+    length < minLength &&
+    // eslint-disable-next-line unicorn/prefer-code-point
+    string1.charCodeAt(length) === string2.charCodeAt(length)
+  ) {
+    length++
+  }
+  return length
+}
+
+/**
+ * Parses one collapsed line into its stack text and count, returning
  * `undefined` for blank or `#` comment lines.
  *
  * Also the format's detection grammar, so `matches` and `parse` agree on what
@@ -77,7 +165,7 @@ class CollapsedProfileBuilder {
  */
 export const parseCollapsedLine = (
   line: string,
-): { frames: string[]; count: number } | undefined => {
+): { stack: string; count: number } | undefined => {
   if (line.length === 0 || line.startsWith(`#`)) {
     return undefined
   }
@@ -94,11 +182,8 @@ export const parseCollapsedLine = (
 
   // Trim extra separator whitespace so a count padded with multiple spaces
   // leaves no trailing space on the leaf frame.
-  const stack = line.slice(0, lastSpace).trimEnd()
-  // An empty stack is a stackless sample; pass no frames so the aggregator
-  // attributes it to an anonymous function, not a lone empty frame.
   return {
-    frames: stack === `` ? [] : stack.split(`;`),
+    stack: line.slice(0, lastSpace).trimEnd(),
     count: Number(countText),
   }
 }

--- a/src/formats/jfr/parse.ts
+++ b/src/formats/jfr/parse.ts
@@ -1155,9 +1155,6 @@ class ChunkResolver {
 
     // Merge identical stacks that recur across chunks by their resolved
     // (global) method indices and leaf line.
-    // `new Array` over `Array.from({ length })`: the latter runs the iteration
-    // protocol per element, too slow for a call that runs per stack.
-    // eslint-disable-next-line unicorn/no-new-array
     const methodIds = new Array<number>(frameCount)
     for (let i = 0; i < frameCount; i++) {
       methodIds[i] = this.#resolveMethod(

--- a/src/formats/v8/heap-snapshot/parse.ts
+++ b/src/formats/v8/heap-snapshot/parse.ts
@@ -375,9 +375,6 @@ const computeNodeOrdinalToLocation = (
     fieldLayout,
   )
 
-  // `new Array` over `Array.from({ length })`: the latter runs the iteration
-  // protocol per element, too slow at heap snapshot node counts.
-  // eslint-disable-next-line unicorn/no-new-array
   const nodeOrdinalToLocation = new Array<SourceLocation>(nodeCount)
   // Cache `FileReference` per file path to avoid repeated construction.
   const fileLocationToRef = new Map<string, FileReference | null>()


### PR DESCRIPTION
Consecutive collapsed lines commonly share a long stack prefix, so shared leading frames reuse the previous line's interned indices instead of re-slicing and re-hashing their names (1.45s -> 0.77s on the largest collapsed input).