### PR TITLE
perf(detect): bound the NUL scan to the first 4 KiB

### DIFF
--- a/src/formats/callgrind/matches.ts
+++ b/src/formats/callgrind/matches.ts
@@ -1,9 +1,9 @@
-import { decodeUtf8Lines } from '../../helpers/bytes.ts'
+import { decodeUtf8Lines, hasLeadingNulByte } from '../../helpers/bytes.ts'
 
 export const matchesCallgrind = (bytes: Uint8Array): boolean => {
   // A NUL byte never appears in callgrind text, so it identifies a binary
   // input that decodes as valid UTF-8.
-  if (bytes.includes(0)) {
+  if (hasLeadingNulByte(bytes)) {
     return false
   }
 

--- a/src/formats/collapsed/matches.ts
+++ b/src/formats/collapsed/matches.ts
@@ -1,10 +1,10 @@
-import { decodeUtf8Lines } from '../../helpers/bytes.ts'
+import { decodeUtf8Lines, hasLeadingNulByte } from '../../helpers/bytes.ts'
 import { parseCollapsedLine } from './parse.ts'
 
 export const matchesCollapsed = (bytes: Uint8Array): boolean => {
   // A NUL byte never appears in real collapsed text and reveals a binary input
   // that decodes as valid UTF-8.
-  if (bytes.includes(0)) {
+  if (hasLeadingNulByte(bytes)) {
     return false
   }
 

--- a/src/helpers/bytes.ts
+++ b/src/helpers/bytes.ts
@@ -99,6 +99,19 @@ export async function* decodeUtf8LinesAsync(
   yield* decoder.flush()
 }
 
+/**
+ * Whether a NUL byte appears within the input's leading bytes.
+ *
+ * Text never contains a NUL, while a binary input stores one within its first
+ * bytes, in a magic number, a length field, or padding. Bounding the scan
+ * rejects a binary input at constant cost instead of reading a large text
+ * input end to end.
+ */
+export const hasLeadingNulByte = (bytes: Uint8Array): boolean =>
+  bytes.subarray(0, NUL_SCAN_LENGTH).includes(0)
+
+const NUL_SCAN_LENGTH = 4096
+
 /** A streaming UTF-8 and line-splitting decoder. */
 class Utf8LineDecoder {
   // A streaming decoder must be exclusive to this instance, since it buffers


### PR DESCRIPTION
matchesCollapsed and matchesCallgrind scanned the whole input for a NUL byte, so detection cost scaled with input size on large text profiles. Because a binary input stores a NUL within its first bytes, scanning only the leading bytes rejects the same inputs at constant cost. An input whose first NUL comes later still fails the UTF-8 decode or the line grammar that runs after the scan.