### PR TITLE
feat: break each call graph ranking down by category

### DIFF
--- a/examples/output/c.valgrind.base.callgrind.md
+++ b/examples/output/c.valgrind.base.callgrind.md
@@ -13,6 +13,10 @@ Recorded 39,556,676 instructions.
 
 Functions ranked by instructions recorded directly in the function body, excluding callees.
 
+#### Categories
+
+##### Ours
+
 |     % | Instructions | Function                                          | Location                                            |
 | ----: | -----------: | ------------------------------------------------- | --------------------------------------------------- |
 | 30.6% |   12,117,184 | `ZSTD_encodeSequences`                            | `lib//common/bitstream.h`                           |
@@ -235,6 +239,10 @@ Lines ranked by contribution to each function's self instructions.
 ### Total instructions
 
 Functions ranked by total instructions recorded in the function and all its callees. Calls within a recursion cycle are excluded from totals, since they re-count the same work.
+
+#### Categories
+
+##### Ours
 
 |     % | Instructions | Function                        | Location                                  |
 | ----: | -----------: | ------------------------------- | ----------------------------------------- |

--- a/examples/output/c.valgrind.current.callgrind.md
+++ b/examples/output/c.valgrind.current.callgrind.md
@@ -13,6 +13,10 @@ Recorded 39,558,041 instructions.
 
 Functions ranked by instructions recorded directly in the function body, excluding callees.
 
+#### Categories
+
+##### Ours
+
 |     % | Instructions | Function                                          | Location                                            |
 | ----: | -----------: | ------------------------------------------------- | --------------------------------------------------- |
 | 30.6% |   12,117,184 | `ZSTD_encodeSequences`                            | `lib//common/bitstream.h`                           |
@@ -235,6 +239,10 @@ Lines ranked by contribution to each function's self instructions.
 ### Total instructions
 
 Functions ranked by total instructions recorded in the function and all its callees. Calls within a recursion cycle are excluded from totals, since they re-count the same work.
+
+#### Categories
+
+##### Ours
 
 |     % | Instructions | Function                        | Location                                  |
 | ----: | -----------: | ------------------------------- | ----------------------------------------- |

--- a/examples/output/c.valgrind.diff.callgrind.md
+++ b/examples/output/c.valgrind.diff.callgrind.md
@@ -38,9 +38,31 @@ Functions with the largest increase in instructions recorded directly in the fun
 | +20.0% |   +18 | <0.1% |      90 → 108 | `__aarch64_ldset4_rel`               | `../../usr/lib/aarch64-linux-gnu/libc.so.6` |
 | +16.7% |   +18 | <0.1% |     108 → 126 | `__aarch64_swp4_acq`                 | `../../usr/lib/aarch64-linux-gnu/libc.so.6` |
 
+##### Ours
+
+| Change | Delta |     % |  Instructions | Function                             | Location                               |
+| -----: | ----: | ----: | ------------: | ------------------------------------ | -------------------------------------- |
+| +17.9% |  +291 | <0.1% | 1,629 → 1,920 | `__futex_abstimed_wait_cancelable64` | `./nptl/./nptl/futex-internal.c`       |
+| +16.6% |  +229 | <0.1% | 1,378 → 1,607 | `pthread_cond_wait@@GLIBC_2.17`      | `./nptl/./nptl/pthread_cond_wait.c`    |
+|  +3.1% |  +120 | <0.1% | 3,828 → 3,948 | `pthread_cond_signal@@GLIBC_2.17`    | `./nptl/./nptl/pthread_cond_signal.c`  |
+|  +1.4% |  +120 | <0.1% | 8,390 → 8,510 | `__pthread_mutex_unlock_usercnt`     | `./nptl/./nptl/pthread_mutex_unlock.c` |
+| +25.0% |  +108 | <0.1% |     432 → 540 | `pthread_cond_signal@@GLIBC_2.17`    | `./nptl/./nptl/pthread_cond_common.c`  |
+| +20.0% |   +81 | <0.1% |     405 → 486 | `__pthread_mutex_cond_lock`          | `./nptl/../nptl/pthread_mutex_lock.c`  |
+|  +8.6% |   +72 | <0.1% |     840 → 912 | `__pthread_enable_asynccancel`       | `./nptl/./nptl/cancellation.c`         |
+|  +8.6% |   +66 | <0.1% |     770 → 836 | `__pthread_disable_asynccancel`      | `./nptl/./nptl/cancellation.c`         |
+| +20.0% |   +42 | <0.1% |     210 → 252 | `__condvar_confirm_wakeup`           | `./nptl/./nptl/pthread_cond_wait.c`    |
+| +20.0% |   +42 | <0.1% |     210 → 252 | `__condvar_dec_grefs`                | `./nptl/./nptl/pthread_cond_wait.c`    |
+| +20.0% |   +24 | <0.1% |     120 → 144 | `__lll_lock_wake`                    | `./nptl/./nptl/lowlevellock.c`         |
+| +16.7% |   +21 | <0.1% |     126 → 147 | `_pthread_cleanup_push@@GLIBC_2.34`  | `./nptl/./nptl/cleanup_compat.c`       |
+| +16.7% |   +18 | <0.1% |     108 → 126 | `_pthread_cleanup_pop@@GLIBC_2.34`   | `./nptl/./nptl/cleanup_compat.c`       |
+|  +6.1% |   +13 | <0.1% |     214 → 227 | `strcspn`                            | `./string/./string/strcspn.c`          |
+|  +2.9% |    +9 | <0.1% |     309 → 318 | `POOL_joinJobs`                      | `lib//common/pool.c`                   |
+
 #### Improvements
 
 Functions with the largest decrease in instructions recorded directly in the function body, excluding callees.
+
+##### Ours
 
 | Change | Delta |     % |    Instructions | Function   | Location                               |
 | -----: | ----: | ----: | --------------: | ---------- | -------------------------------------- |
@@ -52,6 +74,8 @@ Functions with the largest decrease in instructions recorded directly in the fun
 #### Regressions
 
 Functions with the largest increase in total instructions recorded in the function and all its callees.
+
+##### Ours
 
 | Change |  Delta |     % |      Instructions | Function                        | Location                                       |
 | -----: | -----: | ----: | ----------------: | ------------------------------- | ---------------------------------------------- |
@@ -79,6 +103,8 @@ Functions with the largest increase in total instructions recorded in the functi
 #### Improvements
 
 Functions with the largest decrease in total instructions recorded in the function and all its callees.
+
+##### Ours
 
 | Change | Delta |     % |    Instructions | Function   | Location                               |
 | -----: | ----: | ----: | --------------: | ---------- | -------------------------------------- |

--- a/src/formats/callgrind/index.test.ts
+++ b/src/formats/callgrind/index.test.ts
@@ -14,10 +14,14 @@ import { normalizeProfileToMdOptions } from '../../options.ts'
 import {
   calleesTables,
   callersTables,
+  categoryRankingTables,
+  categorySectionTables,
   categoryTables,
+  diffRankingTable,
   improvementsTables,
   linesTables,
   profileTitles,
+  rankingTable,
   regressionsTables,
   summaryLines,
 } from '../../testing.ts'
@@ -1098,5 +1102,203 @@ describe(`convert`, () => {
         },
       ],
     ])
+  })
+})
+
+describe(`category subsections`, () => {
+  // Aggregated as the generic origin, which categorizes an installed system
+  // library path as `stdlib` and the rest as `ours`.
+  const categoryOptions = normalizeProfileToMdOptions({
+    baseURL: `/app`,
+    showEntry: () => true,
+  })
+
+  const md = convertBytesToMd(
+    callgrindConverter,
+    makeCallgrind([
+      `events: Ir`,
+      `fl=/app/a.c`,
+      `fn=main`,
+      `1 600`,
+      `fl=/usr/lib/libc.so`,
+      `fn=malloc`,
+      `1 390`,
+      `fl=/usr/include/c++/12/vector`,
+      `fn=reserve`,
+      `1 10`,
+    ]),
+    categoryOptions,
+  )
+
+  const OURS_ROWS = [
+    {
+      '%': `60.0%`,
+      Instructions: `600`,
+      Function: `main`,
+      Location: `a.c`,
+    },
+  ]
+  const NATIVE_ROWS = [
+    {
+      '%': `39.0%`,
+      Instructions: `390`,
+      Function: `malloc`,
+      Location: `../usr/lib/libc.so`,
+    },
+  ]
+  const STDLIB_ROWS = [
+    {
+      '%': `1.0%`,
+      Instructions: `10`,
+      Function: `reserve`,
+      Location: `../usr/include/c++/12/vector`,
+    },
+  ]
+
+  test(`splits the self ranking into a subsection per covered category`, () => {
+    expect(rankingTable(md, `Self instructions`)).toEqual([
+      ...OURS_ROWS,
+      ...NATIVE_ROWS,
+      ...STDLIB_ROWS,
+    ])
+    expect(categorySectionTables(md, `Self instructions`)).toEqual({
+      Ours: OURS_ROWS,
+      Native: NATIVE_ROWS,
+      'Standard library': STDLIB_ROWS,
+    })
+  })
+
+  test(`splits the total ranking into the same categories`, () => {
+    expect(rankingTable(md, `Total instructions`)).toEqual([
+      ...OURS_ROWS,
+      ...NATIVE_ROWS,
+      ...STDLIB_ROWS,
+    ])
+    expect(categorySectionTables(md, `Total instructions`)).toEqual({
+      Ours: OURS_ROWS,
+      Native: NATIVE_ROWS,
+      'Standard library': STDLIB_ROWS,
+    })
+  })
+
+  test(`splits a ranking whose functions all fall in one category`, () => {
+    const singleCategoryMd = convertBytesToMd(
+      callgrindConverter,
+      makeCallgrind([`events: Ir`, `fl=/app/a.c`, `fn=main`, `1 600`]),
+      categoryOptions,
+    )
+
+    expect(rankingTable(singleCategoryMd, `Self instructions`)).toBeUndefined()
+    expect(
+      categorySectionTables(singleCategoryMd, `Self instructions`),
+    ).toEqual({
+      Ours: [
+        {
+          '%': `100.0%`,
+          Instructions: `600`,
+          Function: `main`,
+          Location: `a.c`,
+        },
+      ],
+    })
+  })
+
+  describe(`in a diff`, () => {
+    const graph = (mainSelf: number, mallocSelf: number) =>
+      makeCallgrind([
+        `events: Ir`,
+        `fl=/app/a.c`,
+        `fn=main`,
+        `1 ${mainSelf}`,
+        `fl=/usr/lib/libc.so`,
+        `fn=malloc`,
+        `1 ${mallocSelf}`,
+        `fl=/usr/include/c++/12/vector`,
+        `fn=reserve`,
+        `1 10`,
+      ])
+
+    const diffMd = diffProfiles(
+      { data: graph(600, 390), format: `callgrind` },
+      { data: graph(300, 700), format: `callgrind` },
+      { baseURL: `/app`, showEntry: () => true },
+    )
+
+    test(`splits each ranking into a subsection per covered category`, () => {
+      expect(
+        categoryRankingTables(diffMd, `Self instructions`, `Regressions`),
+      ).toEqual({
+        Native: [
+          {
+            Change: `+79.5%`,
+            Delta: `+310`,
+            '%': `39.0% → 69.3%`,
+            Instructions: `390 → 700`,
+            Function: `malloc`,
+            Location: `../usr/lib/libc.so`,
+          },
+        ],
+      })
+      expect(
+        categoryRankingTables(diffMd, `Self instructions`, `Improvements`),
+      ).toEqual({
+        Ours: [
+          {
+            Change: `-50.0%`,
+            Delta: `-300`,
+            '%': `60.0% → 29.7%`,
+            Instructions: `600 → 300`,
+            Function: `main`,
+            Location: `a.c`,
+          },
+        ],
+      })
+    })
+
+    test(`splits a ranking whose functions all fall in one category`, () => {
+      const singleCategoryMd = diffProfiles(
+        {
+          data: makeCallgrind([
+            `events: Ir`,
+            `fl=/app/a.c`,
+            `fn=main`,
+            `1 600`,
+          ]),
+          format: `callgrind`,
+        },
+        {
+          data: makeCallgrind([
+            `events: Ir`,
+            `fl=/app/a.c`,
+            `fn=main`,
+            `1 300`,
+          ]),
+          format: `callgrind`,
+        },
+        { baseURL: `/app`, showEntry: () => true },
+      )
+
+      expect(
+        diffRankingTable(singleCategoryMd, `Self instructions`, `Improvements`),
+      ).toBeUndefined()
+      expect(
+        categoryRankingTables(
+          singleCategoryMd,
+          `Self instructions`,
+          `Improvements`,
+        ),
+      ).toEqual({
+        Ours: [
+          {
+            Change: `-50.0%`,
+            Delta: `-300`,
+            '%': `100.0%`,
+            Instructions: `600 → 300`,
+            Function: `main`,
+            Location: `a.c`,
+          },
+        ],
+      })
+    })
   })
 })

--- a/src/modalities/call-graph/format.ts
+++ b/src/modalities/call-graph/format.ts
@@ -13,6 +13,12 @@ import {
 } from '../../helpers/markdown.ts'
 import type { FormattingProfileToMdOptions } from '../../options.ts'
 import {
+  formatRankingTables,
+  rankFunctions,
+  subsectionCategories,
+  subsectionDiffCategories,
+} from '../category.ts'
+import {
   ENTRY_FILTER_DISABLED_NOTE,
   formatDiffFunctionSections,
   formatFunctionHeading,
@@ -23,6 +29,7 @@ import {
   selectDiffEntities,
   showDiffEntity,
 } from '../format.ts'
+import type { Category } from '../format.ts'
 import {
   formatProseValue,
   formatProseValueDelta,
@@ -150,49 +157,65 @@ const formatHottestFunctions = ({
   graph: AggregatedCallGraph
   options: FormattingProfileToMdOptions
   headingLevel: number
-}): RootContent[] =>
-  formatSectionGroup(
+}): RootContent[] => {
+  // Resolved once for both rankings, since a category's share comes from the
+  // shown functions' self values whether the ranking is by self or total value.
+  const categories = subsectionCategories({
+    entries: graph.functions.filter(func => options.showEntry(func)),
+    selfValueOf: func => func.selfValues[measure.index]!,
+    categoryOf: func => func.category,
+    minCategoryShare: options.minCategoryShare,
+  })
+
+  return formatSectionGroup(
     [heading(headingLevel, `Hottest functions`)],
     [
       ...formatHottestSelfFunctions({
         measure,
         graph,
+        categories,
         options,
         headingLevel: headingLevel + 1,
       }),
       ...formatHottestTotalFunctions({
         measure,
         graph,
+        categories,
         options,
         headingLevel: headingLevel + 1,
       }),
     ],
   )
+}
 
 const formatHottestSelfFunctions = ({
   measure,
   graph,
+  categories,
   options,
   headingLevel,
 }: {
   measure: Measure
   graph: AggregatedCallGraph
+  categories: Category[]
   options: FormattingProfileToMdOptions
   headingLevel: number
 }): RootContent[] => {
   const { metric, index } = measure
-  const hottestFunctions = selectTopN(
-    graph.functions.filter(
-      func => options.showEntry(func) && func.selfValues[index]! > 0,
+  const valueOf = (func: AggregatedCallGraphFunction) => func.selfValues[index]!
+  const ranking = rankFunctions({
+    functions: graph.functions.filter(
+      func => options.showEntry(func) && valueOf(func) > 0,
     ),
-    options.topN,
-    func => func.selfValues[index]!,
-  )
-  if (hottestFunctions.length === 0) {
+    categories,
+    valueOf,
+    topN: options.topN,
+  })
+  if (ranking.hottestFunctions.length === 0) {
     return []
   }
 
-  const hottestLinesSections = hottestFunctions
+  const hottestLinesSections = ranking.displayedFunctions
     .filter(func => func.lineToMetrics.size > 0)
     .flatMap(func =>
       formatHottestLines({
@@ -203,20 +226,23 @@ const formatHottestSelfFunctions = ({
       }),
     )
 
-  const total = graph.totalValues[index]!
   return [
     heading(headingLevel, `Self ${measureColumnNoun(metric)}`),
     paragraph(
       `Functions ranked by ${measureRankedByPhrase(metric)} directly in the function body, excluding callees.`,
     ),
-    formatTable(
-      functionColumns(metric, `Function`, options),
-      hottestFunctions.map(func => ({
-        func,
-        value: func.selfValues[index]!,
-        total,
-      })),
-    ),
+    ...formatRankingTables({
+      ranking,
+      formatFunctionTable: functions =>
+        formatFunctionTable({
+          functions,
+          metric,
+          valueOf,
+          total: graph.totalValues[index]!,
+          options,
+        }),
+      headingLevel: headingLevel + 1,
+    }),
     ...formatSectionGroup(
       [
         heading(headingLevel + 1, `Lines`),
@@ -228,6 +254,24 @@ const formatHottestSelfFunctions = ({
     ),
   ]
 }
+
+const formatFunctionTable = ({
+  functions,
+  metric,
+  valueOf,
+  total,
+  options,
+}: {
+  functions: AggregatedCallGraphFunction[]
+  metric: Metric
+  valueOf: (func: AggregatedCallGraphFunction) => number
+  total: number
+  options: FormattingProfileToMdOptions
+}): RootContent =>
+  formatTable(
+    functionColumns(metric, `Function`, options),
+    functions.map(func => ({ func, value: valueOf(func), total })),
+  )
 
 const formatHottestLines = ({
   measure,
@@ -267,29 +311,34 @@ const formatHottestLines = ({
 const formatHottestTotalFunctions = ({
   measure,
   graph,
+  categories,
   options,
   headingLevel,
 }: {
   measure: Measure
   graph: AggregatedCallGraph
+  categories: Category[]
   options: FormattingProfileToMdOptions
   headingLevel: number
 }): RootContent[] => {
   const { metric, index } = measure
-  const total = graph.totalValues[index]!
-  const hottestFunctions = selectTopN(
-    graph.functions.filter(
-      func => options.showEntry(func) && func.totalValues[index]! > 0,
+  const valueOf = (func: AggregatedCallGraphFunction) =>
+    func.totalValues[index]!
+  const ranking = rankFunctions({
+    functions: graph.functions.filter(
+      func => options.showEntry(func) && valueOf(func) > 0,
     ),
-    options.topN,
-    func => func.totalValues[index]!,
-  )
-  if (hottestFunctions.length === 0) {
+    categories,
+    valueOf,
+    topN: options.topN,
+  })
+  if (ranking.hottestFunctions.length === 0) {
     return []
   }
 
+  const { displayedFunctions } = ranking
   const hasCallCounts = graphHasCallCounts(graph)
-  const callerSections = hottestFunctions.flatMap(func =>
+  const callerSections = displayedFunctions.flatMap(func =>
     formatHottestArcs({
       measure,
       func,
@@ -299,7 +348,7 @@ const formatHottestTotalFunctions = ({
       headingLevel: headingLevel + 2,
     }),
   )
-  const calleeSections = hottestFunctions.flatMap(func =>
+  const calleeSections = displayedFunctions.flatMap(func =>
     formatHottestArcs({
       measure,
       func,
@@ -315,14 +364,18 @@ const formatHottestTotalFunctions = ({
     paragraph(
       `Functions ranked by total ${measureRankedByPhrase(metric)} in the function and all its callees. Calls within a recursion cycle are excluded from totals, since they re-count the same work.`,
     ),
-    formatTable(
-      functionColumns(metric, `Function`, options),
-      hottestFunctions.map(func => ({
-        func,
-        value: func.totalValues[index]!,
-        total,
-      })),
-    ),
+    ...formatRankingTables({
+      ranking,
+      formatFunctionTable: functions =>
+        formatFunctionTable({
+          functions,
+          metric,
+          valueOf,
+          total: graph.totalValues[index]!,
+          options,
+        }),
+      headingLevel: headingLevel + 1,
+    }),
     ...formatSectionGroup(
       [
         heading(headingLevel + 1, `Callers`),
@@ -505,13 +558,24 @@ const formatDiffFunctions = ({
   measure: AggregatedCallGraphDiff[`metrics`][number]
   options: FormattingProfileToMdOptions
   headingLevel: number
-}): RootContent[] =>
-  formatSectionGroup(
+}): RootContent[] => {
+  // Resolved once for both rankings, over the functions the diff shows.
+  const categories = subsectionDiffCategories({
+    entries: diff.functions.filter(func => showDiffEntity(func, options)),
+    baseSelfValueOf: func => func.base?.selfValues[measure.baseIndex] ?? 0,
+    currentSelfValueOf: func =>
+      func.current?.selfValues[measure.currentIndex] ?? 0,
+    categoryOf: func => func.category,
+    minCategoryShare: options.minCategoryShare,
+  })
+
+  return formatSectionGroup(
     [heading(headingLevel, `Hottest functions`)],
     [
       ...formatDiffDirectionFunctions({
         diff,
         measure,
+        categories,
         options,
         headingLevel: headingLevel + 1,
         direction: `self`,
@@ -519,23 +583,27 @@ const formatDiffFunctions = ({
       ...formatDiffDirectionFunctions({
         diff,
         measure,
+        categories,
         options,
         headingLevel: headingLevel + 1,
         direction: `total`,
       }),
     ],
   )
+}
 
 /** The Self or Total regressions/improvements subsections of a diff. */
 const formatDiffDirectionFunctions = ({
   diff,
   measure,
+  categories,
   options,
   headingLevel,
   direction,
 }: {
   diff: AggregatedCallGraphDiff
   measure: AggregatedCallGraphDiff[`metrics`][number]
+  categories: Category[]
   options: FormattingProfileToMdOptions
   headingLevel: number
   direction: `self` | `total`
@@ -549,14 +617,16 @@ const formatDiffDirectionFunctions = ({
       ? 0
       : (direction === `self` ? func.selfValues : func.totalValues)[index]!
 
-  const { regressions, improvements, hasActive } = selectDiffEntities(
-    diff.functions.map(func => ({
-      entity: func,
-      baseValue: valueOf(func.base, baseIndex),
-      currentValue: valueOf(func.current, currentIndex),
-    })),
-    options,
-  )
+  const { regressions, improvements, hasActive, categoryRankings } =
+    selectDiffEntities(
+      diff.functions.map(func => ({
+        entity: func,
+        baseValue: valueOf(func.base, baseIndex),
+        currentValue: valueOf(func.current, currentIndex),
+      })),
+      options,
+      { categories, categoryOf: func => func.category },
+    )
 
   const baseTotal = diff.base.totalValues[baseIndex]!
   const currentTotal = diff.current.totalValues[currentIndex]!
@@ -592,6 +662,7 @@ const formatDiffDirectionFunctions = ({
     hasActive,
     regressions,
     improvements,
+    categoryRankings,
     rowOf: ({ entity }) => rowOf(entity),
   })
 }

--- a/src/modalities/call-stack-profile/format.test.ts
+++ b/src/modalities/call-stack-profile/format.test.ts
@@ -5,8 +5,10 @@ import {
   categoryRankingTables,
   categorySectionTables,
   categoryTables,
+  diffRankingTable,
   improvementsTables,
   profileTitles,
+  rankingTable,
   regressionsTables,
   resolveProfileToMdOptions,
   summaryLines,
@@ -592,6 +594,29 @@ describe(`formatCallStackProfile`, () => {
         formatCallStackProfile(makeMixedProfile(), defaultOptions),
       )
 
+      expect(rankingTable(md, `Self time`)).toEqual([
+        {
+          '%': `60.5%`,
+          Time: `0.6ms`,
+          Samples: `60`,
+          Function: `ourFunc`,
+          Location: `src/a.ts`,
+        },
+        {
+          '%': `39.4%`,
+          Time: `0.4ms`,
+          Samples: `39`,
+          Function: `libFunc`,
+          Location: `node_modules/lib/index.js`,
+        },
+        {
+          '%': `0.1%`,
+          Time: `1.0µs`,
+          Samples: `1`,
+          Function: `nativeCall`,
+          Location: `<unknown>`,
+        },
+      ])
       expect(categorySectionTables(md, `Self time`)).toEqual({
         Ours: [
           {
@@ -679,6 +704,7 @@ describe(`formatCallStackProfile`, () => {
         formatCallStackProfile(profile, defaultOptions),
       )
 
+      expect(rankingTable(md, `Self time`)).toBeUndefined()
       expect(categorySectionTables(md, `Self time`)).toEqual({
         Ours: [
           {
@@ -1260,6 +1286,34 @@ describe(`formatCallStackProfileDiff`, () => {
       })
     })
 
+    test(`ranks a diff's entries above their category subsections`, () => {
+      const md = diffMixedProfiles([60, 39, 1], [30, 70, 10])
+
+      expect(diffRankingTable(md, `Self time`, `Regressions`)).toEqual([
+        {
+          '%': `39.0% → 63.6%`,
+          Change: `+79.5%`,
+          Delta: `+0.31ms`,
+          Time: `0.4ms → 0.7ms`,
+          Samples: `39 → 70`,
+          Function: `libFunc`,
+          Location: `node_modules/lib/index.js`,
+        },
+        {
+          '%': `1.0% → 9.1%`,
+          Change: `+900.0%`,
+          Delta: `+0.09ms`,
+          Time: `10.0µs → 0.1ms`,
+          Samples: `1 → 10`,
+          Function: `nativeCall`,
+          Location: `<unknown>`,
+        },
+      ])
+      expect(
+        Object.keys(categoryRankingTables(md, `Self time`, `Regressions`)),
+      ).toEqual([`Third-party`, `Native`])
+    })
+
     test(`admits a category by its larger side`, () => {
       // The dependency's share drops from 39.0% to under 1%, so only its base
       // side meets the threshold.
@@ -1273,6 +1327,7 @@ describe(`formatCallStackProfileDiff`, () => {
     test(`splits a ranking whose entries all fall in one category`, () => {
       const md = diffMixedProfiles([100, 0, 0], [50, 0, 0])
 
+      expect(diffRankingTable(md, `Self time`, `Improvements`)).toBeUndefined()
       expect(categoryRankingTables(md, `Self time`, `Improvements`)).toEqual({
         Ours: [
           {

--- a/src/modalities/call-stack-profile/format.ts
+++ b/src/modalities/call-stack-profile/format.ts
@@ -19,16 +19,19 @@ import {
   text,
 } from '../../helpers/markdown.ts'
 import type { FormattingProfileToMdOptions } from '../../options.ts'
-import { subsectionCategories, subsectionDiffCategories } from '../category.ts'
+import {
+  formatRankingTables,
+  rankFunctions,
+  subsectionCategories,
+  subsectionDiffCategories,
+} from '../category.ts'
 import {
   ENTRY_FILTER_DISABLED_NOTE,
-  formatCategory,
   formatDiffFunctionSections,
   formatFunctionHeading,
   formatMeasureSections,
   formatTitle,
   formatZeroTotalNote,
-  isRepeatedByCategory,
   resolveEntryFilter,
   selectDiffEntities,
   showDiffEntity,
@@ -348,10 +351,8 @@ const formatHottestSelfFunctions = ({
     ),
     ...formatRankingTables({
       ranking,
-      measure,
-      valueOf,
-      countOf,
-      options,
+      formatFunctionTable: functions =>
+        formatFunctionTable({ functions, measure, valueOf, countOf, options }),
       headingLevel: headingLevel + 1,
     }),
     ...formatSectionGroup(
@@ -374,136 +375,6 @@ const formatHottestSelfFunctions = ({
     ),
   ]
 }
-
-/** One category's own ranking of {@link functions}. */
-type CategoryRanking = {
-  category: Category
-  functions: AggregatedCallStackProfileFunction[]
-}
-
-/** The functions a ranking displays, overall and within each category. */
-type FunctionRanking = {
-  hottestFunctions: AggregatedCallStackProfileFunction[]
-  categoryRankings: CategoryRanking[]
-  displayedFunctions: AggregatedCallStackProfileFunction[]
-}
-
-/**
- * Ranks {@link functions} by {@link valueOf}, overall and within each of
- * {@link categories}, keeping the top {@link topN} of each.
- *
- * Every ranked function gets the same breakdowns, whichever ranking displayed
- * it, so {@link FunctionRanking.displayedFunctions} contains each of them once,
- * ordered as the rankings above them are.
- */
-const rankFunctions = ({
-  functions,
-  categories,
-  valueOf,
-  topN,
-}: {
-  functions: AggregatedCallStackProfileFunction[]
-  categories: Category[]
-  valueOf: (func: AggregatedCallStackProfileFunction) => number
-  topN: number
-}): FunctionRanking => {
-  const hottestFunctions = selectTopN(functions, topN, valueOf)
-  const categoryRankings = categories.map(category => ({
-    category,
-    functions: selectTopN(
-      functions.filter(func => func.category === category),
-      topN,
-      valueOf,
-    ),
-  }))
-  const displayedFunctions = [
-    ...new Set([
-      ...hottestFunctions,
-      ...categoryRankings.flatMap(({ functions }) => functions),
-    ]),
-  ].sort((func1, func2) => valueOf(func2) - valueOf(func1))
-  return { hottestFunctions, categoryRankings, displayedFunctions }
-}
-
-/**
- * The table ranking {@link FunctionRanking.hottestFunctions}, followed by the
- * per-category subsections repeating that ranking within each category.
- *
- * A category subsection ranking exactly the hottest functions repeats the
- * overall table, which then shows once, under the heading naming the category
- * every function falls in.
- */
-const formatRankingTables = ({
-  ranking: { hottestFunctions, categoryRankings },
-  measure,
-  valueOf,
-  countOf,
-  options,
-  headingLevel,
-}: {
-  ranking: FunctionRanking
-  measure: Measure
-  valueOf: (func: AggregatedCallStackProfileFunction) => number
-  countOf: (func: AggregatedCallStackProfileFunction) => number
-  options: FormattingProfileToMdOptions
-  headingLevel: number
-}): RootContent[] => [
-  ...(isRepeatedByCategory(
-    hottestFunctions,
-    categoryRankings.map(({ functions }) => functions),
-  )
-    ? []
-    : [
-        formatFunctionTable({
-          functions: hottestFunctions,
-          measure,
-          valueOf,
-          countOf,
-          options,
-        }),
-      ]),
-  ...formatCategoryRankings({
-    categoryRankings,
-    measure,
-    valueOf,
-    countOf,
-    options,
-    headingLevel,
-  }),
-]
-
-const formatCategoryRankings = ({
-  categoryRankings,
-  measure,
-  valueOf,
-  countOf,
-  options,
-  headingLevel,
-}: {
-  categoryRankings: CategoryRanking[]
-  measure: Measure
-  valueOf: (func: AggregatedCallStackProfileFunction) => number
-  countOf: (func: AggregatedCallStackProfileFunction) => number
-  options: FormattingProfileToMdOptions
-  headingLevel: number
-}): RootContent[] =>
-  formatSectionGroup(
-    [heading(headingLevel, `Categories`)],
-    categoryRankings.flatMap(({ category, functions }) =>
-      functions.length === 0
-        ? []
-        : [
-            heading(headingLevel + 1, formatCategory(category)),
-            formatFunctionTable({
-              functions,
-              measure,
-              valueOf,
-              countOf,
-              options,
-            }),
-          ],
-    ),
-  )
 
 const formatFunctionTable = ({
   functions,
@@ -647,10 +518,8 @@ const formatHottestTotalFunctions = ({
     ),
     ...formatRankingTables({
       ranking,
-      measure,
-      valueOf,
-      countOf,
-      options,
+      formatFunctionTable: functions =>
+        formatFunctionTable({ functions, measure, valueOf, countOf, options }),
       headingLevel: headingLevel + 1,
     }),
     ...formatSectionGroup(

--- a/src/modalities/category.ts
+++ b/src/modalities/category.ts
@@ -3,6 +3,12 @@
  * that categorize functions.
  */
 
+import type { RootContent } from 'mdast'
+import { selectTopN } from '../helpers/heap.ts'
+import { formatSectionGroup, heading } from '../helpers/markdown.ts'
+import { formatCategory, isRepeatedByCategory } from './format.ts'
+import type { Category } from './format.ts'
+
 /**
  * The categories {@link entries} break down into, ordered by descending share
  * of the total.
@@ -76,6 +82,87 @@ export const subsectionDiffCategories = <Entry, Category extends string>({
     ),
     minCategoryShare,
   )
+
+/** The functions a ranking displays, overall and within each category. */
+export type FunctionRanking<Func> = {
+  hottestFunctions: Func[]
+  categoryRankings: { category: Category; functions: Func[] }[]
+  displayedFunctions: Func[]
+}
+
+/**
+ * Ranks {@link functions} by {@link valueOf}, overall and within each of
+ * {@link categories}, keeping the top {@link topN} of each.
+ *
+ * Every ranked function has the same breakdowns below it, whichever ranking
+ * displays it, so {@link FunctionRanking.displayedFunctions} contains each
+ * function once, sorted by {@link valueOf} like the rankings above it.
+ */
+export const rankFunctions = <Func extends { category: Category }>({
+  functions,
+  categories,
+  valueOf,
+  topN,
+}: {
+  functions: Func[]
+  categories: Category[]
+  valueOf: (func: Func) => number
+  topN: number
+}): FunctionRanking<Func> => {
+  const hottestFunctions = selectTopN(functions, topN, valueOf)
+  const categoryRankings = categories.map(category => ({
+    category,
+    functions: selectTopN(
+      functions.filter(func => func.category === category),
+      topN,
+      valueOf,
+    ),
+  }))
+  const displayedFunctions = [
+    ...new Set([
+      ...hottestFunctions,
+      ...categoryRankings.flatMap(({ functions }) => functions),
+    ]),
+  ].sort((func1, func2) => valueOf(func2) - valueOf(func1))
+  return { hottestFunctions, categoryRankings, displayedFunctions }
+}
+
+/**
+ * The table ranking {@link FunctionRanking.hottestFunctions}, followed by the
+ * per-category subsections repeating that ranking within each category.
+ * {@link formatFunctionTable} builds every table.
+ *
+ * A category subsection ranking exactly the hottest functions repeats the
+ * overall table, so the table shows once, under the heading naming that
+ * category.
+ */
+export const formatRankingTables = <Func>({
+  ranking: { hottestFunctions, categoryRankings },
+  formatFunctionTable,
+  headingLevel,
+}: {
+  ranking: FunctionRanking<Func>
+  formatFunctionTable: (functions: Func[]) => RootContent
+  headingLevel: number
+}): RootContent[] => [
+  ...(isRepeatedByCategory(
+    hottestFunctions,
+    categoryRankings.map(({ functions }) => functions),
+  )
+    ? []
+    : [formatFunctionTable(hottestFunctions)]),
+  ...formatSectionGroup(
+    [heading(headingLevel, `Categories`)],
+    categoryRankings.flatMap(({ category, functions }) =>
+      functions.length === 0
+        ? []
+        : [
+            heading(headingLevel + 1, formatCategory(category)),
+            formatFunctionTable(functions),
+          ],
+    ),
+  ),
+]
 
 /** Per-category sums of one side's values, with the total they sum to. */
 type CategorySums<Category extends string> = {

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -86,6 +86,31 @@ export const improvementsTables = (md: string, section: string): Table[] => {
 }
 
 /**
+ * The table ranking {@link section}'s own entries, above its category
+ * subsections, or `undefined` when a category subsection repeats it.
+ */
+export const rankingTable = (md: string, section: string): Table | undefined =>
+  tableBeforeSubsections(nodesUnderHeading(parseMd(md), section))
+
+/**
+ * The table ranking the entries of {@link ranking} (a diff's `Regressions` or
+ * `Improvements`) in {@link section}, as in {@link rankingTable}.
+ */
+export const diffRankingTable = (
+  md: string,
+  section: string,
+  ranking: string,
+): Table | undefined =>
+  tableBeforeSubsections(
+    nodesUnderHeadingIn(nodesUnderHeading(parseMd(md), section), ranking),
+  )
+
+const tableBeforeSubsections = (nodes: readonly Node[]): Table | undefined => {
+  const table = nextTable(nodes, 0)
+  return table && rowsFromTable(table)
+}
+
+/**
  * Each category subsection's table under {@link section}, keyed by category, so
  * an assertion checks which categories the section broke down as well as their
  * rows.


### PR DESCRIPTION
Extends the per-category breakdown to the call graph, which shares the sampling profile's function categories and ranking structure. Coverage is measured over recorded self costs, the call graph analogue of self values.

No generated example changes: `c.valgrind` records all of its cost under `ours`, and `ruby.rbspy`'s callgrind export records no self cost for its first metric, so both leave their rankings unsplit. The unit tests cover the split, matching categories across the self-ranked and total-ranked sections, and the single-category case.

For https://github.com/TomerAberbach/profiler-md/issues/397