### PR TITLE
perf(examples): convert examples on a worker thread pool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,89 +9,89 @@ friendly Markdown.
 profiler-md
 ├── src/
 │   │
-│   ├── index.ts              # API entry point
+│   ├── index.ts                  # API entry point
 │   │
 │   ├── cli/
-│   │   ├── index.ts          # CLI entry point that orchestrates the run
-│   │   ├── cli.ts            # Optique flag/usage/topic definitions
-│   │   ├── input.ts          # Reads stdin or file, decompresses gzip/brotli
-│   │   ├── options.ts        # Builds API options from CLI flags
-│   │   ├── output.ts         # Writes Markdown to file or stdout (optionally paged)
-│   │   ├── pager.ts          # Spawns $PAGER or `less` for stdout output
-│   │   ├── highlight.ts      # ANSI Markdown syntax highlighting for stdout
-│   │   ├── theme-kindling.ts # Custom Shiki theme for syntax highlighting
-│   │   ├── logo.ts           # ASCII art logo printed to stderr by --version
-│   │   ├── ansis.ts          # ANSI color helpers (respects TTY/no-color)
-│   │   ├── help.ts           # Prints CLI help and per-topic docs
-│   │   ├── languages.ts      # Language display metadata
-│   │   ├── examples.ts       # Parses metadata from examples/ filenames
-│   │   └── error.ts          # CliError class and top-level error reporting
+│   │   ├── index.ts              # CLI entry point that orchestrates the run
+│   │   ├── cli.ts                # Optique flag/usage/topic definitions
+│   │   ├── input.ts              # Reads stdin or file, decompresses gzip/brotli
+│   │   ├── options.ts            # Builds API options from CLI flags
+│   │   ├── output.ts             # Writes Markdown to file or stdout (optionally paged)
+│   │   ├── pager.ts              # Spawns $PAGER or `less` for stdout output
+│   │   ├── highlight.ts          # ANSI Markdown syntax highlighting for stdout
+│   │   ├── theme-kindling.ts     # Custom Shiki theme for syntax highlighting
+│   │   ├── logo.ts               # ASCII art logo printed to stderr by --version
+│   │   ├── ansis.ts              # ANSI color helpers (respects TTY/no-color)
+│   │   ├── help.ts               # Prints CLI help and per-topic docs
+│   │   ├── languages.ts          # Language display metadata
+│   │   ├── examples.ts           # Parses metadata from examples/ filenames
+│   │   └── error.ts              # CliError class and top-level error reporting
 │   │
-│   ├── formats/              # Individual profile format implementations
-│   │   ├── converter.ts      # Format converter types
-│   │   ├── registry.ts       # Format converter registry
-│   │   ├── index.ts          # profileToMd(Async)/diffProfiles(Async) and format auto-detection
-│   │   ├── **/<name>/        # One per format, top-level (e.g. collapsed) or nested in a subdirectory (e.g. v8/cpu-profile)
-│   │   │   ├── matches.ts    # Cheap auto-detection check for the format
-│   │   │   ├── parse.ts      # Parses input into a modality's parsed type
-│   │   │   ├── index.ts      # Exports the format's converter
-│   │   │   └── testing.ts    # Test-only utilities specific to this format (optional)
-│   │   └── testing.ts        # Test-only utilities for running a converter and reading example inputs
+│   ├── formats/                  # Individual profile format implementations
+│   │   ├── converter.ts          # Format converter types
+│   │   ├── registry.ts           # Format converter registry
+│   │   ├── index.ts              # profileToMd(Async)/diffProfiles(Async) and format auto-detection
+│   │   ├── **/<name>/            # One per format, top-level (e.g. collapsed) or nested in a subdirectory (e.g. v8/cpu-profile)
+│   │   │   ├── matches.ts        # Cheap auto-detection check for the format
+│   │   │   ├── parse.ts          # Parses input into a modality's parsed type
+│   │   │   ├── index.ts          # Exports the format's converter
+│   │   │   └── testing.ts        # Test-only utilities specific to this format (optional)
+│   │   └── testing.ts            # Test-only utilities for running a converter and reading example inputs
 │   │
-│   ├── origins/              # Profiler detection and categorization
-│   │   ├── origin.ts         # OriginSpec type + match and frame-normalization helpers
-│   │   ├── categorize.ts     # Generic categorization rule helpers
-│   │   ├── jvm.ts            # JVM runtime conventions shared across origins
-│   │   ├── javascript.ts     # JavaScript ecosystem conventions shared across origins
-│   │   ├── cpython.ts        # CPython interpreter conventions shared across origins
+│   ├── origins/                  # Profiler detection and categorization
+│   │   ├── origin.ts             # OriginSpec type + match and frame-normalization helpers
+│   │   ├── categorize.ts         # Generic categorization rule helpers
+│   │   ├── jvm.ts                # JVM runtime conventions shared across origins
+│   │   ├── javascript.ts         # JavaScript ecosystem conventions shared across origins
+│   │   ├── cpython.ts            # CPython interpreter conventions shared across origins
 │   │   ├── specs/
-│   │   │   ├── <name>.ts     # One file per origin (e.g. node, node-pprof, jdk)
-│   │   │   └── index.ts      # Exports originSpecs in detection-priority order
-│   │   ├── index.ts          # Origin registry and derived detector
-│   │   └── testing.ts        # Test-only origin detection and entry construction helpers
+│   │   │   ├── <name>.ts         # One file per origin (e.g. node, node-pprof, jdk)
+│   │   │   └── index.ts          # Exports originSpecs in detection-priority order
+│   │   ├── index.ts              # Origin registry and derived detector
+│   │   └── testing.ts            # Test-only origin detection and entry construction helpers
 │   │
-│   ├── modalities/           # Individual modality implementations
-│   │   ├── aggregator.ts     # Uniform per-input aggregator contract all modalities implement
-│   │   ├── diff.ts           # Base/current diffing primitives
-│   │   ├── stack-frame.ts    # Stack frame type, distinct-frame origin detection, and normalization shared across modalities
-│   │   ├── metric.ts         # Recorded metric types and inference logic
-│   │   ├── measure.ts        # Metric phrasing and cell formatting shared across modalities
-│   │   ├── table.ts          # Table cell/column types + Markdown table/diff-table formatting
-│   │   ├── format.ts         # Formatting helpers shared across modalities
-│   │   ├── call-stack-profile/ # Common call stack profile conversion logic
-│   │   │   ├── type.ts       # Parsed call stack profile types
-│   │   │   ├── aggregate.ts  # Observation aggregation over frames
-│   │   │   ├── diff.ts       # Aggregated call stack profile diffing logic
-│   │   │   ├── measure.ts    # Profile-resolved measure views with count fallback
-│   │   │   ├── table.ts      # The call stack profile formatter's table columns
-│   │   │   ├── format.ts     # Call stack profile and diff to Markdown formatting
-│   │   │   ├── index.ts      # Barrel file
-│   │   │   └── testing.ts    # Test-only utilities specific to this module
-│   │   ├── call-graph/       # Common weighted call graph conversion logic
-│   │   │   ├── type.ts       # Parsed call graph types
-│   │   │   ├── aggregate.ts  # Function-node merging, cycle-safe totals, and categorization
-│   │   │   ├── diff.ts       # Aggregated call graph diffing logic
-│   │   │   ├── table.ts      # The call graph formatter's table columns
-│   │   │   ├── format.ts     # Call graph and diff to Markdown formatting
-│   │   │   ├── index.ts      # Barrel file
-│   │   │   └── testing.ts    # Test-only utilities specific to this module
-│   │   └── heap-snapshot/    # Common heap snapshot conversion logic
-│   │       ├── type.ts       # Parsed heap snapshot types
-│   │       ├── graph.ts      # Node adjacency graph in CSR format
-│   │       ├── retained.ts   # Retained size computation
-│   │       ├── aggregate.ts  # Heap snapshot aggregation over classified nodes
-│   │       ├── diff.ts       # Aggregated heap snapshot diffing logic
-│   │       ├── table.ts      # The heap snapshot formatter's table columns
-│   │       ├── format.ts     # Heap snapshot and diff to Markdown formatting
-│   │       ├── index.ts      # Barrel file
-│   │       └── testing.ts    # Test-only utilities specific to this module
+│   ├── modalities/               # Individual modality implementations
+│   │   ├── aggregator.ts         # Uniform per-input aggregator contract all modalities implement
+│   │   ├── diff.ts               # Base/current diffing primitives
+│   │   ├── stack-frame.ts        # Stack frame type, distinct-frame origin detection, and normalization shared across modalities
+│   │   ├── metric.ts             # Recorded metric types and inference logic
+│   │   ├── measure.ts            # Metric phrasing and cell formatting shared across modalities
+│   │   ├── table.ts              # Table cell/column types + Markdown table/diff-table formatting
+│   │   ├── format.ts             # Formatting helpers shared across modalities
+│   │   ├── call-stack-profile/   # Common call stack profile conversion logic
+│   │   │   ├── type.ts           # Parsed call stack profile types
+│   │   │   ├── aggregate.ts      # Observation aggregation over frames
+│   │   │   ├── diff.ts           # Aggregated call stack profile diffing logic
+│   │   │   ├── measure.ts        # Profile-resolved measure views with count fallback
+│   │   │   ├── table.ts          # The call stack profile formatter's table columns
+│   │   │   ├── format.ts         # Call stack profile and diff to Markdown formatting
+│   │   │   ├── index.ts          # Barrel file
+│   │   │   └── testing.ts        # Test-only utilities specific to this module
+│   │   ├── call-graph/           # Common weighted call graph conversion logic
+│   │   │   ├── type.ts           # Parsed call graph types
+│   │   │   ├── aggregate.ts      # Function-node merging, cycle-safe totals, and categorization
+│   │   │   ├── diff.ts           # Aggregated call graph diffing logic
+│   │   │   ├── table.ts          # The call graph formatter's table columns
+│   │   │   ├── format.ts         # Call graph and diff to Markdown formatting
+│   │   │   ├── index.ts          # Barrel file
+│   │   │   └── testing.ts        # Test-only utilities specific to this module
+│   │   └── heap-snapshot/        # Common heap snapshot conversion logic
+│   │       ├── type.ts           # Parsed heap snapshot types
+│   │       ├── graph.ts          # Node adjacency graph in CSR format
+│   │       ├── retained.ts       # Retained size computation
+│   │       ├── aggregate.ts      # Heap snapshot aggregation over classified nodes
+│   │       ├── diff.ts           # Aggregated heap snapshot diffing logic
+│   │       ├── table.ts          # The heap snapshot formatter's table columns
+│   │       ├── format.ts         # Heap snapshot and diff to Markdown formatting
+│   │       ├── index.ts          # Barrel file
+│   │       └── testing.ts        # Test-only utilities specific to this module
 │   │
-│   ├── options.ts            # API option types and normalization logic
-│   ├── location.ts           # URL, file path, and line:column location logic
-│   ├── source-map.ts         # Source map resolution logic
-│   ├── testing.ts            # Test-only option resolution and cross-modality Markdown assertion helpers
+│   ├── options.ts                # API option types and normalization logic
+│   ├── location.ts               # URL, file path, and line:column location logic
+│   ├── source-map.ts             # Source map resolution logic
+│   ├── testing.ts                # Test-only option resolution and cross-modality Markdown assertion helpers
 │   │
-│   └── helpers/              # Truly generic (non-profiling) utility functions
+│   └── helpers/                  # Truly generic (non-profiling) utility functions
 │       ├── array.ts
 │       ├── bytes.ts
 │       ├── graph.ts
@@ -104,35 +104,36 @@ profiler-md
 │       └── types.ts
 │
 ├── docs/
-│   ├── api.md                # Programmatic API guide linked from the readme
-│   ├── languages/            # Per-language generation instructions (`profiler-md --help <language>`)
-│   └── formats/              # Per-format descriptions (`profiler-md --help <format>`)
+│   ├── api.md                    # Programmatic API guide linked from the readme
+│   ├── languages/                # Per-language generation instructions (`profiler-md --help <language>`)
+│   └── formats/                  # Per-format descriptions (`profiler-md --help <format>`)
 │
 ├── skills/
-│   └── profile-optimize/     # Agent skill published with the package
+│   └── profile-optimize/         # Agent skill published with the package
 │
 ├── .claude/
-│   ├── dimensions.md         # Where behavior belongs across format/modality/origin
-│   ├── hooks/lint-format.sh  # Lints and formats each written file
-│   └── skills/               # Repo-only agent skills (new-format, new-modality, new-origin, new-input, bench)
+│   ├── dimensions.md             # Where behavior belongs across format/modality/origin
+│   ├── hooks/lint-format.sh      # Lints and formats each written file
+│   └── skills/                   # Repo-only agent skills (new-format, new-modality, new-origin, new-input, bench)
 │
-├── scripts/                  # Bash and TypeScript scripts
-│   ├── bench                 # Benchmark the CLI with the given arguments
-│   ├── generate-inputs       # Regenerate examples/input/ by running scripts/inputs/ inside a nix dev shell
-│   ├── inputs/               # Per-language workload scripts (<lang>.sh + shared _*.sh), assets/ workload inputs, and profiler toolchain nix flake
-│   ├── update-examples.ts    # Update examples/output/ from examples/input/
-│   ├── update-readme.ts      # Update the readme (CLI help + language matrix) from src/cli/languages.ts
-│   └── update-demo.ts        # Record assets/demo.gif with vhs and embed its input digest
+├── scripts/                      # Bash and TypeScript scripts
+│   ├── bench                     # Benchmark the CLI with the given arguments
+│   ├── generate-inputs           # Regenerate examples/input/ by running scripts/inputs/ inside a nix dev shell
+│   ├── inputs/                   # Per-language workload scripts (<lang>.sh + shared _*.sh), assets/ workload inputs, and profiler toolchain nix flake
+│   ├── update-examples.ts        # Update examples/output/ from examples/input/ on a worker thread pool
+│   ├── update-examples-worker.ts # Converts one example per message, then checks or writes it
+│   ├── update-readme.ts          # Update the readme (CLI help + language matrix) from src/cli/languages.ts
+│   └── update-demo.ts            # Record assets/demo.gif with vhs and embed its input digest
 │
 ├── assets/
-│   ├── demo.tape             # vhs script for the readme demo
-│   ├── demo.gif              # Recorded from demo.tape with `pnpm update-demo`
-│   └── logo.svg              # Readme logo
+│   ├── demo.tape                 # vhs script for the readme demo
+│   ├── demo.gif                  # Recorded from demo.tape with `pnpm update-demo`
+│   └── logo.svg                  # Readme logo
 │
-├── examples/                 # Filenames are `<lang>.<origin>.<config?>.<base|current|diff>.<ext>`, parsed by src/cli/examples.ts
-│   ├── input/                # Profile and snapshot inputs for testing and docs
-│   └── output/               # Markdown generated from examples/input/* with `pnpm update-examples`
-└── readme.md                 # CLI and matrix sections generated with `pnpm update-readme`
+├── examples/                     # Filenames are `<lang>.<origin>.<config?>.<base|current|diff>.<ext>`, parsed by src/cli/examples.ts
+│   ├── input/                    # Profile and snapshot inputs for testing and docs
+│   └── output/                   # Markdown generated from examples/input/* with `pnpm update-examples`
+└── readme.md                     # CLI and matrix sections generated with `pnpm update-readme`
 ```
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "dedent": "^1.7.2",
     "eslint": "^10.8.0",
     "knip": "^6.29.0",
-    "limit-concur": "^4.0.0",
     "mdast-util-gfm": "^3.1.0",
     "micromark-extension-gfm": "^3.0.0",
     "npm-run-all2": "^9.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,9 +104,6 @@ importers:
       knip:
         specifier: ^6.29.0
         version: 6.29.0
-      limit-concur:
-        specifier: ^4.0.0
-        version: 4.0.0
       mdast-util-gfm:
         specifier: ^3.1.0
         version: 3.1.0(supports-color@7.2.0)
@@ -2406,10 +2403,6 @@ packages:
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
-
-  limit-concur@4.0.0:
-    resolution: {integrity: sha512-BXUCP52gLz8JA8/cRKkXswOV6FnA2gl8hL8DbgQuo8XA9NKcwU3Oq/Cg1JyAZ+gyNmFEZXI+ZYLes0BrZkl+7g==}
-    engines: {node: '>= 22'}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -5670,8 +5663,6 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
-
-  limit-concur@4.0.0: {}
 
   locate-path@6.0.0:
     dependencies:

--- a/scripts/update-examples-worker.ts
+++ b/scripts/update-examples-worker.ts
@@ -1,0 +1,91 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { enableCompileCache } from 'node:module'
+import { join } from 'node:path'
+import { parentPort, workerData } from 'node:worker_threads'
+import { brotliDecompressSync, gunzipSync } from 'node:zlib'
+import type { ProfileToMdOptions } from '../src/options.ts'
+
+// Reuse compiled bytecode across the worker threads and runs, roughly halving
+// each thread's module loading. The dynamic import below runs after the cache
+// is enabled, so the conversion modules use it.
+enableCompileCache(join(`node_modules`, `.cache`, `node-compile-cache`))
+
+const { profileToMd, diffProfiles } = await import(`../src/index.ts`)
+
+/** One example to convert, sent by the pool. */
+export type ExampleTask = {
+  exampleName: string
+  inputPaths: string[]
+}
+
+/** A converted example's outcome, posted back to the pool. */
+export type ExampleResult = {
+  exampleName: string
+  elapsed: number
+  /** The message to fail the run with, when `--check` found a problem. */
+  failure?: string
+}
+
+const { check } = workerData as { check: boolean }
+
+const options: ProfileToMdOptions = { baseURL: `auto` }
+
+// The CLI's decompression rule (`src/cli/input.ts`): brotli by file suffix,
+// gzip by magic bytes. Reading and decompressing synchronously keeps the work
+// on this thread instead of the process-wide libuv pool the threads would
+// contend on.
+const readInput = (inputPath: string): Uint8Array => {
+  const bytes = readFileSync(inputPath)
+  if (inputPath.endsWith(`.br`)) {
+    return brotliDecompressSync(bytes)
+  }
+  if (bytes[0] === 0x1f && bytes[1] === 0x8b) {
+    return gunzipSync(bytes)
+  }
+  return bytes
+}
+
+const convertInputs = (inputPaths: string[]): string => {
+  const inputs = inputPaths.map(readInput)
+  return inputs.length === 1
+    ? profileToMd(inputs[0]!, options)
+    : diffProfiles(inputs[0]!, inputs[1]!, options)
+}
+
+/** Returns the message to fail the run with, or `undefined` when up to date. */
+const checkExample = (
+  examplePath: string,
+  markdown: string,
+): string | undefined => {
+  let existing
+  try {
+    existing = readFileSync(examplePath, `utf8`)
+  } catch {
+    return `${examplePath} does not exist. Run \`pnpm update-examples\` to fix.`
+  }
+
+  if (existing !== markdown) {
+    return `${examplePath} is out of date. Run \`pnpm update-examples\` to fix.`
+  }
+  return undefined
+}
+
+const updateExample = ({ exampleName, inputPaths }: ExampleTask): void => {
+  const examplePath = join(`examples/output`, `${exampleName}.md`)
+
+  const start = performance.now()
+  const markdown = convertInputs(inputPaths)
+  const elapsed = performance.now() - start
+
+  let failure
+  if (check) {
+    failure = checkExample(examplePath, markdown)
+  } else {
+    writeFileSync(examplePath, markdown)
+  }
+
+  const result: ExampleResult = { exampleName, elapsed, failure }
+  parentPort!.postMessage(result)
+}
+
+parentPort!.on(`message`, updateExample)

--- a/scripts/update-examples.ts
+++ b/scripts/update-examples.ts
@@ -1,132 +1,58 @@
-import { execFile } from 'node:child_process'
-import {
-  readdirSync,
-  readFileSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from 'node:fs'
+import { readdirSync, rmSync, statSync } from 'node:fs'
 import { availableParallelism } from 'node:os'
 import { join } from 'node:path'
-import { promisify } from 'node:util'
-import limitConcur from 'limit-concur'
-
-const execFileAsync = promisify(execFile)
+import { Worker } from 'node:worker_threads'
+import type { ExampleResult, ExampleTask } from './update-examples-worker.ts'
 
 const check = process.argv.includes(`--check`)
 
-const compileCachePath = join(`node_modules`, `.cache`, `node-compile-cache`)
-const inputFilenames = readdirSync(`examples/input`)
+/** An input pair diffed into a single example. */
+type DiffPair = { name: string; ext: string; base: string; current: string }
+
+/** One example to convert: an output name and the inputs converted into it. */
+type Example = { name: string; inputs: string[] }
 
 // Inputs named `<name>.base.<ext>` and `<name>.current.<ext>` are also diffed
 // as a pair into `examples/output/<name>.diff.<ext>.md`. Keyed by `<name>.<ext>`
 // since a single `<name>` can have several extensions (e.g. `javascript.node` has
 // `.cpuprofile`, `.heapprofile`, and `.heapsnapshot`).
-const pairs = new Map<
-  string,
-  { name: string; ext: string; base?: string; current?: string }
->()
-for (const filename of inputFilenames) {
-  // `ext` allows dots so multi-segment extensions like `.speedscope.json` pair
-  // up (e.g. `ruby.base.speedscope.json` / `ruby.current.speedscope.json`).
-  const match = /^(?<name>.+)\.(?<role>base|current)\.(?<ext>.+)$/u.exec(
-    filename,
-  )
-  if (!match) {
-    continue
-  }
-
-  const { name, role, ext } = match.groups!
-  const key = `${name}.${ext}`
-  let pair = pairs.get(key)
-  if (!pair) {
-    pair = { name: name!, ext: ext! }
-    pairs.set(key, pair)
-  }
-  pair[role as `base` | `current`] = filename
-}
-for (const { name, base, current } of pairs.values()) {
-  if (!base || !current) {
-    process.stderr.write(
-      `examples/input/${base ?? current} is missing its ${
-        base ? `current` : `base`
-      } counterpart for the "${name}" diff pair.\n`,
+const findDiffPairs = (inputFilenames: string[]): DiffPair[] => {
+  const pairs = new Map<
+    string,
+    { name: string; ext: string; base?: string; current?: string }
+  >()
+  for (const filename of inputFilenames) {
+    // `ext` allows dots so multi-segment extensions like `.speedscope.json` pair
+    // up (e.g. `ruby.base.speedscope.json` / `ruby.current.speedscope.json`).
+    const match = /^(?<name>.+)\.(?<role>base|current)\.(?<ext>.+)$/u.exec(
+      filename,
     )
-    process.exit(1)
+    if (!match) {
+      continue
+    }
+
+    const { name, role, ext } = match.groups!
+    const key = `${name}.${ext}`
+    let pair = pairs.get(key)
+    if (!pair) {
+      pair = { name: name!, ext: ext! }
+      pairs.set(key, pair)
+    }
+    pair[role as `base` | `current`] = filename
   }
-}
 
-const markdownFilenames = new Set([
-  ...inputFilenames.map(filename => `${filename}.md`),
-  ...[...pairs.values()].map(({ name, ext }) => `${name}.diff.${ext}.md`),
-])
-
-if (check) {
-  for (const filename of readdirSync(`examples/output`)) {
-    if (!markdownFilenames.has(filename)) {
+  return [...pairs.values()].map(({ name, ext, base, current }) => {
+    if (!base || !current) {
       process.stderr.write(
-        `examples/output/${filename} has no corresponding input. Run \`pnpm update-examples\` to fix.\n`,
+        `examples/input/${base ?? current} is missing its ${
+          base ? `current` : `base`
+        } counterpart for the "${name}" diff pair.\n`,
       )
       process.exit(1)
     }
-  }
-} else {
-  for (const filename of readdirSync(`examples/output`)) {
-    if (!markdownFilenames.has(filename)) {
-      rmSync(join(`examples/output`, filename))
-    }
-  }
+    return { name, ext, base, current }
+  })
 }
-
-const total = inputFilenames.length + pairs.size
-let done = 0
-
-const updateExample = limitConcur(
-  availableParallelism(),
-  async (exampleName: string, inputPaths: string[]): Promise<void> => {
-    const examplePath = join(`examples/output`, `${exampleName}.md`)
-
-    const start = performance.now()
-    const { stdout: markdown } = await execFileAsync(
-      `node`,
-      [`src/cli/index.ts`, `--base-url`, `auto`, ...inputPaths],
-      {
-        encoding: `utf8`,
-        maxBuffer: 64 * 1024 * 1024,
-        // Reuse compiled bytecode across the spawned CLI processes, roughly
-        // halving each one's startup.
-        env: { ...process.env, NODE_COMPILE_CACHE: compileCachePath },
-      },
-    )
-    const elapsed = performance.now() - start
-
-    done++
-    process.stderr.write(
-      `[${done}/${total}] ${exampleName} ${elapsed.toFixed(0)}ms\n`,
-    )
-
-    if (check) {
-      let existing
-      try {
-        existing = readFileSync(examplePath, `utf8`)
-      } catch {
-        process.stderr.write(
-          `${examplePath} does not exist. Run \`pnpm update-examples\` to fix.\n`,
-        )
-        process.exit(1)
-      }
-
-      if (existing !== markdown) {
-        process.stderr.write(
-          `${examplePath} is out of date. Run \`pnpm update-examples\` to fix.\n`,
-        )
-        process.exit(1)
-      }
-    } else {
-      writeFileSync(examplePath, markdown)
-    }
-  },
-)
 
 const totalInputBytes = (filenames: string[]): number =>
   filenames.reduce(
@@ -138,21 +64,114 @@ const totalInputBytes = (filenames: string[]): number =>
 // Conversion cost tracks input size, so the largest examples start first.
 // Started last, one would run alone while the other workers sit idle,
 // stretching the run past the point everything else finished.
-const examples = [
-  ...inputFilenames.map(filename => ({ name: filename, inputs: [filename] })),
-  ...[...pairs.values()].map(({ name, ext, base, current }) => ({
-    name: `${name}.diff.${ext}`,
-    inputs: [base!, current!],
-  })),
-]
-  .map(example => ({ ...example, bytes: totalInputBytes(example.inputs) }))
-  .sort((example1, example2) => example2.bytes - example1.bytes)
+const listExamplesLargestFirst = (
+  inputFilenames: string[],
+  pairs: DiffPair[],
+): Example[] =>
+  [
+    ...inputFilenames.map(filename => ({ name: filename, inputs: [filename] })),
+    ...pairs.map(({ name, ext, base, current }) => ({
+      name: `${name}.diff.${ext}`,
+      inputs: [base, current],
+    })),
+  ]
+    .map(example => ({ ...example, bytes: totalInputBytes(example.inputs) }))
+    .sort((example1, example2) => example2.bytes - example1.bytes)
 
-await Promise.all(
-  examples.map(({ name, inputs }) =>
-    updateExample(
-      name,
-      inputs.map(filename => join(`examples/input`, filename)),
-    ),
-  ),
+/** Deletes the outputs that no longer have an input, or fails under `--check`. */
+const deleteOutputsWithoutInput = (examples: Example[]): void => {
+  const expectedFilenames = new Set(examples.map(({ name }) => `${name}.md`))
+  for (const filename of readdirSync(`examples/output`)) {
+    if (expectedFilenames.has(filename)) {
+      continue
+    }
+
+    if (check) {
+      process.stderr.write(
+        `examples/output/${filename} has no corresponding input. Run \`pnpm update-examples\` to fix.\n`,
+      )
+      process.exit(1)
+    } else {
+      rmSync(join(`examples/output`, filename))
+    }
+  }
+}
+
+const reportConverted = (
+  { exampleName, elapsed, failure }: ExampleResult,
+  done: number,
+  total: number,
+): void => {
+  process.stderr.write(
+    `[${done}/${total}] ${exampleName} ${elapsed.toFixed(0)}ms\n`,
+  )
+  if (failure !== undefined) {
+    process.stderr.write(`${failure}\n`)
+    process.exit(1)
+  }
+}
+
+// Each worker takes the next example as it finishes the one it has.
+const convertOnWorkers = (
+  workers: Worker[],
+  examples: Example[],
+): Promise<void> => {
+  let nextIndex = 0
+  let done = 0
+  return new Promise<void>((resolve, reject) => {
+    for (const worker of workers) {
+      const sendNext = (): void => {
+        if (nextIndex >= examples.length) {
+          if (done === examples.length) {
+            resolve()
+          }
+          return
+        }
+
+        const { name, inputs } = examples[nextIndex]!
+        nextIndex++
+        const task: ExampleTask = {
+          exampleName: name,
+          inputPaths: inputs.map(filename => join(`examples/input`, filename)),
+        }
+        worker.postMessage(task)
+      }
+
+      worker.on(`message`, (result: ExampleResult) => {
+        done++
+        reportConverted(result, done, examples.length)
+        sendNext()
+      })
+      worker.on(`error`, reject)
+      sendNext()
+    }
+  })
+}
+
+// A pool of worker threads, each converting one example at a time in-process,
+// so the module graph loads once per thread instead of once per example.
+const convertExamples = async (examples: Example[]): Promise<void> => {
+  if (examples.length === 0) {
+    return
+  }
+
+  const workers = Array.from(
+    { length: Math.min(availableParallelism(), examples.length) },
+    () =>
+      new Worker(new URL(`update-examples-worker.ts`, import.meta.url), {
+        workerData: { check },
+      }),
+  )
+
+  await convertOnWorkers(workers, examples)
+
+  await Promise.all(workers.map(worker => worker.terminate()))
+}
+
+const inputFilenames = readdirSync(`examples/input`)
+const examples = listExamplesLargestFirst(
+  inputFilenames,
+  findDiffPairs(inputFilenames),
 )
+deleteOutputsWithoutInput(examples)
+await convertExamples(examples)


### PR DESCRIPTION
update-examples spawned the CLI once per example, so most of the run went to a process per example resolving and loading the module graph. A pool of worker threads loads it once per thread and converts in-process through profileToMd/diffProfiles, with the same discovery, ordering, progress, and check semantics. Reading and decompressing synchronously keeps each example on its own thread instead of the process-wide libuv pool the threads would contend on. Every example converts byte-identically, and the run takes roughly 20-30% less wall time.