### PR TITLE
perf(test): give each input project a larger share of the inputs

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,8 +17,12 @@ const inputProcessingFiles = [
  * The input bytes one project should process. A format holding more splits
  * across several projects, so its inputs never run one at a time in a single
  * worker however large they grow.
+ *
+ * Every project transforms and imports the module graph again. This budget
+ * yields roughly one partition per core, and more partitions would pay that
+ * fixed cost again without running more tests at once.
  */
-const PROJECT_INPUT_BYTES = 64 * 1024 * 1024
+const PROJECT_INPUT_BYTES = 512 * 1024 * 1024
 
 const inputDirectory = path.join(import.meta.dirname, `examples/input`)
 


### PR DESCRIPTION
Every project transforms and imports the module graph again. At 64 MB the inputs split across 29 projects, so that fixed cost dominated the run once the per-input conversions shrank. A 512 MB budget yields roughly one partition per core, cutting the suite's CPU time by 38% and its wall time by half.