### PR TITLE
perf(test): run the CLI over one input per compression scheme

### DIFF
--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1,5 +1,13 @@
 import { spawn } from 'node:child_process'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  closeSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { brotliCompressSync, gzipSync } from 'node:zlib'
@@ -9,6 +17,7 @@ import {
   injectedFormat,
   injectedInputs,
   inputPath,
+  smallestInput,
 } from '../formats/testing.ts'
 import { languageExtensionToPrimary } from './languages.ts'
 
@@ -22,9 +31,34 @@ const inputFilenames = injectedInputs()
 // samples (e.g. a lock profile that saw no contention) — the no-data message.
 const MARKDOWN_OR_NO_DATA = /^(?:# |No profiling data found\.)/u
 
+/** Whether a file starts with the gzip magic number. */
+const isGzipped = (filename: string): boolean => {
+  const magic = Buffer.alloc(2)
+  const file = openSync(inputPath(filename), `r`)
+  try {
+    readSync(file, magic, 0, 2, 0)
+  } finally {
+    closeSync(file)
+  }
+  return magic[0] === 0x1f && magic[1] === 0x8b
+}
+
+/**
+ * The inputs the CLI converts: the smallest of each compression scheme the
+ * project's inputs use. Reading a file and decompressing its bytes is
+ * format-agnostic work the CLI does itself. Below that is the API, which the
+ * format and origin suites already run over every committed input, so spawning
+ * the CLI for each one would repeat gigabytes of conversion in a subprocess.
+ */
+const cliInputFilenames = [true, false].flatMap(gzipped =>
+  smallestInput(
+    inputFilenames.filter(filename => isGzipped(filename) === gzipped),
+  ),
+)
+
 // Registered conditionally because the `unit` project receives no inputs.
-if (inputFilenames.length > 0) {
-  test.concurrent.each(inputFilenames)(
+if (cliInputFilenames.length > 0) {
+  test.concurrent.each(cliInputFilenames)(
     `outputs markdown from a %s file`,
     async filename => {
       const { status, stdout } = await runCli([inputPath(filename)])

--- a/src/formats/index.test.ts
+++ b/src/formats/index.test.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 import { describe, expect, test, vi } from 'vitest'
 import { projects } from '../../vitest.config.ts'
 import { parseExampleFilename } from '../cli/examples.ts'
@@ -30,6 +30,7 @@ import {
   injectedInputs,
   inputPath,
   readInput,
+  smallestInput,
 } from './testing.ts'
 import {
   makeV8CallFrame,
@@ -67,28 +68,14 @@ const jsonInputs = [...inputSets.json]
 const binaryInputs = [...inputSets.binary]
 const allInputs = [...jsonInputs, ...binaryInputs]
 
-/**
- * The input the input-type matrix converts, or none in the `unit` project.
- * Reading bytes handed to the pipeline as a string, a `Blob`, or a stream
- * happens above the converter and is the same for every format. The matrix
- * takes the project's smallest input because converting every committed one
- * would run gigabytes through the pipeline several times over.
- */
-const smallest = (filenames: string[]): string[] =>
-  filenames.length === 0
-    ? []
-    : [
-        filenames.reduce((smallest, filename) =>
-          statSync(inputPath(filename)).size <
-          statSync(inputPath(smallest)).size
-            ? filename
-            : smallest,
-        ),
-      ]
-
-const smallestJsonInput = smallest(jsonInputs)
-const smallestBinaryInput = smallest(binaryInputs)
-const smallestInput = smallest(allInputs)
+// The inputs the input-type matrix converts, or none in the `unit` project.
+// Reading bytes handed to the pipeline as a string, a `Blob`, or a stream
+// happens above the converter and is the same for every format. The matrix
+// takes the project's smallest input because converting every committed one
+// would run gigabytes through the pipeline several times over.
+const smallestJsonInput = smallestInput(jsonInputs)
+const smallestBinaryInput = smallestInput(binaryInputs)
+const smallestAnyInput = smallestInput(allInputs)
 
 // Some real captures legitimately have no samples (e.g. a lock profile that saw
 // no contention), so the pipeline yields the no-data message instead of a
@@ -588,8 +575,8 @@ describe(`profileToMd`, () => {
 })
 
 describe(`profileToMdAsync`, () => {
-  if (smallestInput.length > 0) {
-    describe.each(smallestInput)(`auto-detects %s`, filename => {
+  if (smallestAnyInput.length > 0) {
+    describe.each(smallestAnyInput)(`auto-detects %s`, filename => {
       const content = readInput(filename)
 
       test(`from Blob`, async () => {
@@ -1130,9 +1117,9 @@ describe(`diffProfiles`, () => {
 
 // Registered conditionally because this suite has no input-independent tests,
 // so it would be empty in the `unit` project.
-if (smallestInput.length > 0) {
+if (smallestAnyInput.length > 0) {
   describe(`diffProfilesAsync`, () => {
-    test.each(smallestInput)(`diffs %s Blob inputs`, async filename => {
+    test.each(smallestAnyInput)(`diffs %s Blob inputs`, async filename => {
       const content = readInput(filename)
 
       const md = await diffProfilesAsync(

--- a/src/formats/testing.ts
+++ b/src/formats/testing.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs'
+import { readFileSync, statSync } from 'node:fs'
 import path from 'node:path'
 import { gunzipSync } from 'node:zlib'
 import { inject } from 'vitest'
@@ -55,6 +55,23 @@ export const readInput = (filename: string): Buffer => {
   const data = readFileSync(inputPath(filename))
   return data[0] === 0x1f && data[1] === 0x8b ? gunzipSync(data) : data
 }
+
+/**
+ * The smallest of the given inputs, as a single-element array, or an empty
+ * array when there are none. A `test.each` over the result registers nothing in
+ * the `unit` project, which receives no inputs.
+ */
+export const smallestInput = (filenames: string[]): string[] =>
+  filenames.length === 0
+    ? []
+    : [
+        filenames.reduce((smallest, filename) =>
+          statSync(inputPath(filename)).size <
+          statSync(inputPath(smallest)).size
+            ? filename
+            : smallest,
+        ),
+      ]
 
 export const convertJsonToMd = (
   converter: JsonFormatConverter,


### PR DESCRIPTION
Reading a file and decompressing its bytes is format-agnostic work the CLI does itself. Below that is the API, which the format and origin suites already run over every committed input, so spawning the CLI for each one repeated gigabytes of conversion in a subprocess. Each project now runs the smallest input of each compression scheme among its inputs, cutting the suite's CPU time by 42%.