### PR TITLE
perf(test): use the threads pool without per-file isolation

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -117,6 +117,11 @@ export const projects = [
 export default defineConfig({
   test: {
     environment: `node`,
+    // Threads over the default forks pool, without per-file isolation. No test
+    // mutates module or global state, so a fresh worker and module graph per
+    // test file would only slow the run.
+    pool: `threads`,
+    isolate: false,
     exclude: [...configDefaults.exclude, `.claude/worktrees/**`],
     projects,
     coverage: {


### PR DESCRIPTION
No test mutates module or global state, so forking a worker and rebuilding the module graph per test file only slows the run (91.5s -> 66s wall).