### PR TITLE
docs: require parsing a format to its spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,9 @@ pnpm generate-inputs go ruby   # Limit to named workload scripts
 
 - Cast untyped profile data to typed data for performance. Validate only when
   necessary to make progress
+- Parse a specified format to its spec, accepting every shape the spec allows.
+  Add handling for a shape the spec forbids only when an input contains it, and
+  name the emitter that writes it in a comment
 - NEVER index into a plain object with profile-derived strings (e.g. frame
   names): keys like `toString` or `constructor` resolve to `Object.prototype`
   members. Use a `Map`


### PR DESCRIPTION
Accepting every shape a format's spec allows keeps a parser correct for emitters with no committed input. Handling a shape the spec forbids needs a comment naming the emitter that writes it, so a later reader can tell the workaround from the spec.