### PR TITLE
fix(systing): count sleeps instead of restating them as a metric

### DIFF
--- a/examples/output/c.systing.cpu.base.systing.md
+++ b/examples/output/c.systing.cpu.base.systing.md
@@ -947,11 +947,11 @@ Common call stack: `unknown (libc.so.6)`
 
 # Uninterruptible sleep profile
 
-Slept 69 times over 69 samples (1 time per sample).
+Slept 69 times.
 
-| Category |      % | Sleeps | Samples |
-| -------- | -----: | -----: | ------: |
-| Kernel   | 100.0% |     69 |      69 |
+| Category |      % | Sleeps |
+| -------- | -----: | -----: |
+| Kernel   | 100.0% |     69 |
 
 ## Hottest functions
 
@@ -963,9 +963,9 @@ Functions ranked by uninterruptible sleeps entered directly in the function body
 
 ##### Kernel
 
-|      % | Sleeps | Samples | Function                    | Location    |
-| -----: | -----: | ------: | --------------------------- | ----------- |
-| 100.0% |     69 |      69 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
+|      % | Sleeps | Function                    | Location    |
+| -----: | -----: | --------------------------- | ----------- |
+| 100.0% |     69 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
 
 #### Callers
 
@@ -973,9 +973,9 @@ Callers ranked by contribution to each function's self sleeps. Inlining can make
 
 ##### `bpf_trace_run4 ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Caller                  | Location    |
-| -----: | -----: | ------: | ----------------------- | ----------- |
-| 100.0% |     69 |      69 | `__schedule ([kernel])` | `<unknown>` |
+|      % | Sleeps | Caller                  | Location    |
+| -----: | -----: | ----------------------- | ----------- |
+| 100.0% |     69 | `__schedule ([kernel])` | `<unknown>` |
 
 ### Total sleeps
 
@@ -985,28 +985,28 @@ Functions ranked by total uninterruptible sleeps entered in the function and all
 
 ##### Kernel
 
-|      % | Sleeps | Samples | Function                                       | Location    |
-| -----: | -----: | ------: | ---------------------------------------------- | ----------- |
-| 100.0% |     69 |      69 | `bpf_trace_run4 ([kernel])`                    | `<unknown>` |
-| 100.0% |     69 |      69 | `__schedule ([kernel])`                        | `<unknown>` |
-| 100.0% |     69 |      69 | `schedule ([kernel])`                          | `<unknown>` |
-|  88.4% |     61 |      61 | `do_syscall_64 ([kernel])`                     | `<unknown>` |
-|  88.4% |     61 |      61 | `entry_SYSCALL_64_after_hwframe ([kernel])`    | `<unknown>` |
-|  82.6% |     57 |      57 | `p9_client_rpc ([kernel])`                     | `<unknown>` |
-|  62.3% |     43 |      43 | `path_openat ([kernel])`                       | `<unknown>` |
-|  62.3% |     43 |      43 | `do_filp_open ([kernel])`                      | `<unknown>` |
-|  43.5% |     30 |      30 | `do_sys_openat2 ([kernel])`                    | `<unknown>` |
-|  43.5% |     30 |      30 | `__x64_sys_openat ([kernel])`                  | `<unknown>` |
-|  27.5% |     19 |      19 | `v9fs_vfs_lookup ([kernel])`                   | `<unknown>` |
-|  26.1% |     18 |      18 | `link_path_walk.part.0.constprop.0 ([kernel])` | `<unknown>` |
-|  21.7% |     15 |      15 | `p9_client_walk ([kernel])`                    | `<unknown>` |
-|  21.7% |     15 |      15 | `walk_component ([kernel])`                    | `<unknown>` |
-|  21.7% |     15 |      15 | `load_elf_binary ([kernel])`                   | `<unknown>` |
-|  21.7% |     15 |      15 | `bprm_execve ([kernel])`                       | `<unknown>` |
-|  21.7% |     15 |      15 | `do_execveat_common ([kernel])`                | `<unknown>` |
-|  21.7% |     15 |      15 | `__x64_sys_execve ([kernel])`                  | `<unknown>` |
-|  21.7% |     15 |      15 | `p9_client_read_once ([kernel])`               | `<unknown>` |
-|  21.7% |     15 |      15 | `p9_client_read ([kernel])`                    | `<unknown>` |
+|      % | Sleeps | Function                                       | Location    |
+| -----: | -----: | ---------------------------------------------- | ----------- |
+| 100.0% |     69 | `bpf_trace_run4 ([kernel])`                    | `<unknown>` |
+| 100.0% |     69 | `__schedule ([kernel])`                        | `<unknown>` |
+| 100.0% |     69 | `schedule ([kernel])`                          | `<unknown>` |
+|  88.4% |     61 | `do_syscall_64 ([kernel])`                     | `<unknown>` |
+|  88.4% |     61 | `entry_SYSCALL_64_after_hwframe ([kernel])`    | `<unknown>` |
+|  82.6% |     57 | `p9_client_rpc ([kernel])`                     | `<unknown>` |
+|  62.3% |     43 | `path_openat ([kernel])`                       | `<unknown>` |
+|  62.3% |     43 | `do_filp_open ([kernel])`                      | `<unknown>` |
+|  43.5% |     30 | `do_sys_openat2 ([kernel])`                    | `<unknown>` |
+|  43.5% |     30 | `__x64_sys_openat ([kernel])`                  | `<unknown>` |
+|  27.5% |     19 | `v9fs_vfs_lookup ([kernel])`                   | `<unknown>` |
+|  26.1% |     18 | `link_path_walk.part.0.constprop.0 ([kernel])` | `<unknown>` |
+|  21.7% |     15 | `p9_client_walk ([kernel])`                    | `<unknown>` |
+|  21.7% |     15 | `walk_component ([kernel])`                    | `<unknown>` |
+|  21.7% |     15 | `load_elf_binary ([kernel])`                   | `<unknown>` |
+|  21.7% |     15 | `bprm_execve ([kernel])`                       | `<unknown>` |
+|  21.7% |     15 | `do_execveat_common ([kernel])`                | `<unknown>` |
+|  21.7% |     15 | `__x64_sys_execve ([kernel])`                  | `<unknown>` |
+|  21.7% |     15 | `p9_client_read_once ([kernel])`               | `<unknown>` |
+|  21.7% |     15 | `p9_client_read ([kernel])`                    | `<unknown>` |
 
 #### Callees
 
@@ -1014,166 +1014,166 @@ Callees ranked by contribution to each function's total sleeps. Inlining can mak
 
 ##### `__schedule ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                      | Location    |
-| -----: | -----: | ------: | --------------------------- | ----------- |
-| 100.0% |     69 |      69 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                      | Location    |
+| -----: | -----: | --------------------------- | ----------- |
+| 100.0% |     69 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
 
 ##### `schedule ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                  | Location    |
-| -----: | -----: | ------: | ----------------------- | ----------- |
-| 100.0% |     69 |      69 | `__schedule ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                  | Location    |
+| -----: | -----: | ----------------------- | ----------- |
+| 100.0% |     69 | `__schedule ([kernel])` | `<unknown>` |
 
 ##### `do_syscall_64 ([kernel])` (`<unknown>`)
 
-|     % | Sleeps | Samples | Callee                         | Location    |
-| ----: | -----: | ------: | ------------------------------ | ----------- |
-| 49.2% |     30 |      30 | `__x64_sys_openat ([kernel])`  | `<unknown>` |
-| 24.6% |     15 |      15 | `__x64_sys_execve ([kernel])`  | `<unknown>` |
-|  9.8% |      6 |       6 | `ksys_read ([kernel])`         | `<unknown>` |
-|  6.6% |      4 |       4 | `__do_sys_newfstat ([kernel])` | `<unknown>` |
-|  3.3% |      2 |       2 | `__x64_sys_pread64 ([kernel])` | `<unknown>` |
+|     % | Sleeps | Callee                         | Location    |
+| ----: | -----: | ------------------------------ | ----------- |
+| 49.2% |     30 | `__x64_sys_openat ([kernel])`  | `<unknown>` |
+| 24.6% |     15 | `__x64_sys_execve ([kernel])`  | `<unknown>` |
+|  9.8% |      6 | `ksys_read ([kernel])`         | `<unknown>` |
+|  6.6% |      4 | `__do_sys_newfstat ([kernel])` | `<unknown>` |
+|  3.3% |      2 | `__x64_sys_pread64 ([kernel])` | `<unknown>` |
 
 ##### `entry_SYSCALL_64_after_hwframe ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                     | Location    |
-| -----: | -----: | ------: | -------------------------- | ----------- |
-| 100.0% |     61 |      61 | `do_syscall_64 ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                     | Location    |
+| -----: | -----: | -------------------------- | ----------- |
+| 100.0% |     61 | `do_syscall_64 ([kernel])` | `<unknown>` |
 
 ##### `p9_client_rpc ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                | Location    |
-| -----: | -----: | ------: | --------------------- | ----------- |
-| 100.0% |     57 |      57 | `schedule ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                | Location    |
+| -----: | -----: | --------------------- | ----------- |
+| 100.0% |     57 | `schedule ([kernel])` | `<unknown>` |
 
 ##### `path_openat ([kernel])` (`<unknown>`)
 
-|     % | Sleeps | Samples | Callee                                         | Location    |
-| ----: | -----: | ------: | ---------------------------------------------- | ----------- |
-| 41.9% |     18 |      18 | `link_path_walk.part.0.constprop.0 ([kernel])` | `<unknown>` |
-| 23.3% |     10 |      10 | `vfs_open ([kernel])`                          | `<unknown>` |
-| 18.6% |      8 |       8 | `lookup_open.isra.0 ([kernel])`                | `<unknown>` |
-|  9.3% |      4 |       4 | `dput.part.0 ([kernel])`                       | `<unknown>` |
-|  7.0% |      3 |       3 | `step_into ([kernel])`                         | `<unknown>` |
+|     % | Sleeps | Callee                                         | Location    |
+| ----: | -----: | ---------------------------------------------- | ----------- |
+| 41.9% |     18 | `link_path_walk.part.0.constprop.0 ([kernel])` | `<unknown>` |
+| 23.3% |     10 | `vfs_open ([kernel])`                          | `<unknown>` |
+| 18.6% |      8 | `lookup_open.isra.0 ([kernel])`                | `<unknown>` |
+|  9.3% |      4 | `dput.part.0 ([kernel])`                       | `<unknown>` |
+|  7.0% |      3 | `step_into ([kernel])`                         | `<unknown>` |
 
 ##### `do_filp_open ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                   | Location    |
-| -----: | -----: | ------: | ------------------------ | ----------- |
-| 100.0% |     43 |      43 | `path_openat ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                   | Location    |
+| -----: | -----: | ------------------------ | ----------- |
+| 100.0% |     43 | `path_openat ([kernel])` | `<unknown>` |
 
 ##### `do_sys_openat2 ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                    | Location    |
-| -----: | -----: | ------: | ------------------------- | ----------- |
-| 100.0% |     30 |      30 | `do_filp_open ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                    | Location    |
+| -----: | -----: | ------------------------- | ----------- |
+| 100.0% |     30 | `do_filp_open ([kernel])` | `<unknown>` |
 
 ##### `__x64_sys_openat ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                      | Location    |
-| -----: | -----: | ------: | --------------------------- | ----------- |
-| 100.0% |     30 |      30 | `do_sys_openat2 ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                      | Location    |
+| -----: | -----: | --------------------------- | ----------- |
+| 100.0% |     30 | `do_sys_openat2 ([kernel])` | `<unknown>` |
 
 ##### `v9fs_vfs_lookup ([kernel])` (`<unknown>`)
 
-|     % | Sleeps | Samples | Callee                                | Location    |
-| ----: | -----: | ------: | ------------------------------------- | ----------- |
-| 52.6% |     10 |      10 | `p9_client_walk ([kernel])`           | `<unknown>` |
-| 47.4% |      9 |       9 | `v9fs_inode_from_fid_dotl ([kernel])` | `<unknown>` |
+|     % | Sleeps | Callee                                | Location    |
+| ----: | -----: | ------------------------------------- | ----------- |
+| 52.6% |     10 | `p9_client_walk ([kernel])`           | `<unknown>` |
+| 47.4% |      9 | `v9fs_inode_from_fid_dotl ([kernel])` | `<unknown>` |
 
 ##### `link_path_walk.part.0.constprop.0 ([kernel])` (`<unknown>`)
 
-|     % | Sleeps | Samples | Callee                      | Location    |
-| ----: | -----: | ------: | --------------------------- | ----------- |
-| 77.8% |     14 |      14 | `walk_component ([kernel])` | `<unknown>` |
-| 22.2% |      4 |       4 | `step_into ([kernel])`      | `<unknown>` |
+|     % | Sleeps | Callee                      | Location    |
+| ----: | -----: | --------------------------- | ----------- |
+| 77.8% |     14 | `walk_component ([kernel])` | `<unknown>` |
+| 22.2% |      4 | `step_into ([kernel])`      | `<unknown>` |
 
 ##### `p9_client_walk ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                     | Location    |
-| -----: | -----: | ------: | -------------------------- | ----------- |
-| 100.0% |     15 |      15 | `p9_client_rpc ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                     | Location    |
+| -----: | -----: | -------------------------- | ----------- |
+| 100.0% |     15 | `p9_client_rpc ([kernel])` | `<unknown>` |
 
 ##### `walk_component ([kernel])` (`<unknown>`)
 
-|     % | Sleeps | Samples | Callee                     | Location    |
-| ----: | -----: | ------: | -------------------------- | ----------- |
-| 73.3% |     11 |      11 | `__lookup_slow ([kernel])` | `<unknown>` |
-| 26.7% |      4 |       4 | `dput.part.0 ([kernel])`   | `<unknown>` |
+|     % | Sleeps | Callee                     | Location    |
+| ----: | -----: | -------------------------- | ----------- |
+| 73.3% |     11 | `__lookup_slow ([kernel])` | `<unknown>` |
+| 26.7% |      4 | `dput.part.0 ([kernel])`   | `<unknown>` |
 
 ##### `load_elf_binary ([kernel])` (`<unknown>`)
 
-|     % | Sleeps | Samples | Callee                      | Location    |
-| ----: | -----: | ------: | --------------------------- | ----------- |
-| 86.7% |     13 |      13 | `open_exec ([kernel])`      | `<unknown>` |
-|  6.7% |      1 |       1 | `__kernel_read ([kernel])`  | `<unknown>` |
-|  6.7% |      1 |       1 | `load_elf_phdrs ([kernel])` | `<unknown>` |
+|     % | Sleeps | Callee                      | Location    |
+| ----: | -----: | --------------------------- | ----------- |
+| 86.7% |     13 | `open_exec ([kernel])`      | `<unknown>` |
+|  6.7% |      1 | `__kernel_read ([kernel])`  | `<unknown>` |
+|  6.7% |      1 | `load_elf_phdrs ([kernel])` | `<unknown>` |
 
 ##### `bprm_execve ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                       | Location    |
-| -----: | -----: | ------: | ---------------------------- | ----------- |
-| 100.0% |     15 |      15 | `load_elf_binary ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                       | Location    |
+| -----: | -----: | ---------------------------- | ----------- |
+| 100.0% |     15 | `load_elf_binary ([kernel])` | `<unknown>` |
 
 ##### `do_execveat_common ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                   | Location    |
-| -----: | -----: | ------: | ------------------------ | ----------- |
-| 100.0% |     15 |      15 | `bprm_execve ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                   | Location    |
+| -----: | -----: | ------------------------ | ----------- |
+| 100.0% |     15 | `bprm_execve ([kernel])` | `<unknown>` |
 
 ##### `__x64_sys_execve ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                          | Location    |
-| -----: | -----: | ------: | ------------------------------- | ----------- |
-| 100.0% |     15 |      15 | `do_execveat_common ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                          | Location    |
+| -----: | -----: | ------------------------------- | ----------- |
+| 100.0% |     15 | `do_execveat_common ([kernel])` | `<unknown>` |
 
 ##### `p9_client_read_once ([kernel])` (`<unknown>`)
 
-|     % | Sleeps | Samples | Callee                                    | Location    |
-| ----: | -----: | ------: | ----------------------------------------- | ----------- |
-| 53.3% |      8 |       8 | `p9_client_zc_rpc.constprop.0 ([kernel])` | `<unknown>` |
-| 46.7% |      7 |       7 | `p9_client_rpc ([kernel])`                | `<unknown>` |
+|     % | Sleeps | Callee                                    | Location    |
+| ----: | -----: | ----------------------------------------- | ----------- |
+| 53.3% |      8 | `p9_client_zc_rpc.constprop.0 ([kernel])` | `<unknown>` |
+| 46.7% |      7 | `p9_client_rpc ([kernel])`                | `<unknown>` |
 
 ##### `p9_client_read ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                           | Location    |
-| -----: | -----: | ------: | -------------------------------- | ----------- |
-| 100.0% |     15 |      15 | `p9_client_read_once ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                           | Location    |
+| -----: | -----: | -------------------------------- | ----------- |
+| 100.0% |     15 | `p9_client_read_once ([kernel])` | `<unknown>` |
 
 ## Hottest call stacks
 
 Call stacks ranked by uninterruptible sleeps entered in their leaf frame. `…` stands for frames the entry filter hides.
 
-|     % | Sleeps | Samples | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| ----: | -----: | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 11.6% |      8 |       8 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_virtio_zc_request ([kernel])` ← `p9_client_zc_rpc.constprop.0 ([kernel])` ← `p9_client_read_once ([kernel])` ← `p9_client_read ([kernel])` ← `v9fs_issue_read ([kernel])` ← `netfs_read_to_pagecache ([kernel])` ← `netfs_read_folio ([kernel])` ← `filemap_read_folio ([kernel])` ← `filemap_fault ([kernel])` ← `__do_fault ([kernel])` ← `do_fault ([kernel])` ← `__handle_mm_fault ([kernel])` ← `handle_mm_fault ([kernel])` ← `do_user_addr_fault ([kernel])` ← `exc_page_fault ([kernel])` ← `asm_exc_page_fault ([kernel])`                                                        |
-|  5.8% |      4 |       4 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_walk ([kernel])` ← `v9fs_file_open ([kernel])` ← `do_dentry_open ([kernel])` ← `vfs_open ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                                   |
-|  5.8% |      4 |       4 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_open ([kernel])` ← `v9fs_file_open ([kernel])` ← `do_dentry_open ([kernel])` ← `vfs_open ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                                   |
-|  5.8% |      4 |       4 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_getattr_dotl ([kernel])` ← `v9fs_vfs_getattr_dotl ([kernel])` ← `vfs_fstat ([kernel])` ← `__do_sys_newfstat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                                                                                                                                     |
-|  4.3% |      3 |       3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_walk ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `v9fs_vfs_atomic_open_dotl ([kernel])` ← `lookup_open.isra.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                             |
-|  4.3% |      3 |       3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_getattr_dotl ([kernel])` ← `v9fs_inode_from_fid_dotl ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `v9fs_vfs_atomic_open_dotl ([kernel])` ← `lookup_open.isra.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                             |
-|  4.3% |      3 |       3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_walk ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `__lookup_slow ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                            |
-|  4.3% |      3 |       3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_getattr_dotl ([kernel])` ← `v9fs_inode_from_fid_dotl ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `__lookup_slow ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                            |
-|  4.3% |      3 |       3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_readlink ([kernel])` ← `v9fs_vfs_get_link_dotl ([kernel])` ← `step_into ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                   |
-|  4.3% |      3 |       3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_clunk ([kernel])` ← `v9fs_dentry_release ([kernel])` ← `__dentry_kill ([kernel])` ← `dput.part.0 ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                            |
-|  4.3% |      3 |       3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_read_once ([kernel])` ← `p9_client_read ([kernel])` ← `v9fs_issue_read ([kernel])` ← `netfs_unbuffered_read_iter_locked ([kernel])` ← `netfs_unbuffered_read_iter ([kernel])` ← `vfs_read ([kernel])` ← `ksys_read ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                              |
-|  4.3% |      3 |       3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `schedule_preempt_disabled ([kernel])` ← `rwsem_down_read_slowpath ([kernel])` ← `down_read_killable ([kernel])` ← `lock_mm_and_find_vma ([kernel])` ← `do_user_addr_fault ([kernel])` ← `exc_page_fault ([kernel])` ← `asm_exc_page_fault ([kernel])` ← `_copy_to_iter ([kernel])` ← `copy_page_to_iter ([kernel])` ← `shmem_file_read_iter ([kernel])` ← `vfs_read ([kernel])` ← `ksys_read ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← … ← `fread (libc.so.6)` ← `AIO_ReadPool_executeReadJob` (`fileio_asyncio.c`) ← `POOL_thread` (`pool.c`) |
-|  2.9% |      2 |       2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_walk ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `__lookup_slow ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                       |
-|  2.9% |      2 |       2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_getattr_dotl ([kernel])` ← `v9fs_inode_from_fid_dotl ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `__lookup_slow ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                       |
-|  2.9% |      2 |       2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_clunk ([kernel])` ← `v9fs_dentry_release ([kernel])` ← `__dentry_kill ([kernel])` ← `dput.part.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                      |
-|  2.9% |      2 |       2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_readlink ([kernel])` ← `v9fs_vfs_get_link_dotl ([kernel])` ← `step_into ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                                                    |
-|  2.9% |      2 |       2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_clunk ([kernel])` ← `v9fs_dentry_release ([kernel])` ← `__dentry_kill ([kernel])` ← `dput.part.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                           |
-|  2.9% |      2 |       2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_read_once ([kernel])` ← `p9_client_read ([kernel])` ← `v9fs_issue_read ([kernel])` ← `netfs_unbuffered_read_iter_locked ([kernel])` ← `netfs_unbuffered_read_iter ([kernel])` ← `vfs_read ([kernel])` ← `__x64_sys_pread64 ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                      |
-|  1.4% |      1 |       1 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_readlink ([kernel])` ← `v9fs_vfs_get_link_dotl ([kernel])` ← `step_into ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                              |
-|  1.4% |      1 |       1 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_clunk ([kernel])` ← `v9fs_dentry_release ([kernel])` ← `__dentry_kill ([kernel])` ← `dput.part.0 ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                       |
+|     % | Sleeps | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ----: | -----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 11.6% |      8 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_virtio_zc_request ([kernel])` ← `p9_client_zc_rpc.constprop.0 ([kernel])` ← `p9_client_read_once ([kernel])` ← `p9_client_read ([kernel])` ← `v9fs_issue_read ([kernel])` ← `netfs_read_to_pagecache ([kernel])` ← `netfs_read_folio ([kernel])` ← `filemap_read_folio ([kernel])` ← `filemap_fault ([kernel])` ← `__do_fault ([kernel])` ← `do_fault ([kernel])` ← `__handle_mm_fault ([kernel])` ← `handle_mm_fault ([kernel])` ← `do_user_addr_fault ([kernel])` ← `exc_page_fault ([kernel])` ← `asm_exc_page_fault ([kernel])`                                                        |
+|  5.8% |      4 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_walk ([kernel])` ← `v9fs_file_open ([kernel])` ← `do_dentry_open ([kernel])` ← `vfs_open ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                                   |
+|  5.8% |      4 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_open ([kernel])` ← `v9fs_file_open ([kernel])` ← `do_dentry_open ([kernel])` ← `vfs_open ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                                   |
+|  5.8% |      4 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_getattr_dotl ([kernel])` ← `v9fs_vfs_getattr_dotl ([kernel])` ← `vfs_fstat ([kernel])` ← `__do_sys_newfstat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                                                                                                                                     |
+|  4.3% |      3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_walk ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `v9fs_vfs_atomic_open_dotl ([kernel])` ← `lookup_open.isra.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                             |
+|  4.3% |      3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_getattr_dotl ([kernel])` ← `v9fs_inode_from_fid_dotl ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `v9fs_vfs_atomic_open_dotl ([kernel])` ← `lookup_open.isra.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                             |
+|  4.3% |      3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_walk ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `__lookup_slow ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                            |
+|  4.3% |      3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_getattr_dotl ([kernel])` ← `v9fs_inode_from_fid_dotl ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `__lookup_slow ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                            |
+|  4.3% |      3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_readlink ([kernel])` ← `v9fs_vfs_get_link_dotl ([kernel])` ← `step_into ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                   |
+|  4.3% |      3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_clunk ([kernel])` ← `v9fs_dentry_release ([kernel])` ← `__dentry_kill ([kernel])` ← `dput.part.0 ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                            |
+|  4.3% |      3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_read_once ([kernel])` ← `p9_client_read ([kernel])` ← `v9fs_issue_read ([kernel])` ← `netfs_unbuffered_read_iter_locked ([kernel])` ← `netfs_unbuffered_read_iter ([kernel])` ← `vfs_read ([kernel])` ← `ksys_read ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                              |
+|  4.3% |      3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `schedule_preempt_disabled ([kernel])` ← `rwsem_down_read_slowpath ([kernel])` ← `down_read_killable ([kernel])` ← `lock_mm_and_find_vma ([kernel])` ← `do_user_addr_fault ([kernel])` ← `exc_page_fault ([kernel])` ← `asm_exc_page_fault ([kernel])` ← `_copy_to_iter ([kernel])` ← `copy_page_to_iter ([kernel])` ← `shmem_file_read_iter ([kernel])` ← `vfs_read ([kernel])` ← `ksys_read ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← … ← `fread (libc.so.6)` ← `AIO_ReadPool_executeReadJob` (`fileio_asyncio.c`) ← `POOL_thread` (`pool.c`) |
+|  2.9% |      2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_walk ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `__lookup_slow ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                       |
+|  2.9% |      2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_getattr_dotl ([kernel])` ← `v9fs_inode_from_fid_dotl ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `__lookup_slow ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                       |
+|  2.9% |      2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_clunk ([kernel])` ← `v9fs_dentry_release ([kernel])` ← `__dentry_kill ([kernel])` ← `dput.part.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                      |
+|  2.9% |      2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_readlink ([kernel])` ← `v9fs_vfs_get_link_dotl ([kernel])` ← `step_into ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                                                    |
+|  2.9% |      2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_clunk ([kernel])` ← `v9fs_dentry_release ([kernel])` ← `__dentry_kill ([kernel])` ← `dput.part.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                           |
+|  2.9% |      2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_read_once ([kernel])` ← `p9_client_read ([kernel])` ← `v9fs_issue_read ([kernel])` ← `netfs_unbuffered_read_iter_locked ([kernel])` ← `netfs_unbuffered_read_iter ([kernel])` ← `vfs_read ([kernel])` ← `__x64_sys_pread64 ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                      |
+|  1.4% |      1 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_readlink ([kernel])` ← `v9fs_vfs_get_link_dotl ([kernel])` ← `step_into ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                              |
+|  1.4% |      1 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_clunk ([kernel])` ← `v9fs_dentry_release ([kernel])` ← `__dentry_kill ([kernel])` ← `dput.part.0 ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                       |
 
 # Interruptible sleep profile
 
-Slept 84 times over 84 samples (1 time per sample).
+Slept 84 times.
 
-| Category |      % | Sleeps | Samples |
-| -------- | -----: | -----: | ------: |
-| Kernel   | 100.0% |     84 |      84 |
+| Category |      % | Sleeps |
+| -------- | -----: | -----: |
+| Kernel   | 100.0% |     84 |
 
 ## Hottest functions
 
@@ -1185,9 +1185,9 @@ Functions ranked by interruptible sleeps entered directly in the function body, 
 
 ##### Kernel
 
-|      % | Sleeps | Samples | Function                    | Location    |
-| -----: | -----: | ------: | --------------------------- | ----------- |
-| 100.0% |     84 |      84 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
+|      % | Sleeps | Function                    | Location    |
+| -----: | -----: | --------------------------- | ----------- |
+| 100.0% |     84 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
 
 #### Callers
 
@@ -1195,52 +1195,52 @@ Callers ranked by contribution to each function's self sleeps. Inlining can make
 
 ##### `bpf_trace_run4 ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Caller                  | Location    |
-| -----: | -----: | ------: | ----------------------- | ----------- |
-| 100.0% |     84 |      84 | `__schedule ([kernel])` | `<unknown>` |
+|      % | Sleeps | Caller                  | Location    |
+| -----: | -----: | ----------------------- | ----------- |
+| 100.0% |     84 | `__schedule ([kernel])` | `<unknown>` |
 
 ### Total sleeps
 
 Functions ranked by total interruptible sleeps entered in the function and all its callees.
 
-|      % | Sleeps | Samples | Function                                    | Location            |
-| -----: | -----: | ------: | ------------------------------------------- | ------------------- |
-| 100.0% |     84 |      84 | `bpf_trace_run4 ([kernel])`                 | `<unknown>`         |
-| 100.0% |     84 |      84 | `__schedule ([kernel])`                     | `<unknown>`         |
-| 100.0% |     84 |      84 | `schedule ([kernel])`                       | `<unknown>`         |
-| 100.0% |     84 |      84 | `futex_wait_queue ([kernel])`               | `<unknown>`         |
-| 100.0% |     84 |      84 | `__futex_wait ([kernel])`                   | `<unknown>`         |
-| 100.0% |     84 |      84 | `futex_wait ([kernel])`                     | `<unknown>`         |
-| 100.0% |     84 |      84 | `do_futex ([kernel])`                       | `<unknown>`         |
-| 100.0% |     84 |      84 | `__x64_sys_futex ([kernel])`                | `<unknown>`         |
-| 100.0% |     84 |      84 | `do_syscall_64 ([kernel])`                  | `<unknown>`         |
-| 100.0% |     84 |      84 | `entry_SYSCALL_64_after_hwframe ([kernel])` | `<unknown>`         |
-| 100.0% |     84 |      84 | `pthread_cond_wait (libc.so.6)`             | `<unknown>`         |
-|  90.5% |     76 |      76 | `POOL_thread`                               | `pool.c`            |
-|   9.5% |      8 |       8 | `FIO_compressFilename_srcFile`              | `fileio.c`          |
-|   9.5% |      8 |       8 | `FIO_compressFilename`                      | `fileio.c`          |
-|   9.5% |      8 |       8 | `main`                                      | `zstdcli.c`         |
-|   7.1% |      6 |       6 | `ZSTDMT_compressStream_generic`             | `zstdmt_compress.c` |
-|   7.1% |      6 |       6 | `ZSTD_compressStream2`                      | `zstd_compress.c`   |
-|   2.4% |      2 |       2 | `POOL_add`                                  | `pool.c`            |
-|   2.4% |      2 |       2 | `AIO_ReadPool_setFile`                      | `fileio_asyncio.c`  |
+|      % | Sleeps | Function                                    | Location            |
+| -----: | -----: | ------------------------------------------- | ------------------- |
+| 100.0% |     84 | `bpf_trace_run4 ([kernel])`                 | `<unknown>`         |
+| 100.0% |     84 | `__schedule ([kernel])`                     | `<unknown>`         |
+| 100.0% |     84 | `schedule ([kernel])`                       | `<unknown>`         |
+| 100.0% |     84 | `futex_wait_queue ([kernel])`               | `<unknown>`         |
+| 100.0% |     84 | `__futex_wait ([kernel])`                   | `<unknown>`         |
+| 100.0% |     84 | `futex_wait ([kernel])`                     | `<unknown>`         |
+| 100.0% |     84 | `do_futex ([kernel])`                       | `<unknown>`         |
+| 100.0% |     84 | `__x64_sys_futex ([kernel])`                | `<unknown>`         |
+| 100.0% |     84 | `do_syscall_64 ([kernel])`                  | `<unknown>`         |
+| 100.0% |     84 | `entry_SYSCALL_64_after_hwframe ([kernel])` | `<unknown>`         |
+| 100.0% |     84 | `pthread_cond_wait (libc.so.6)`             | `<unknown>`         |
+|  90.5% |     76 | `POOL_thread`                               | `pool.c`            |
+|   9.5% |      8 | `FIO_compressFilename_srcFile`              | `fileio.c`          |
+|   9.5% |      8 | `FIO_compressFilename`                      | `fileio.c`          |
+|   9.5% |      8 | `main`                                      | `zstdcli.c`         |
+|   7.1% |      6 | `ZSTDMT_compressStream_generic`             | `zstdmt_compress.c` |
+|   7.1% |      6 | `ZSTD_compressStream2`                      | `zstd_compress.c`   |
+|   2.4% |      2 | `POOL_add`                                  | `pool.c`            |
+|   2.4% |      2 | `AIO_ReadPool_setFile`                      | `fileio_asyncio.c`  |
 
 #### Categories
 
 ##### Kernel
 
-|      % | Sleeps | Samples | Function                                    | Location    |
-| -----: | -----: | ------: | ------------------------------------------- | ----------- |
-| 100.0% |     84 |      84 | `bpf_trace_run4 ([kernel])`                 | `<unknown>` |
-| 100.0% |     84 |      84 | `__schedule ([kernel])`                     | `<unknown>` |
-| 100.0% |     84 |      84 | `schedule ([kernel])`                       | `<unknown>` |
-| 100.0% |     84 |      84 | `futex_wait_queue ([kernel])`               | `<unknown>` |
-| 100.0% |     84 |      84 | `__futex_wait ([kernel])`                   | `<unknown>` |
-| 100.0% |     84 |      84 | `futex_wait ([kernel])`                     | `<unknown>` |
-| 100.0% |     84 |      84 | `do_futex ([kernel])`                       | `<unknown>` |
-| 100.0% |     84 |      84 | `__x64_sys_futex ([kernel])`                | `<unknown>` |
-| 100.0% |     84 |      84 | `do_syscall_64 ([kernel])`                  | `<unknown>` |
-| 100.0% |     84 |      84 | `entry_SYSCALL_64_after_hwframe ([kernel])` | `<unknown>` |
+|      % | Sleeps | Function                                    | Location    |
+| -----: | -----: | ------------------------------------------- | ----------- |
+| 100.0% |     84 | `bpf_trace_run4 ([kernel])`                 | `<unknown>` |
+| 100.0% |     84 | `__schedule ([kernel])`                     | `<unknown>` |
+| 100.0% |     84 | `schedule ([kernel])`                       | `<unknown>` |
+| 100.0% |     84 | `futex_wait_queue ([kernel])`               | `<unknown>` |
+| 100.0% |     84 | `__futex_wait ([kernel])`                   | `<unknown>` |
+| 100.0% |     84 | `futex_wait ([kernel])`                     | `<unknown>` |
+| 100.0% |     84 | `do_futex ([kernel])`                       | `<unknown>` |
+| 100.0% |     84 | `__x64_sys_futex ([kernel])`                | `<unknown>` |
+| 100.0% |     84 | `do_syscall_64 ([kernel])`                  | `<unknown>` |
+| 100.0% |     84 | `entry_SYSCALL_64_after_hwframe ([kernel])` | `<unknown>` |
 
 #### Callees
 
@@ -1248,113 +1248,113 @@ Callees ranked by contribution to each function's total sleeps. Inlining can mak
 
 ##### `__schedule ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                      | Location    |
-| -----: | -----: | ------: | --------------------------- | ----------- |
-| 100.0% |     84 |      84 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                      | Location    |
+| -----: | -----: | --------------------------- | ----------- |
+| 100.0% |     84 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
 
 ##### `schedule ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                  | Location    |
-| -----: | -----: | ------: | ----------------------- | ----------- |
-| 100.0% |     84 |      84 | `__schedule ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                  | Location    |
+| -----: | -----: | ----------------------- | ----------- |
+| 100.0% |     84 | `__schedule ([kernel])` | `<unknown>` |
 
 ##### `futex_wait_queue ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                | Location    |
-| -----: | -----: | ------: | --------------------- | ----------- |
-| 100.0% |     84 |      84 | `schedule ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                | Location    |
+| -----: | -----: | --------------------- | ----------- |
+| 100.0% |     84 | `schedule ([kernel])` | `<unknown>` |
 
 ##### `__futex_wait ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                        | Location    |
-| -----: | -----: | ------: | ----------------------------- | ----------- |
-| 100.0% |     84 |      84 | `futex_wait_queue ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                        | Location    |
+| -----: | -----: | ----------------------------- | ----------- |
+| 100.0% |     84 | `futex_wait_queue ([kernel])` | `<unknown>` |
 
 ##### `futex_wait ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                    | Location    |
-| -----: | -----: | ------: | ------------------------- | ----------- |
-| 100.0% |     84 |      84 | `__futex_wait ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                    | Location    |
+| -----: | -----: | ------------------------- | ----------- |
+| 100.0% |     84 | `__futex_wait ([kernel])` | `<unknown>` |
 
 ##### `do_futex ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                  | Location    |
-| -----: | -----: | ------: | ----------------------- | ----------- |
-| 100.0% |     84 |      84 | `futex_wait ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                  | Location    |
+| -----: | -----: | ----------------------- | ----------- |
+| 100.0% |     84 | `futex_wait ([kernel])` | `<unknown>` |
 
 ##### `__x64_sys_futex ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                | Location    |
-| -----: | -----: | ------: | --------------------- | ----------- |
-| 100.0% |     84 |      84 | `do_futex ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                | Location    |
+| -----: | -----: | --------------------- | ----------- |
+| 100.0% |     84 | `do_futex ([kernel])` | `<unknown>` |
 
 ##### `do_syscall_64 ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                       | Location    |
-| -----: | -----: | ------: | ---------------------------- | ----------- |
-| 100.0% |     84 |      84 | `__x64_sys_futex ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                       | Location    |
+| -----: | -----: | ---------------------------- | ----------- |
+| 100.0% |     84 | `__x64_sys_futex ([kernel])` | `<unknown>` |
 
 ##### `entry_SYSCALL_64_after_hwframe ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                     | Location    |
-| -----: | -----: | ------: | -------------------------- | ----------- |
-| 100.0% |     84 |      84 | `do_syscall_64 ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                     | Location    |
+| -----: | -----: | -------------------------- | ----------- |
+| 100.0% |     84 | `do_syscall_64 ([kernel])` | `<unknown>` |
 
 ##### `POOL_thread` (`pool.c`)
 
-|      % | Sleeps | Samples | Callee                          | Location    |
-| -----: | -----: | ------: | ------------------------------- | ----------- |
-| 100.0% |     76 |      76 | `pthread_cond_wait (libc.so.6)` | `<unknown>` |
+|      % | Sleeps | Callee                          | Location    |
+| -----: | -----: | ------------------------------- | ----------- |
+| 100.0% |     76 | `pthread_cond_wait (libc.so.6)` | `<unknown>` |
 
 ##### `FIO_compressFilename_srcFile` (`fileio.c`)
 
-|     % | Sleeps | Samples | Callee                 | Location           |
-| ----: | -----: | ------: | ---------------------- | ------------------ |
-| 75.0% |      6 |       6 | `ZSTD_compressStream2` | `zstd_compress.c`  |
-| 25.0% |      2 |       2 | `AIO_ReadPool_setFile` | `fileio_asyncio.c` |
+|     % | Sleeps | Callee                 | Location           |
+| ----: | -----: | ---------------------- | ------------------ |
+| 75.0% |      6 | `ZSTD_compressStream2` | `zstd_compress.c`  |
+| 25.0% |      2 | `AIO_ReadPool_setFile` | `fileio_asyncio.c` |
 
 ##### `FIO_compressFilename` (`fileio.c`)
 
-|      % | Sleeps | Samples | Callee                         | Location   |
-| -----: | -----: | ------: | ------------------------------ | ---------- |
-| 100.0% |      8 |       8 | `FIO_compressFilename_srcFile` | `fileio.c` |
+|      % | Sleeps | Callee                         | Location   |
+| -----: | -----: | ------------------------------ | ---------- |
+| 100.0% |      8 | `FIO_compressFilename_srcFile` | `fileio.c` |
 
 ##### `main` (`zstdcli.c`)
 
-|      % | Sleeps | Samples | Callee                 | Location   |
-| -----: | -----: | ------: | ---------------------- | ---------- |
-| 100.0% |      8 |       8 | `FIO_compressFilename` | `fileio.c` |
+|      % | Sleeps | Callee                 | Location   |
+| -----: | -----: | ---------------------- | ---------- |
+| 100.0% |      8 | `FIO_compressFilename` | `fileio.c` |
 
 ##### `ZSTDMT_compressStream_generic` (`zstdmt_compress.c`)
 
-|      % | Sleeps | Samples | Callee                          | Location    |
-| -----: | -----: | ------: | ------------------------------- | ----------- |
-| 100.0% |      6 |       6 | `pthread_cond_wait (libc.so.6)` | `<unknown>` |
+|      % | Sleeps | Callee                          | Location    |
+| -----: | -----: | ------------------------------- | ----------- |
+| 100.0% |      6 | `pthread_cond_wait (libc.so.6)` | `<unknown>` |
 
 ##### `ZSTD_compressStream2` (`zstd_compress.c`)
 
-|      % | Sleeps | Samples | Callee                          | Location            |
-| -----: | -----: | ------: | ------------------------------- | ------------------- |
-| 100.0% |      6 |       6 | `ZSTDMT_compressStream_generic` | `zstdmt_compress.c` |
+|      % | Sleeps | Callee                          | Location            |
+| -----: | -----: | ------------------------------- | ------------------- |
+| 100.0% |      6 | `ZSTDMT_compressStream_generic` | `zstdmt_compress.c` |
 
 ##### `POOL_add` (`pool.c`)
 
-|      % | Sleeps | Samples | Callee                          | Location    |
-| -----: | -----: | ------: | ------------------------------- | ----------- |
-| 100.0% |      2 |       2 | `pthread_cond_wait (libc.so.6)` | `<unknown>` |
+|      % | Sleeps | Callee                          | Location    |
+| -----: | -----: | ------------------------------- | ----------- |
+| 100.0% |      2 | `pthread_cond_wait (libc.so.6)` | `<unknown>` |
 
 ##### `AIO_ReadPool_setFile` (`fileio_asyncio.c`)
 
-|      % | Sleeps | Samples | Callee     | Location |
-| -----: | -----: | ------: | ---------- | -------- |
-| 100.0% |      2 |       2 | `POOL_add` | `pool.c` |
+|      % | Sleeps | Callee     | Location |
+| -----: | -----: | ---------- | -------- |
+| 100.0% |      2 | `POOL_add` | `pool.c` |
 
 ## Hottest call stacks
 
 Call stacks ranked by interruptible sleeps entered in their leaf frame. `…` stands for frames the entry filter hides.
 
-|     % | Sleeps | Samples | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| ----: | -----: | ------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 90.5% |     76 |      76 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `futex_wait_queue ([kernel])` ← `__futex_wait ([kernel])` ← `futex_wait ([kernel])` ← `do_futex ([kernel])` ← `__x64_sys_futex ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← … ← `pthread_cond_wait (libc.so.6)` ← `POOL_thread` (`pool.c`)                                                                                                                                                                         |
-|  7.1% |      6 |       6 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `futex_wait_queue ([kernel])` ← `__futex_wait ([kernel])` ← `futex_wait ([kernel])` ← `do_futex ([kernel])` ← `__x64_sys_futex ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← … ← `pthread_cond_wait (libc.so.6)` ← `ZSTDMT_compressStream_generic` (`zstdmt_compress.c`) ← `ZSTD_compressStream2` (`zstd_compress.c`) ← `FIO_compressFilename_srcFile` (`fileio.c`) ← `FIO_compressFilename` ← `main` (`zstdcli.c`) |
-|  2.4% |      2 |       2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `futex_wait_queue ([kernel])` ← `__futex_wait ([kernel])` ← `futex_wait ([kernel])` ← `do_futex ([kernel])` ← `__x64_sys_futex ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← … ← `pthread_cond_wait (libc.so.6)` ← `POOL_add` (`pool.c`) ← `AIO_ReadPool_setFile` (`fileio_asyncio.c`) ← `FIO_compressFilename_srcFile` (`fileio.c`) ← `FIO_compressFilename` ← `main` (`zstdcli.c`)                                |
+|     % | Sleeps | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ----: | -----: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 90.5% |     76 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `futex_wait_queue ([kernel])` ← `__futex_wait ([kernel])` ← `futex_wait ([kernel])` ← `do_futex ([kernel])` ← `__x64_sys_futex ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← … ← `pthread_cond_wait (libc.so.6)` ← `POOL_thread` (`pool.c`)                                                                                                                                                                         |
+|  7.1% |      6 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `futex_wait_queue ([kernel])` ← `__futex_wait ([kernel])` ← `futex_wait ([kernel])` ← `do_futex ([kernel])` ← `__x64_sys_futex ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← … ← `pthread_cond_wait (libc.so.6)` ← `ZSTDMT_compressStream_generic` (`zstdmt_compress.c`) ← `ZSTD_compressStream2` (`zstd_compress.c`) ← `FIO_compressFilename_srcFile` (`fileio.c`) ← `FIO_compressFilename` ← `main` (`zstdcli.c`) |
+|  2.4% |      2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `futex_wait_queue ([kernel])` ← `__futex_wait ([kernel])` ← `futex_wait ([kernel])` ← `do_futex ([kernel])` ← `__x64_sys_futex ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← … ← `pthread_cond_wait (libc.so.6)` ← `POOL_add` (`pool.c`) ← `AIO_ReadPool_setFile` (`fileio_asyncio.c`) ← `FIO_compressFilename_srcFile` (`fileio.c`) ← `FIO_compressFilename` ← `main` (`zstdcli.c`)                                |

--- a/examples/output/c.systing.cpu.current.systing.md
+++ b/examples/output/c.systing.cpu.current.systing.md
@@ -961,11 +961,11 @@ Common call stack: `unknown (libc.so.6)`
 
 # Uninterruptible sleep profile
 
-Slept 71 times over 71 samples (1 time per sample).
+Slept 71 times.
 
-| Category |      % | Sleeps | Samples |
-| -------- | -----: | -----: | ------: |
-| Kernel   | 100.0% |     71 |      71 |
+| Category |      % | Sleeps |
+| -------- | -----: | -----: |
+| Kernel   | 100.0% |     71 |
 
 ## Hottest functions
 
@@ -977,9 +977,9 @@ Functions ranked by uninterruptible sleeps entered directly in the function body
 
 ##### Kernel
 
-|      % | Sleeps | Samples | Function                    | Location    |
-| -----: | -----: | ------: | --------------------------- | ----------- |
-| 100.0% |     71 |      71 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
+|      % | Sleeps | Function                    | Location    |
+| -----: | -----: | --------------------------- | ----------- |
+| 100.0% |     71 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
 
 #### Callers
 
@@ -987,9 +987,9 @@ Callers ranked by contribution to each function's self sleeps. Inlining can make
 
 ##### `bpf_trace_run4 ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Caller                  | Location    |
-| -----: | -----: | ------: | ----------------------- | ----------- |
-| 100.0% |     71 |      71 | `__schedule ([kernel])` | `<unknown>` |
+|      % | Sleeps | Caller                  | Location    |
+| -----: | -----: | ----------------------- | ----------- |
+| 100.0% |     71 | `__schedule ([kernel])` | `<unknown>` |
 
 ### Total sleeps
 
@@ -999,28 +999,28 @@ Functions ranked by total uninterruptible sleeps entered in the function and all
 
 ##### Kernel
 
-|      % | Sleeps | Samples | Function                                       | Location    |
-| -----: | -----: | ------: | ---------------------------------------------- | ----------- |
-| 100.0% |     71 |      71 | `bpf_trace_run4 ([kernel])`                    | `<unknown>` |
-| 100.0% |     71 |      71 | `__schedule ([kernel])`                        | `<unknown>` |
-| 100.0% |     71 |      71 | `schedule ([kernel])`                          | `<unknown>` |
-|  87.3% |     62 |      62 | `do_syscall_64 ([kernel])`                     | `<unknown>` |
-|  87.3% |     62 |      62 | `entry_SYSCALL_64_after_hwframe ([kernel])`    | `<unknown>` |
-|  78.9% |     56 |      56 | `p9_client_rpc ([kernel])`                     | `<unknown>` |
-|  59.2% |     42 |      42 | `path_openat ([kernel])`                       | `<unknown>` |
-|  59.2% |     42 |      42 | `do_filp_open ([kernel])`                      | `<unknown>` |
-|  42.3% |     30 |      30 | `do_sys_openat2 ([kernel])`                    | `<unknown>` |
-|  42.3% |     30 |      30 | `__x64_sys_openat ([kernel])`                  | `<unknown>` |
-|  25.4% |     18 |      18 | `v9fs_vfs_lookup ([kernel])`                   | `<unknown>` |
-|  25.4% |     18 |      18 | `link_path_walk.part.0.constprop.0 ([kernel])` | `<unknown>` |
-|  22.5% |     16 |      16 | `p9_client_read_once ([kernel])`               | `<unknown>` |
-|  22.5% |     16 |      16 | `p9_client_read ([kernel])`                    | `<unknown>` |
-|  22.5% |     16 |      16 | `v9fs_issue_read ([kernel])`                   | `<unknown>` |
-|  21.1% |     15 |      15 | `walk_component ([kernel])`                    | `<unknown>` |
-|  19.7% |     14 |      14 | `p9_client_walk ([kernel])`                    | `<unknown>` |
-|  19.7% |     14 |      14 | `load_elf_binary ([kernel])`                   | `<unknown>` |
-|  19.7% |     14 |      14 | `bprm_execve ([kernel])`                       | `<unknown>` |
-|  19.7% |     14 |      14 | `do_execveat_common ([kernel])`                | `<unknown>` |
+|      % | Sleeps | Function                                       | Location    |
+| -----: | -----: | ---------------------------------------------- | ----------- |
+| 100.0% |     71 | `bpf_trace_run4 ([kernel])`                    | `<unknown>` |
+| 100.0% |     71 | `__schedule ([kernel])`                        | `<unknown>` |
+| 100.0% |     71 | `schedule ([kernel])`                          | `<unknown>` |
+|  87.3% |     62 | `do_syscall_64 ([kernel])`                     | `<unknown>` |
+|  87.3% |     62 | `entry_SYSCALL_64_after_hwframe ([kernel])`    | `<unknown>` |
+|  78.9% |     56 | `p9_client_rpc ([kernel])`                     | `<unknown>` |
+|  59.2% |     42 | `path_openat ([kernel])`                       | `<unknown>` |
+|  59.2% |     42 | `do_filp_open ([kernel])`                      | `<unknown>` |
+|  42.3% |     30 | `do_sys_openat2 ([kernel])`                    | `<unknown>` |
+|  42.3% |     30 | `__x64_sys_openat ([kernel])`                  | `<unknown>` |
+|  25.4% |     18 | `v9fs_vfs_lookup ([kernel])`                   | `<unknown>` |
+|  25.4% |     18 | `link_path_walk.part.0.constprop.0 ([kernel])` | `<unknown>` |
+|  22.5% |     16 | `p9_client_read_once ([kernel])`               | `<unknown>` |
+|  22.5% |     16 | `p9_client_read ([kernel])`                    | `<unknown>` |
+|  22.5% |     16 | `v9fs_issue_read ([kernel])`                   | `<unknown>` |
+|  21.1% |     15 | `walk_component ([kernel])`                    | `<unknown>` |
+|  19.7% |     14 | `p9_client_walk ([kernel])`                    | `<unknown>` |
+|  19.7% |     14 | `load_elf_binary ([kernel])`                   | `<unknown>` |
+|  19.7% |     14 | `bprm_execve ([kernel])`                       | `<unknown>` |
+|  19.7% |     14 | `do_execveat_common ([kernel])`                | `<unknown>` |
 
 #### Callees
 
@@ -1028,166 +1028,166 @@ Callees ranked by contribution to each function's total sleeps. Inlining can mak
 
 ##### `__schedule ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                      | Location    |
-| -----: | -----: | ------: | --------------------------- | ----------- |
-| 100.0% |     71 |      71 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                      | Location    |
+| -----: | -----: | --------------------------- | ----------- |
+| 100.0% |     71 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
 
 ##### `schedule ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                  | Location    |
-| -----: | -----: | ------: | ----------------------- | ----------- |
-| 100.0% |     71 |      71 | `__schedule ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                  | Location    |
+| -----: | -----: | ----------------------- | ----------- |
+| 100.0% |     71 | `__schedule ([kernel])` | `<unknown>` |
 
 ##### `do_syscall_64 ([kernel])` (`<unknown>`)
 
-|     % | Sleeps | Samples | Callee                         | Location    |
-| ----: | -----: | ------: | ------------------------------ | ----------- |
-| 48.4% |     30 |      30 | `__x64_sys_openat ([kernel])`  | `<unknown>` |
-| 22.6% |     14 |      14 | `__x64_sys_execve ([kernel])`  | `<unknown>` |
-|  9.7% |      6 |       6 | `ksys_read ([kernel])`         | `<unknown>` |
-|  6.5% |      4 |       4 | `__do_sys_newfstat ([kernel])` | `<unknown>` |
-|  3.2% |      2 |       2 | `__x64_sys_pread64 ([kernel])` | `<unknown>` |
+|     % | Sleeps | Callee                         | Location    |
+| ----: | -----: | ------------------------------ | ----------- |
+| 48.4% |     30 | `__x64_sys_openat ([kernel])`  | `<unknown>` |
+| 22.6% |     14 | `__x64_sys_execve ([kernel])`  | `<unknown>` |
+|  9.7% |      6 | `ksys_read ([kernel])`         | `<unknown>` |
+|  6.5% |      4 | `__do_sys_newfstat ([kernel])` | `<unknown>` |
+|  3.2% |      2 | `__x64_sys_pread64 ([kernel])` | `<unknown>` |
 
 ##### `entry_SYSCALL_64_after_hwframe ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                     | Location    |
-| -----: | -----: | ------: | -------------------------- | ----------- |
-| 100.0% |     62 |      62 | `do_syscall_64 ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                     | Location    |
+| -----: | -----: | -------------------------- | ----------- |
+| 100.0% |     62 | `do_syscall_64 ([kernel])` | `<unknown>` |
 
 ##### `p9_client_rpc ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                | Location    |
-| -----: | -----: | ------: | --------------------- | ----------- |
-| 100.0% |     56 |      56 | `schedule ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                | Location    |
+| -----: | -----: | --------------------- | ----------- |
+| 100.0% |     56 | `schedule ([kernel])` | `<unknown>` |
 
 ##### `path_openat ([kernel])` (`<unknown>`)
 
-|     % | Sleeps | Samples | Callee                                         | Location    |
-| ----: | -----: | ------: | ---------------------------------------------- | ----------- |
-| 42.9% |     18 |      18 | `link_path_walk.part.0.constprop.0 ([kernel])` | `<unknown>` |
-| 23.8% |     10 |      10 | `vfs_open ([kernel])`                          | `<unknown>` |
-| 16.7% |      7 |       7 | `lookup_open.isra.0 ([kernel])`                | `<unknown>` |
-|  9.5% |      4 |       4 | `dput.part.0 ([kernel])`                       | `<unknown>` |
-|  7.1% |      3 |       3 | `step_into ([kernel])`                         | `<unknown>` |
+|     % | Sleeps | Callee                                         | Location    |
+| ----: | -----: | ---------------------------------------------- | ----------- |
+| 42.9% |     18 | `link_path_walk.part.0.constprop.0 ([kernel])` | `<unknown>` |
+| 23.8% |     10 | `vfs_open ([kernel])`                          | `<unknown>` |
+| 16.7% |      7 | `lookup_open.isra.0 ([kernel])`                | `<unknown>` |
+|  9.5% |      4 | `dput.part.0 ([kernel])`                       | `<unknown>` |
+|  7.1% |      3 | `step_into ([kernel])`                         | `<unknown>` |
 
 ##### `do_filp_open ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                   | Location    |
-| -----: | -----: | ------: | ------------------------ | ----------- |
-| 100.0% |     42 |      42 | `path_openat ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                   | Location    |
+| -----: | -----: | ------------------------ | ----------- |
+| 100.0% |     42 | `path_openat ([kernel])` | `<unknown>` |
 
 ##### `do_sys_openat2 ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                    | Location    |
-| -----: | -----: | ------: | ------------------------- | ----------- |
-| 100.0% |     30 |      30 | `do_filp_open ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                    | Location    |
+| -----: | -----: | ------------------------- | ----------- |
+| 100.0% |     30 | `do_filp_open ([kernel])` | `<unknown>` |
 
 ##### `__x64_sys_openat ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                      | Location    |
-| -----: | -----: | ------: | --------------------------- | ----------- |
-| 100.0% |     30 |      30 | `do_sys_openat2 ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                      | Location    |
+| -----: | -----: | --------------------------- | ----------- |
+| 100.0% |     30 | `do_sys_openat2 ([kernel])` | `<unknown>` |
 
 ##### `v9fs_vfs_lookup ([kernel])` (`<unknown>`)
 
-|     % | Sleeps | Samples | Callee                                | Location    |
-| ----: | -----: | ------: | ------------------------------------- | ----------- |
-| 50.0% |      9 |       9 | `p9_client_walk ([kernel])`           | `<unknown>` |
-| 50.0% |      9 |       9 | `v9fs_inode_from_fid_dotl ([kernel])` | `<unknown>` |
+|     % | Sleeps | Callee                                | Location    |
+| ----: | -----: | ------------------------------------- | ----------- |
+| 50.0% |      9 | `p9_client_walk ([kernel])`           | `<unknown>` |
+| 50.0% |      9 | `v9fs_inode_from_fid_dotl ([kernel])` | `<unknown>` |
 
 ##### `link_path_walk.part.0.constprop.0 ([kernel])` (`<unknown>`)
 
-|     % | Sleeps | Samples | Callee                      | Location    |
-| ----: | -----: | ------: | --------------------------- | ----------- |
-| 77.8% |     14 |      14 | `walk_component ([kernel])` | `<unknown>` |
-| 22.2% |      4 |       4 | `step_into ([kernel])`      | `<unknown>` |
+|     % | Sleeps | Callee                      | Location    |
+| ----: | -----: | --------------------------- | ----------- |
+| 77.8% |     14 | `walk_component ([kernel])` | `<unknown>` |
+| 22.2% |      4 | `step_into ([kernel])`      | `<unknown>` |
 
 ##### `p9_client_read_once ([kernel])` (`<unknown>`)
 
-|     % | Sleeps | Samples | Callee                                    | Location    |
-| ----: | -----: | ------: | ----------------------------------------- | ----------- |
-| 56.3% |      9 |       9 | `p9_client_zc_rpc.constprop.0 ([kernel])` | `<unknown>` |
-| 43.8% |      7 |       7 | `p9_client_rpc ([kernel])`                | `<unknown>` |
+|     % | Sleeps | Callee                                    | Location    |
+| ----: | -----: | ----------------------------------------- | ----------- |
+| 56.3% |      9 | `p9_client_zc_rpc.constprop.0 ([kernel])` | `<unknown>` |
+| 43.8% |      7 | `p9_client_rpc ([kernel])`                | `<unknown>` |
 
 ##### `p9_client_read ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                           | Location    |
-| -----: | -----: | ------: | -------------------------------- | ----------- |
-| 100.0% |     16 |      16 | `p9_client_read_once ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                           | Location    |
+| -----: | -----: | -------------------------------- | ----------- |
+| 100.0% |     16 | `p9_client_read_once ([kernel])` | `<unknown>` |
 
 ##### `v9fs_issue_read ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                      | Location    |
-| -----: | -----: | ------: | --------------------------- | ----------- |
-| 100.0% |     16 |      16 | `p9_client_read ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                      | Location    |
+| -----: | -----: | --------------------------- | ----------- |
+| 100.0% |     16 | `p9_client_read ([kernel])` | `<unknown>` |
 
 ##### `walk_component ([kernel])` (`<unknown>`)
 
-|     % | Sleeps | Samples | Callee                     | Location    |
-| ----: | -----: | ------: | -------------------------- | ----------- |
-| 73.3% |     11 |      11 | `__lookup_slow ([kernel])` | `<unknown>` |
-| 26.7% |      4 |       4 | `dput.part.0 ([kernel])`   | `<unknown>` |
+|     % | Sleeps | Callee                     | Location    |
+| ----: | -----: | -------------------------- | ----------- |
+| 73.3% |     11 | `__lookup_slow ([kernel])` | `<unknown>` |
+| 26.7% |      4 | `dput.part.0 ([kernel])`   | `<unknown>` |
 
 ##### `p9_client_walk ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                     | Location    |
-| -----: | -----: | ------: | -------------------------- | ----------- |
-| 100.0% |     14 |      14 | `p9_client_rpc ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                     | Location    |
+| -----: | -----: | -------------------------- | ----------- |
+| 100.0% |     14 | `p9_client_rpc ([kernel])` | `<unknown>` |
 
 ##### `load_elf_binary ([kernel])` (`<unknown>`)
 
-|     % | Sleeps | Samples | Callee                      | Location    |
-| ----: | -----: | ------: | --------------------------- | ----------- |
-| 85.7% |     12 |      12 | `open_exec ([kernel])`      | `<unknown>` |
-|  7.1% |      1 |       1 | `__kernel_read ([kernel])`  | `<unknown>` |
-|  7.1% |      1 |       1 | `load_elf_phdrs ([kernel])` | `<unknown>` |
+|     % | Sleeps | Callee                      | Location    |
+| ----: | -----: | --------------------------- | ----------- |
+| 85.7% |     12 | `open_exec ([kernel])`      | `<unknown>` |
+|  7.1% |      1 | `__kernel_read ([kernel])`  | `<unknown>` |
+|  7.1% |      1 | `load_elf_phdrs ([kernel])` | `<unknown>` |
 
 ##### `bprm_execve ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                       | Location    |
-| -----: | -----: | ------: | ---------------------------- | ----------- |
-| 100.0% |     14 |      14 | `load_elf_binary ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                       | Location    |
+| -----: | -----: | ---------------------------- | ----------- |
+| 100.0% |     14 | `load_elf_binary ([kernel])` | `<unknown>` |
 
 ##### `do_execveat_common ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                   | Location    |
-| -----: | -----: | ------: | ------------------------ | ----------- |
-| 100.0% |     14 |      14 | `bprm_execve ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                   | Location    |
+| -----: | -----: | ------------------------ | ----------- |
+| 100.0% |     14 | `bprm_execve ([kernel])` | `<unknown>` |
 
 ## Hottest call stacks
 
 Call stacks ranked by uninterruptible sleeps entered in their leaf frame. `…` stands for frames the entry filter hides.
 
-|     % | Sleeps | Samples | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| ----: | -----: | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 12.7% |      9 |       9 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_virtio_zc_request ([kernel])` ← `p9_client_zc_rpc.constprop.0 ([kernel])` ← `p9_client_read_once ([kernel])` ← `p9_client_read ([kernel])` ← `v9fs_issue_read ([kernel])` ← `netfs_read_to_pagecache ([kernel])` ← `netfs_read_folio ([kernel])` ← `filemap_read_folio ([kernel])` ← `filemap_fault ([kernel])` ← `__do_fault ([kernel])` ← `do_fault ([kernel])` ← `__handle_mm_fault ([kernel])` ← `handle_mm_fault ([kernel])` ← `do_user_addr_fault ([kernel])` ← `exc_page_fault ([kernel])` ← `asm_exc_page_fault ([kernel])`                                                        |
-|  5.6% |      4 |       4 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_getattr_dotl ([kernel])` ← `v9fs_vfs_getattr_dotl ([kernel])` ← `vfs_fstat ([kernel])` ← `__do_sys_newfstat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                                                                                                                                     |
-|  5.6% |      4 |       4 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_walk ([kernel])` ← `v9fs_file_open ([kernel])` ← `do_dentry_open ([kernel])` ← `vfs_open ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                                   |
-|  5.6% |      4 |       4 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_open ([kernel])` ← `v9fs_file_open ([kernel])` ← `do_dentry_open ([kernel])` ← `vfs_open ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                                   |
-|  4.2% |      3 |       3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_walk ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `__lookup_slow ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                            |
-|  4.2% |      3 |       3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_getattr_dotl ([kernel])` ← `v9fs_inode_from_fid_dotl ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `__lookup_slow ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                            |
-|  4.2% |      3 |       3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_readlink ([kernel])` ← `v9fs_vfs_get_link_dotl ([kernel])` ← `step_into ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                   |
-|  4.2% |      3 |       3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_clunk ([kernel])` ← `v9fs_dentry_release ([kernel])` ← `__dentry_kill ([kernel])` ← `dput.part.0 ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                            |
-|  4.2% |      3 |       3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_walk ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `v9fs_vfs_atomic_open_dotl ([kernel])` ← `lookup_open.isra.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                             |
-|  4.2% |      3 |       3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_getattr_dotl ([kernel])` ← `v9fs_inode_from_fid_dotl ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `v9fs_vfs_atomic_open_dotl ([kernel])` ← `lookup_open.isra.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                             |
-|  4.2% |      3 |       3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_read_once ([kernel])` ← `p9_client_read ([kernel])` ← `v9fs_issue_read ([kernel])` ← `netfs_unbuffered_read_iter_locked ([kernel])` ← `netfs_unbuffered_read_iter ([kernel])` ← `vfs_read ([kernel])` ← `ksys_read ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                              |
-|  4.2% |      3 |       3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `schedule_preempt_disabled ([kernel])` ← `rwsem_down_read_slowpath ([kernel])` ← `down_read_killable ([kernel])` ← `lock_mm_and_find_vma ([kernel])` ← `do_user_addr_fault ([kernel])` ← `exc_page_fault ([kernel])` ← `asm_exc_page_fault ([kernel])` ← `_copy_to_iter ([kernel])` ← `copy_page_to_iter ([kernel])` ← `shmem_file_read_iter ([kernel])` ← `vfs_read ([kernel])` ← `ksys_read ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← … ← `fread (libc.so.6)` ← `AIO_ReadPool_executeReadJob` (`fileio_asyncio.c`) ← `POOL_thread` (`pool.c`) |
-|  2.8% |      2 |       2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_readlink ([kernel])` ← `v9fs_vfs_get_link_dotl ([kernel])` ← `step_into ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                                                    |
-|  2.8% |      2 |       2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_clunk ([kernel])` ← `v9fs_dentry_release ([kernel])` ← `__dentry_kill ([kernel])` ← `dput.part.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                           |
-|  2.8% |      2 |       2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_walk ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `__lookup_slow ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                       |
-|  2.8% |      2 |       2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_getattr_dotl ([kernel])` ← `v9fs_inode_from_fid_dotl ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `__lookup_slow ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                       |
-|  2.8% |      2 |       2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_clunk ([kernel])` ← `v9fs_dentry_release ([kernel])` ← `__dentry_kill ([kernel])` ← `dput.part.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                      |
-|  2.8% |      2 |       2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_read_once ([kernel])` ← `p9_client_read ([kernel])` ← `v9fs_issue_read ([kernel])` ← `netfs_unbuffered_read_iter_locked ([kernel])` ← `netfs_unbuffered_read_iter ([kernel])` ← `vfs_read ([kernel])` ← `__x64_sys_pread64 ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                      |
-|  2.8% |      2 |       2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `schedule_preempt_disabled ([kernel])` ← `rwsem_down_write_slowpath ([kernel])` ← `down_write_killable ([kernel])` ← `do_mprotect_pkey ([kernel])` ← `__x64_sys_mprotect ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← `__mprotect (libc.so.6)` ← `POOL_create_advanced` (`pool.c`) ← `ZSTDMT_createCCtx_advanced` (`zstdmt_compress.c`) ← `ZSTD_CCtx_init_compressStream2` (`zstd_compress.c`) ← `ZSTD_compressStream2` ← `FIO_compressFilename_srcFile` (`fileio.c`) ← `FIO_compressFilename` ← `main` (`zstdcli.c`)                              |
-|  1.4% |      1 |       1 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_readlink ([kernel])` ← `v9fs_vfs_get_link_dotl ([kernel])` ← `step_into ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                              |
+|     % | Sleeps | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ----: | -----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 12.7% |      9 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_virtio_zc_request ([kernel])` ← `p9_client_zc_rpc.constprop.0 ([kernel])` ← `p9_client_read_once ([kernel])` ← `p9_client_read ([kernel])` ← `v9fs_issue_read ([kernel])` ← `netfs_read_to_pagecache ([kernel])` ← `netfs_read_folio ([kernel])` ← `filemap_read_folio ([kernel])` ← `filemap_fault ([kernel])` ← `__do_fault ([kernel])` ← `do_fault ([kernel])` ← `__handle_mm_fault ([kernel])` ← `handle_mm_fault ([kernel])` ← `do_user_addr_fault ([kernel])` ← `exc_page_fault ([kernel])` ← `asm_exc_page_fault ([kernel])`                                                        |
+|  5.6% |      4 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_getattr_dotl ([kernel])` ← `v9fs_vfs_getattr_dotl ([kernel])` ← `vfs_fstat ([kernel])` ← `__do_sys_newfstat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                                                                                                                                     |
+|  5.6% |      4 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_walk ([kernel])` ← `v9fs_file_open ([kernel])` ← `do_dentry_open ([kernel])` ← `vfs_open ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                                   |
+|  5.6% |      4 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_open ([kernel])` ← `v9fs_file_open ([kernel])` ← `do_dentry_open ([kernel])` ← `vfs_open ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                                   |
+|  4.2% |      3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_walk ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `__lookup_slow ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                            |
+|  4.2% |      3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_getattr_dotl ([kernel])` ← `v9fs_inode_from_fid_dotl ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `__lookup_slow ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                            |
+|  4.2% |      3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_readlink ([kernel])` ← `v9fs_vfs_get_link_dotl ([kernel])` ← `step_into ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                   |
+|  4.2% |      3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_clunk ([kernel])` ← `v9fs_dentry_release ([kernel])` ← `__dentry_kill ([kernel])` ← `dput.part.0 ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                            |
+|  4.2% |      3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_walk ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `v9fs_vfs_atomic_open_dotl ([kernel])` ← `lookup_open.isra.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                             |
+|  4.2% |      3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_getattr_dotl ([kernel])` ← `v9fs_inode_from_fid_dotl ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `v9fs_vfs_atomic_open_dotl ([kernel])` ← `lookup_open.isra.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                             |
+|  4.2% |      3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_read_once ([kernel])` ← `p9_client_read ([kernel])` ← `v9fs_issue_read ([kernel])` ← `netfs_unbuffered_read_iter_locked ([kernel])` ← `netfs_unbuffered_read_iter ([kernel])` ← `vfs_read ([kernel])` ← `ksys_read ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                              |
+|  4.2% |      3 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `schedule_preempt_disabled ([kernel])` ← `rwsem_down_read_slowpath ([kernel])` ← `down_read_killable ([kernel])` ← `lock_mm_and_find_vma ([kernel])` ← `do_user_addr_fault ([kernel])` ← `exc_page_fault ([kernel])` ← `asm_exc_page_fault ([kernel])` ← `_copy_to_iter ([kernel])` ← `copy_page_to_iter ([kernel])` ← `shmem_file_read_iter ([kernel])` ← `vfs_read ([kernel])` ← `ksys_read ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← … ← `fread (libc.so.6)` ← `AIO_ReadPool_executeReadJob` (`fileio_asyncio.c`) ← `POOL_thread` (`pool.c`) |
+|  2.8% |      2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_readlink ([kernel])` ← `v9fs_vfs_get_link_dotl ([kernel])` ← `step_into ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                                                    |
+|  2.8% |      2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_clunk ([kernel])` ← `v9fs_dentry_release ([kernel])` ← `__dentry_kill ([kernel])` ← `dput.part.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_sys_openat2 ([kernel])` ← `__x64_sys_openat ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                           |
+|  2.8% |      2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_walk ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `__lookup_slow ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                       |
+|  2.8% |      2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_getattr_dotl ([kernel])` ← `v9fs_inode_from_fid_dotl ([kernel])` ← `v9fs_vfs_lookup ([kernel])` ← `__lookup_slow ([kernel])` ← `walk_component ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                       |
+|  2.8% |      2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_clunk ([kernel])` ← `v9fs_dentry_release ([kernel])` ← `__dentry_kill ([kernel])` ← `dput.part.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                      |
+|  2.8% |      2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_read_once ([kernel])` ← `p9_client_read ([kernel])` ← `v9fs_issue_read ([kernel])` ← `netfs_unbuffered_read_iter_locked ([kernel])` ← `netfs_unbuffered_read_iter ([kernel])` ← `vfs_read ([kernel])` ← `__x64_sys_pread64 ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                                                                                                                                                                      |
+|  2.8% |      2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `schedule_preempt_disabled ([kernel])` ← `rwsem_down_write_slowpath ([kernel])` ← `down_write_killable ([kernel])` ← `do_mprotect_pkey ([kernel])` ← `__x64_sys_mprotect ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← `__mprotect (libc.so.6)` ← `POOL_create_advanced` (`pool.c`) ← `ZSTDMT_createCCtx_advanced` (`zstdmt_compress.c`) ← `ZSTD_CCtx_init_compressStream2` (`zstd_compress.c`) ← `ZSTD_compressStream2` ← `FIO_compressFilename_srcFile` (`fileio.c`) ← `FIO_compressFilename` ← `main` (`zstdcli.c`)                              |
+|  1.4% |      1 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `p9_client_rpc ([kernel])` ← `p9_client_readlink ([kernel])` ← `v9fs_vfs_get_link_dotl ([kernel])` ← `step_into ([kernel])` ← `link_path_walk.part.0.constprop.0 ([kernel])` ← `path_openat ([kernel])` ← `do_filp_open ([kernel])` ← `do_open_execat ([kernel])` ← `open_exec ([kernel])` ← `load_elf_binary ([kernel])` ← `bprm_execve ([kernel])` ← `do_execveat_common ([kernel])` ← `__x64_sys_execve ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])`                                                                                              |
 
 # Interruptible sleep profile
 
-Slept 87 times over 87 samples (1 time per sample).
+Slept 87 times.
 
-| Category |      % | Sleeps | Samples |
-| -------- | -----: | -----: | ------: |
-| Kernel   | 100.0% |     87 |      87 |
+| Category |      % | Sleeps |
+| -------- | -----: | -----: |
+| Kernel   | 100.0% |     87 |
 
 ## Hottest functions
 
@@ -1199,9 +1199,9 @@ Functions ranked by interruptible sleeps entered directly in the function body, 
 
 ##### Kernel
 
-|      % | Sleeps | Samples | Function                    | Location    |
-| -----: | -----: | ------: | --------------------------- | ----------- |
-| 100.0% |     87 |      87 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
+|      % | Sleeps | Function                    | Location    |
+| -----: | -----: | --------------------------- | ----------- |
+| 100.0% |     87 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
 
 #### Callers
 
@@ -1209,52 +1209,52 @@ Callers ranked by contribution to each function's self sleeps. Inlining can make
 
 ##### `bpf_trace_run4 ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Caller                  | Location    |
-| -----: | -----: | ------: | ----------------------- | ----------- |
-| 100.0% |     87 |      87 | `__schedule ([kernel])` | `<unknown>` |
+|      % | Sleeps | Caller                  | Location    |
+| -----: | -----: | ----------------------- | ----------- |
+| 100.0% |     87 | `__schedule ([kernel])` | `<unknown>` |
 
 ### Total sleeps
 
 Functions ranked by total interruptible sleeps entered in the function and all its callees.
 
-|      % | Sleeps | Samples | Function                                    | Location            |
-| -----: | -----: | ------: | ------------------------------------------- | ------------------- |
-| 100.0% |     87 |      87 | `bpf_trace_run4 ([kernel])`                 | `<unknown>`         |
-| 100.0% |     87 |      87 | `__schedule ([kernel])`                     | `<unknown>`         |
-| 100.0% |     87 |      87 | `schedule ([kernel])`                       | `<unknown>`         |
-| 100.0% |     87 |      87 | `futex_wait_queue ([kernel])`               | `<unknown>`         |
-| 100.0% |     87 |      87 | `__futex_wait ([kernel])`                   | `<unknown>`         |
-| 100.0% |     87 |      87 | `futex_wait ([kernel])`                     | `<unknown>`         |
-| 100.0% |     87 |      87 | `do_futex ([kernel])`                       | `<unknown>`         |
-| 100.0% |     87 |      87 | `__x64_sys_futex ([kernel])`                | `<unknown>`         |
-| 100.0% |     87 |      87 | `do_syscall_64 ([kernel])`                  | `<unknown>`         |
-| 100.0% |     87 |      87 | `entry_SYSCALL_64_after_hwframe ([kernel])` | `<unknown>`         |
-| 100.0% |     87 |      87 | `pthread_cond_wait (libc.so.6)`             | `<unknown>`         |
-|  89.7% |     78 |      78 | `POOL_thread`                               | `pool.c`            |
-|  10.3% |      9 |       9 | `FIO_compressFilename_srcFile`              | `fileio.c`          |
-|  10.3% |      9 |       9 | `FIO_compressFilename`                      | `fileio.c`          |
-|  10.3% |      9 |       9 | `main`                                      | `zstdcli.c`         |
-|   8.0% |      7 |       7 | `ZSTDMT_compressStream_generic`             | `zstdmt_compress.c` |
-|   8.0% |      7 |       7 | `ZSTD_compressStream2`                      | `zstd_compress.c`   |
-|   2.3% |      2 |       2 | `POOL_add`                                  | `pool.c`            |
-|   2.3% |      2 |       2 | `AIO_ReadPool_setFile`                      | `fileio_asyncio.c`  |
+|      % | Sleeps | Function                                    | Location            |
+| -----: | -----: | ------------------------------------------- | ------------------- |
+| 100.0% |     87 | `bpf_trace_run4 ([kernel])`                 | `<unknown>`         |
+| 100.0% |     87 | `__schedule ([kernel])`                     | `<unknown>`         |
+| 100.0% |     87 | `schedule ([kernel])`                       | `<unknown>`         |
+| 100.0% |     87 | `futex_wait_queue ([kernel])`               | `<unknown>`         |
+| 100.0% |     87 | `__futex_wait ([kernel])`                   | `<unknown>`         |
+| 100.0% |     87 | `futex_wait ([kernel])`                     | `<unknown>`         |
+| 100.0% |     87 | `do_futex ([kernel])`                       | `<unknown>`         |
+| 100.0% |     87 | `__x64_sys_futex ([kernel])`                | `<unknown>`         |
+| 100.0% |     87 | `do_syscall_64 ([kernel])`                  | `<unknown>`         |
+| 100.0% |     87 | `entry_SYSCALL_64_after_hwframe ([kernel])` | `<unknown>`         |
+| 100.0% |     87 | `pthread_cond_wait (libc.so.6)`             | `<unknown>`         |
+|  89.7% |     78 | `POOL_thread`                               | `pool.c`            |
+|  10.3% |      9 | `FIO_compressFilename_srcFile`              | `fileio.c`          |
+|  10.3% |      9 | `FIO_compressFilename`                      | `fileio.c`          |
+|  10.3% |      9 | `main`                                      | `zstdcli.c`         |
+|   8.0% |      7 | `ZSTDMT_compressStream_generic`             | `zstdmt_compress.c` |
+|   8.0% |      7 | `ZSTD_compressStream2`                      | `zstd_compress.c`   |
+|   2.3% |      2 | `POOL_add`                                  | `pool.c`            |
+|   2.3% |      2 | `AIO_ReadPool_setFile`                      | `fileio_asyncio.c`  |
 
 #### Categories
 
 ##### Kernel
 
-|      % | Sleeps | Samples | Function                                    | Location    |
-| -----: | -----: | ------: | ------------------------------------------- | ----------- |
-| 100.0% |     87 |      87 | `bpf_trace_run4 ([kernel])`                 | `<unknown>` |
-| 100.0% |     87 |      87 | `__schedule ([kernel])`                     | `<unknown>` |
-| 100.0% |     87 |      87 | `schedule ([kernel])`                       | `<unknown>` |
-| 100.0% |     87 |      87 | `futex_wait_queue ([kernel])`               | `<unknown>` |
-| 100.0% |     87 |      87 | `__futex_wait ([kernel])`                   | `<unknown>` |
-| 100.0% |     87 |      87 | `futex_wait ([kernel])`                     | `<unknown>` |
-| 100.0% |     87 |      87 | `do_futex ([kernel])`                       | `<unknown>` |
-| 100.0% |     87 |      87 | `__x64_sys_futex ([kernel])`                | `<unknown>` |
-| 100.0% |     87 |      87 | `do_syscall_64 ([kernel])`                  | `<unknown>` |
-| 100.0% |     87 |      87 | `entry_SYSCALL_64_after_hwframe ([kernel])` | `<unknown>` |
+|      % | Sleeps | Function                                    | Location    |
+| -----: | -----: | ------------------------------------------- | ----------- |
+| 100.0% |     87 | `bpf_trace_run4 ([kernel])`                 | `<unknown>` |
+| 100.0% |     87 | `__schedule ([kernel])`                     | `<unknown>` |
+| 100.0% |     87 | `schedule ([kernel])`                       | `<unknown>` |
+| 100.0% |     87 | `futex_wait_queue ([kernel])`               | `<unknown>` |
+| 100.0% |     87 | `__futex_wait ([kernel])`                   | `<unknown>` |
+| 100.0% |     87 | `futex_wait ([kernel])`                     | `<unknown>` |
+| 100.0% |     87 | `do_futex ([kernel])`                       | `<unknown>` |
+| 100.0% |     87 | `__x64_sys_futex ([kernel])`                | `<unknown>` |
+| 100.0% |     87 | `do_syscall_64 ([kernel])`                  | `<unknown>` |
+| 100.0% |     87 | `entry_SYSCALL_64_after_hwframe ([kernel])` | `<unknown>` |
 
 #### Callees
 
@@ -1262,113 +1262,113 @@ Callees ranked by contribution to each function's total sleeps. Inlining can mak
 
 ##### `__schedule ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                      | Location    |
-| -----: | -----: | ------: | --------------------------- | ----------- |
-| 100.0% |     87 |      87 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                      | Location    |
+| -----: | -----: | --------------------------- | ----------- |
+| 100.0% |     87 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
 
 ##### `schedule ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                  | Location    |
-| -----: | -----: | ------: | ----------------------- | ----------- |
-| 100.0% |     87 |      87 | `__schedule ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                  | Location    |
+| -----: | -----: | ----------------------- | ----------- |
+| 100.0% |     87 | `__schedule ([kernel])` | `<unknown>` |
 
 ##### `futex_wait_queue ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                | Location    |
-| -----: | -----: | ------: | --------------------- | ----------- |
-| 100.0% |     87 |      87 | `schedule ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                | Location    |
+| -----: | -----: | --------------------- | ----------- |
+| 100.0% |     87 | `schedule ([kernel])` | `<unknown>` |
 
 ##### `__futex_wait ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                        | Location    |
-| -----: | -----: | ------: | ----------------------------- | ----------- |
-| 100.0% |     87 |      87 | `futex_wait_queue ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                        | Location    |
+| -----: | -----: | ----------------------------- | ----------- |
+| 100.0% |     87 | `futex_wait_queue ([kernel])` | `<unknown>` |
 
 ##### `futex_wait ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                    | Location    |
-| -----: | -----: | ------: | ------------------------- | ----------- |
-| 100.0% |     87 |      87 | `__futex_wait ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                    | Location    |
+| -----: | -----: | ------------------------- | ----------- |
+| 100.0% |     87 | `__futex_wait ([kernel])` | `<unknown>` |
 
 ##### `do_futex ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                  | Location    |
-| -----: | -----: | ------: | ----------------------- | ----------- |
-| 100.0% |     87 |      87 | `futex_wait ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                  | Location    |
+| -----: | -----: | ----------------------- | ----------- |
+| 100.0% |     87 | `futex_wait ([kernel])` | `<unknown>` |
 
 ##### `__x64_sys_futex ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                | Location    |
-| -----: | -----: | ------: | --------------------- | ----------- |
-| 100.0% |     87 |      87 | `do_futex ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                | Location    |
+| -----: | -----: | --------------------- | ----------- |
+| 100.0% |     87 | `do_futex ([kernel])` | `<unknown>` |
 
 ##### `do_syscall_64 ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                       | Location    |
-| -----: | -----: | ------: | ---------------------------- | ----------- |
-| 100.0% |     87 |      87 | `__x64_sys_futex ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                       | Location    |
+| -----: | -----: | ---------------------------- | ----------- |
+| 100.0% |     87 | `__x64_sys_futex ([kernel])` | `<unknown>` |
 
 ##### `entry_SYSCALL_64_after_hwframe ([kernel])` (`<unknown>`)
 
-|      % | Sleeps | Samples | Callee                     | Location    |
-| -----: | -----: | ------: | -------------------------- | ----------- |
-| 100.0% |     87 |      87 | `do_syscall_64 ([kernel])` | `<unknown>` |
+|      % | Sleeps | Callee                     | Location    |
+| -----: | -----: | -------------------------- | ----------- |
+| 100.0% |     87 | `do_syscall_64 ([kernel])` | `<unknown>` |
 
 ##### `POOL_thread` (`pool.c`)
 
-|      % | Sleeps | Samples | Callee                          | Location    |
-| -----: | -----: | ------: | ------------------------------- | ----------- |
-| 100.0% |     78 |      78 | `pthread_cond_wait (libc.so.6)` | `<unknown>` |
+|      % | Sleeps | Callee                          | Location    |
+| -----: | -----: | ------------------------------- | ----------- |
+| 100.0% |     78 | `pthread_cond_wait (libc.so.6)` | `<unknown>` |
 
 ##### `FIO_compressFilename_srcFile` (`fileio.c`)
 
-|     % | Sleeps | Samples | Callee                 | Location           |
-| ----: | -----: | ------: | ---------------------- | ------------------ |
-| 77.8% |      7 |       7 | `ZSTD_compressStream2` | `zstd_compress.c`  |
-| 22.2% |      2 |       2 | `AIO_ReadPool_setFile` | `fileio_asyncio.c` |
+|     % | Sleeps | Callee                 | Location           |
+| ----: | -----: | ---------------------- | ------------------ |
+| 77.8% |      7 | `ZSTD_compressStream2` | `zstd_compress.c`  |
+| 22.2% |      2 | `AIO_ReadPool_setFile` | `fileio_asyncio.c` |
 
 ##### `FIO_compressFilename` (`fileio.c`)
 
-|      % | Sleeps | Samples | Callee                         | Location   |
-| -----: | -----: | ------: | ------------------------------ | ---------- |
-| 100.0% |      9 |       9 | `FIO_compressFilename_srcFile` | `fileio.c` |
+|      % | Sleeps | Callee                         | Location   |
+| -----: | -----: | ------------------------------ | ---------- |
+| 100.0% |      9 | `FIO_compressFilename_srcFile` | `fileio.c` |
 
 ##### `main` (`zstdcli.c`)
 
-|      % | Sleeps | Samples | Callee                 | Location   |
-| -----: | -----: | ------: | ---------------------- | ---------- |
-| 100.0% |      9 |       9 | `FIO_compressFilename` | `fileio.c` |
+|      % | Sleeps | Callee                 | Location   |
+| -----: | -----: | ---------------------- | ---------- |
+| 100.0% |      9 | `FIO_compressFilename` | `fileio.c` |
 
 ##### `ZSTDMT_compressStream_generic` (`zstdmt_compress.c`)
 
-|      % | Sleeps | Samples | Callee                          | Location    |
-| -----: | -----: | ------: | ------------------------------- | ----------- |
-| 100.0% |      7 |       7 | `pthread_cond_wait (libc.so.6)` | `<unknown>` |
+|      % | Sleeps | Callee                          | Location    |
+| -----: | -----: | ------------------------------- | ----------- |
+| 100.0% |      7 | `pthread_cond_wait (libc.so.6)` | `<unknown>` |
 
 ##### `ZSTD_compressStream2` (`zstd_compress.c`)
 
-|      % | Sleeps | Samples | Callee                          | Location            |
-| -----: | -----: | ------: | ------------------------------- | ------------------- |
-| 100.0% |      7 |       7 | `ZSTDMT_compressStream_generic` | `zstdmt_compress.c` |
+|      % | Sleeps | Callee                          | Location            |
+| -----: | -----: | ------------------------------- | ------------------- |
+| 100.0% |      7 | `ZSTDMT_compressStream_generic` | `zstdmt_compress.c` |
 
 ##### `POOL_add` (`pool.c`)
 
-|      % | Sleeps | Samples | Callee                          | Location    |
-| -----: | -----: | ------: | ------------------------------- | ----------- |
-| 100.0% |      2 |       2 | `pthread_cond_wait (libc.so.6)` | `<unknown>` |
+|      % | Sleeps | Callee                          | Location    |
+| -----: | -----: | ------------------------------- | ----------- |
+| 100.0% |      2 | `pthread_cond_wait (libc.so.6)` | `<unknown>` |
 
 ##### `AIO_ReadPool_setFile` (`fileio_asyncio.c`)
 
-|      % | Sleeps | Samples | Callee     | Location |
-| -----: | -----: | ------: | ---------- | -------- |
-| 100.0% |      2 |       2 | `POOL_add` | `pool.c` |
+|      % | Sleeps | Callee     | Location |
+| -----: | -----: | ---------- | -------- |
+| 100.0% |      2 | `POOL_add` | `pool.c` |
 
 ## Hottest call stacks
 
 Call stacks ranked by interruptible sleeps entered in their leaf frame. `…` stands for frames the entry filter hides.
 
-|     % | Sleeps | Samples | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| ----: | -----: | ------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 89.7% |     78 |      78 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `futex_wait_queue ([kernel])` ← `__futex_wait ([kernel])` ← `futex_wait ([kernel])` ← `do_futex ([kernel])` ← `__x64_sys_futex ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← … ← `pthread_cond_wait (libc.so.6)` ← `POOL_thread` (`pool.c`)                                                                                                                                                                         |
-|  8.0% |      7 |       7 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `futex_wait_queue ([kernel])` ← `__futex_wait ([kernel])` ← `futex_wait ([kernel])` ← `do_futex ([kernel])` ← `__x64_sys_futex ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← … ← `pthread_cond_wait (libc.so.6)` ← `ZSTDMT_compressStream_generic` (`zstdmt_compress.c`) ← `ZSTD_compressStream2` (`zstd_compress.c`) ← `FIO_compressFilename_srcFile` (`fileio.c`) ← `FIO_compressFilename` ← `main` (`zstdcli.c`) |
-|  2.3% |      2 |       2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `futex_wait_queue ([kernel])` ← `__futex_wait ([kernel])` ← `futex_wait ([kernel])` ← `do_futex ([kernel])` ← `__x64_sys_futex ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← … ← `pthread_cond_wait (libc.so.6)` ← `POOL_add` (`pool.c`) ← `AIO_ReadPool_setFile` (`fileio_asyncio.c`) ← `FIO_compressFilename_srcFile` (`fileio.c`) ← `FIO_compressFilename` ← `main` (`zstdcli.c`)                                |
+|     % | Sleeps | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ----: | -----: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 89.7% |     78 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `futex_wait_queue ([kernel])` ← `__futex_wait ([kernel])` ← `futex_wait ([kernel])` ← `do_futex ([kernel])` ← `__x64_sys_futex ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← … ← `pthread_cond_wait (libc.so.6)` ← `POOL_thread` (`pool.c`)                                                                                                                                                                         |
+|  8.0% |      7 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `futex_wait_queue ([kernel])` ← `__futex_wait ([kernel])` ← `futex_wait ([kernel])` ← `do_futex ([kernel])` ← `__x64_sys_futex ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← … ← `pthread_cond_wait (libc.so.6)` ← `ZSTDMT_compressStream_generic` (`zstdmt_compress.c`) ← `ZSTD_compressStream2` (`zstd_compress.c`) ← `FIO_compressFilename_srcFile` (`fileio.c`) ← `FIO_compressFilename` ← `main` (`zstdcli.c`) |
+|  2.3% |      2 | `bpf_trace_run4 ([kernel])` ← `__schedule ([kernel])` ← `schedule ([kernel])` ← `futex_wait_queue ([kernel])` ← `__futex_wait ([kernel])` ← `futex_wait ([kernel])` ← `do_futex ([kernel])` ← `__x64_sys_futex ([kernel])` ← `do_syscall_64 ([kernel])` ← `entry_SYSCALL_64_after_hwframe ([kernel])` ← … ← `pthread_cond_wait (libc.so.6)` ← `POOL_add` (`pool.c`) ← `AIO_ReadPool_setFile` (`fileio_asyncio.c`) ← `FIO_compressFilename_srcFile` (`fileio.c`) ← `FIO_compressFilename` ← `main` (`zstdcli.c`)                                |

--- a/examples/output/c.systing.cpu.diff.systing.md
+++ b/examples/output/c.systing.cpu.diff.systing.md
@@ -349,11 +349,11 @@ Functions with the largest decrease in total time spent in the function and all 
 
 # Uninterruptible sleep profile diff
 
-Slept 69 times → 71 times (+2 times, +2.9%) over 69 samples → 71 samples (1 time per sample).
+Slept 69 times → 71 times (+2 times, +2.9%).
 
-| Category | Change | Delta |      % |  Sleeps | Samples |
-| -------- | -----: | ----: | -----: | ------: | ------: |
-| Kernel   |  +2.9% |    +2 | 100.0% | 69 → 71 | 69 → 71 |
+| Category | Change | Delta |      % |  Sleeps |
+| -------- | -----: | ----: | -----: | ------: |
+| Kernel   |  +2.9% |    +2 | 100.0% | 69 → 71 |
 
 ## Hottest functions
 
@@ -365,9 +365,9 @@ Functions with the largest increase in uninterruptible sleeps entered directly i
 
 ##### Kernel
 
-| Change | Delta |      % |  Sleeps | Samples | Function                    | Location    |
-| -----: | ----: | -----: | ------: | ------: | --------------------------- | ----------- |
-|  +2.9% |    +2 | 100.0% | 69 → 71 | 69 → 71 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
+| Change | Delta |      % |  Sleeps | Function                    | Location    |
+| -----: | ----: | -----: | ------: | --------------------------- | ----------- |
+|  +2.9% |    +2 | 100.0% | 69 → 71 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
 
 ### Total sleeps
 
@@ -375,53 +375,53 @@ Functions with the largest increase in uninterruptible sleeps entered directly i
 
 Functions with the largest increase in total uninterruptible sleeps entered in the function and all its callees.
 
-|  Change | Delta |             % |  Sleeps | Samples | Function                                    | Location            |
-| ------: | ----: | ------------: | ------: | ------: | ------------------------------------------- | ------------------- |
-|   +2.9% |    +2 |        100.0% | 69 → 71 | 69 → 71 | `bpf_trace_run4 ([kernel])`                 | `<unknown>`         |
-|   +2.9% |    +2 |        100.0% | 69 → 71 | 69 → 71 | `__schedule ([kernel])`                     | `<unknown>`         |
-|   +2.9% |    +2 |        100.0% | 69 → 71 | 69 → 71 | `schedule ([kernel])`                       | `<unknown>`         |
-|  +50.0% |    +2 |   5.8% → 8.5% |   4 → 6 |   4 → 6 | `schedule_preempt_disabled ([kernel])`      | `<unknown>`         |
-| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 |   1 → 3 | `rwsem_down_write_slowpath ([kernel])`      | `<unknown>`         |
-| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 |   1 → 3 | `down_write_killable ([kernel])`            | `<unknown>`         |
-| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 |   1 → 3 | `POOL_create_advanced`                      | `pool.c`            |
-| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 |   1 → 3 | `ZSTDMT_createCCtx_advanced`                | `zstdmt_compress.c` |
-| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 |   1 → 3 | `ZSTD_CCtx_init_compressStream2`            | `zstd_compress.c`   |
-| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 |   1 → 3 | `ZSTD_compressStream2`                      | `zstd_compress.c`   |
-| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 |   1 → 3 | `FIO_compressFilename_srcFile`              | `fileio.c`          |
-| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 |   1 → 3 | `FIO_compressFilename`                      | `fileio.c`          |
-| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 |   1 → 3 | `main`                                      | `zstdcli.c`         |
-|   +1.6% |    +1 | 88.4% → 87.3% | 61 → 62 | 61 → 62 | `do_syscall_64 ([kernel])`                  | `<unknown>`         |
-|   +1.6% |    +1 | 88.4% → 87.3% | 61 → 62 | 61 → 62 | `entry_SYSCALL_64_after_hwframe ([kernel])` | `<unknown>`         |
-|   +6.7% |    +1 | 21.7% → 22.5% | 15 → 16 | 15 → 16 | `p9_client_read_once ([kernel])`            | `<unknown>`         |
-|   +6.7% |    +1 | 21.7% → 22.5% | 15 → 16 | 15 → 16 | `p9_client_read ([kernel])`                 | `<unknown>`         |
-|   +6.7% |    +1 | 21.7% → 22.5% | 15 → 16 | 15 → 16 | `v9fs_issue_read ([kernel])`                | `<unknown>`         |
-|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 |   8 → 9 | `p9_virtio_zc_request ([kernel])`           | `<unknown>`         |
-|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 |   8 → 9 | `p9_client_zc_rpc.constprop.0 ([kernel])`   | `<unknown>`         |
+|  Change | Delta |             % |  Sleeps | Function                                    | Location            |
+| ------: | ----: | ------------: | ------: | ------------------------------------------- | ------------------- |
+|   +2.9% |    +2 |        100.0% | 69 → 71 | `bpf_trace_run4 ([kernel])`                 | `<unknown>`         |
+|   +2.9% |    +2 |        100.0% | 69 → 71 | `__schedule ([kernel])`                     | `<unknown>`         |
+|   +2.9% |    +2 |        100.0% | 69 → 71 | `schedule ([kernel])`                       | `<unknown>`         |
+|  +50.0% |    +2 |   5.8% → 8.5% |   4 → 6 | `schedule_preempt_disabled ([kernel])`      | `<unknown>`         |
+| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 | `rwsem_down_write_slowpath ([kernel])`      | `<unknown>`         |
+| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 | `down_write_killable ([kernel])`            | `<unknown>`         |
+| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 | `POOL_create_advanced`                      | `pool.c`            |
+| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 | `ZSTDMT_createCCtx_advanced`                | `zstdmt_compress.c` |
+| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 | `ZSTD_CCtx_init_compressStream2`            | `zstd_compress.c`   |
+| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 | `ZSTD_compressStream2`                      | `zstd_compress.c`   |
+| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 | `FIO_compressFilename_srcFile`              | `fileio.c`          |
+| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 | `FIO_compressFilename`                      | `fileio.c`          |
+| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 | `main`                                      | `zstdcli.c`         |
+|   +1.6% |    +1 | 88.4% → 87.3% | 61 → 62 | `do_syscall_64 ([kernel])`                  | `<unknown>`         |
+|   +1.6% |    +1 | 88.4% → 87.3% | 61 → 62 | `entry_SYSCALL_64_after_hwframe ([kernel])` | `<unknown>`         |
+|   +6.7% |    +1 | 21.7% → 22.5% | 15 → 16 | `p9_client_read_once ([kernel])`            | `<unknown>`         |
+|   +6.7% |    +1 | 21.7% → 22.5% | 15 → 16 | `p9_client_read ([kernel])`                 | `<unknown>`         |
+|   +6.7% |    +1 | 21.7% → 22.5% | 15 → 16 | `v9fs_issue_read ([kernel])`                | `<unknown>`         |
+|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 | `p9_virtio_zc_request ([kernel])`           | `<unknown>`         |
+|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 | `p9_client_zc_rpc.constprop.0 ([kernel])`   | `<unknown>`         |
 
 ##### Kernel
 
-|  Change | Delta |             % |  Sleeps | Samples | Function                                    | Location    |
-| ------: | ----: | ------------: | ------: | ------: | ------------------------------------------- | ----------- |
-|   +2.9% |    +2 |        100.0% | 69 → 71 | 69 → 71 | `bpf_trace_run4 ([kernel])`                 | `<unknown>` |
-|   +2.9% |    +2 |        100.0% | 69 → 71 | 69 → 71 | `__schedule ([kernel])`                     | `<unknown>` |
-|   +2.9% |    +2 |        100.0% | 69 → 71 | 69 → 71 | `schedule ([kernel])`                       | `<unknown>` |
-|  +50.0% |    +2 |   5.8% → 8.5% |   4 → 6 |   4 → 6 | `schedule_preempt_disabled ([kernel])`      | `<unknown>` |
-| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 |   1 → 3 | `rwsem_down_write_slowpath ([kernel])`      | `<unknown>` |
-| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 |   1 → 3 | `down_write_killable ([kernel])`            | `<unknown>` |
-|   +1.6% |    +1 | 88.4% → 87.3% | 61 → 62 | 61 → 62 | `do_syscall_64 ([kernel])`                  | `<unknown>` |
-|   +1.6% |    +1 | 88.4% → 87.3% | 61 → 62 | 61 → 62 | `entry_SYSCALL_64_after_hwframe ([kernel])` | `<unknown>` |
-|   +6.7% |    +1 | 21.7% → 22.5% | 15 → 16 | 15 → 16 | `p9_client_read_once ([kernel])`            | `<unknown>` |
-|   +6.7% |    +1 | 21.7% → 22.5% | 15 → 16 | 15 → 16 | `p9_client_read ([kernel])`                 | `<unknown>` |
-|   +6.7% |    +1 | 21.7% → 22.5% | 15 → 16 | 15 → 16 | `v9fs_issue_read ([kernel])`                | `<unknown>` |
-|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 |   8 → 9 | `p9_virtio_zc_request ([kernel])`           | `<unknown>` |
-|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 |   8 → 9 | `p9_client_zc_rpc.constprop.0 ([kernel])`   | `<unknown>` |
-|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 |   8 → 9 | `netfs_read_to_pagecache ([kernel])`        | `<unknown>` |
-|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 |   8 → 9 | `netfs_read_folio ([kernel])`               | `<unknown>` |
-|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 |   8 → 9 | `filemap_read_folio ([kernel])`             | `<unknown>` |
-|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 |   8 → 9 | `filemap_fault ([kernel])`                  | `<unknown>` |
-|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 |   8 → 9 | `__do_fault ([kernel])`                     | `<unknown>` |
-|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 |   8 → 9 | `do_fault ([kernel])`                       | `<unknown>` |
-|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 |   8 → 9 | `__handle_mm_fault ([kernel])`              | `<unknown>` |
+|  Change | Delta |             % |  Sleeps | Function                                    | Location    |
+| ------: | ----: | ------------: | ------: | ------------------------------------------- | ----------- |
+|   +2.9% |    +2 |        100.0% | 69 → 71 | `bpf_trace_run4 ([kernel])`                 | `<unknown>` |
+|   +2.9% |    +2 |        100.0% | 69 → 71 | `__schedule ([kernel])`                     | `<unknown>` |
+|   +2.9% |    +2 |        100.0% | 69 → 71 | `schedule ([kernel])`                       | `<unknown>` |
+|  +50.0% |    +2 |   5.8% → 8.5% |   4 → 6 | `schedule_preempt_disabled ([kernel])`      | `<unknown>` |
+| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 | `rwsem_down_write_slowpath ([kernel])`      | `<unknown>` |
+| +200.0% |    +2 |   1.4% → 4.2% |   1 → 3 | `down_write_killable ([kernel])`            | `<unknown>` |
+|   +1.6% |    +1 | 88.4% → 87.3% | 61 → 62 | `do_syscall_64 ([kernel])`                  | `<unknown>` |
+|   +1.6% |    +1 | 88.4% → 87.3% | 61 → 62 | `entry_SYSCALL_64_after_hwframe ([kernel])` | `<unknown>` |
+|   +6.7% |    +1 | 21.7% → 22.5% | 15 → 16 | `p9_client_read_once ([kernel])`            | `<unknown>` |
+|   +6.7% |    +1 | 21.7% → 22.5% | 15 → 16 | `p9_client_read ([kernel])`                 | `<unknown>` |
+|   +6.7% |    +1 | 21.7% → 22.5% | 15 → 16 | `v9fs_issue_read ([kernel])`                | `<unknown>` |
+|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 | `p9_virtio_zc_request ([kernel])`           | `<unknown>` |
+|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 | `p9_client_zc_rpc.constprop.0 ([kernel])`   | `<unknown>` |
+|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 | `netfs_read_to_pagecache ([kernel])`        | `<unknown>` |
+|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 | `netfs_read_folio ([kernel])`               | `<unknown>` |
+|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 | `filemap_read_folio ([kernel])`             | `<unknown>` |
+|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 | `filemap_fault ([kernel])`                  | `<unknown>` |
+|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 | `__do_fault ([kernel])`                     | `<unknown>` |
+|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 | `do_fault ([kernel])`                       | `<unknown>` |
+|  +12.5% |    +1 | 11.6% → 12.7% |   8 → 9 | `__handle_mm_fault ([kernel])`              | `<unknown>` |
 
 #### Improvements
 
@@ -429,29 +429,29 @@ Functions with the largest decrease in total uninterruptible sleeps entered in t
 
 ##### Kernel
 
-| Change | Delta |             % |  Sleeps | Samples | Function                               | Location    |
-| -----: | ----: | ------------: | ------: | ------: | -------------------------------------- | ----------- |
-|  -1.8% |    -1 | 82.6% → 78.9% | 57 → 56 | 57 → 56 | `p9_client_rpc ([kernel])`             | `<unknown>` |
-|  -6.7% |    -1 | 21.7% → 19.7% | 15 → 14 | 15 → 14 | `p9_client_walk ([kernel])`            | `<unknown>` |
-|  -5.3% |    -1 | 27.5% → 25.4% | 19 → 18 | 19 → 18 | `v9fs_vfs_lookup ([kernel])`           | `<unknown>` |
-|  -2.3% |    -1 | 62.3% → 59.2% | 43 → 42 | 43 → 42 | `path_openat ([kernel])`               | `<unknown>` |
-|  -2.3% |    -1 | 62.3% → 59.2% | 43 → 42 | 43 → 42 | `do_filp_open ([kernel])`              | `<unknown>` |
-|  -7.7% |    -1 | 18.8% → 16.9% | 13 → 12 | 13 → 12 | `do_open_execat ([kernel])`            | `<unknown>` |
-|  -7.7% |    -1 | 18.8% → 16.9% | 13 → 12 | 13 → 12 | `open_exec ([kernel])`                 | `<unknown>` |
-|  -6.7% |    -1 | 21.7% → 19.7% | 15 → 14 | 15 → 14 | `load_elf_binary ([kernel])`           | `<unknown>` |
-|  -6.7% |    -1 | 21.7% → 19.7% | 15 → 14 | 15 → 14 | `bprm_execve ([kernel])`               | `<unknown>` |
-|  -6.7% |    -1 | 21.7% → 19.7% | 15 → 14 | 15 → 14 | `do_execveat_common ([kernel])`        | `<unknown>` |
-|  -6.7% |    -1 | 21.7% → 19.7% | 15 → 14 | 15 → 14 | `__x64_sys_execve ([kernel])`          | `<unknown>` |
-| -12.5% |    -1 |  11.6% → 9.9% |   8 → 7 |   8 → 7 | `v9fs_vfs_atomic_open_dotl ([kernel])` | `<unknown>` |
-| -12.5% |    -1 |  11.6% → 9.9% |   8 → 7 |   8 → 7 | `lookup_open.isra.0 ([kernel])`        | `<unknown>` |
+| Change | Delta |             % |  Sleeps | Function                               | Location    |
+| -----: | ----: | ------------: | ------: | -------------------------------------- | ----------- |
+|  -1.8% |    -1 | 82.6% → 78.9% | 57 → 56 | `p9_client_rpc ([kernel])`             | `<unknown>` |
+|  -6.7% |    -1 | 21.7% → 19.7% | 15 → 14 | `p9_client_walk ([kernel])`            | `<unknown>` |
+|  -5.3% |    -1 | 27.5% → 25.4% | 19 → 18 | `v9fs_vfs_lookup ([kernel])`           | `<unknown>` |
+|  -2.3% |    -1 | 62.3% → 59.2% | 43 → 42 | `path_openat ([kernel])`               | `<unknown>` |
+|  -2.3% |    -1 | 62.3% → 59.2% | 43 → 42 | `do_filp_open ([kernel])`              | `<unknown>` |
+|  -7.7% |    -1 | 18.8% → 16.9% | 13 → 12 | `do_open_execat ([kernel])`            | `<unknown>` |
+|  -7.7% |    -1 | 18.8% → 16.9% | 13 → 12 | `open_exec ([kernel])`                 | `<unknown>` |
+|  -6.7% |    -1 | 21.7% → 19.7% | 15 → 14 | `load_elf_binary ([kernel])`           | `<unknown>` |
+|  -6.7% |    -1 | 21.7% → 19.7% | 15 → 14 | `bprm_execve ([kernel])`               | `<unknown>` |
+|  -6.7% |    -1 | 21.7% → 19.7% | 15 → 14 | `do_execveat_common ([kernel])`        | `<unknown>` |
+|  -6.7% |    -1 | 21.7% → 19.7% | 15 → 14 | `__x64_sys_execve ([kernel])`          | `<unknown>` |
+| -12.5% |    -1 |  11.6% → 9.9% |   8 → 7 | `v9fs_vfs_atomic_open_dotl ([kernel])` | `<unknown>` |
+| -12.5% |    -1 |  11.6% → 9.9% |   8 → 7 | `lookup_open.isra.0 ([kernel])`        | `<unknown>` |
 
 # Interruptible sleep profile diff
 
-Slept 84 times → 87 times (+3 times, +3.6%) over 84 samples → 87 samples (1 time per sample).
+Slept 84 times → 87 times (+3 times, +3.6%).
 
-| Category | Change | Delta |      % |  Sleeps | Samples |
-| -------- | -----: | ----: | -----: | ------: | ------: |
-| Kernel   |  +3.6% |    +3 | 100.0% | 84 → 87 | 84 → 87 |
+| Category | Change | Delta |      % |  Sleeps |
+| -------- | -----: | ----: | -----: | ------: |
+| Kernel   |  +3.6% |    +3 | 100.0% | 84 → 87 |
 
 ## Hottest functions
 
@@ -463,9 +463,9 @@ Functions with the largest increase in interruptible sleeps entered directly in 
 
 ##### Kernel
 
-| Change | Delta |      % |  Sleeps | Samples | Function                    | Location    |
-| -----: | ----: | -----: | ------: | ------: | --------------------------- | ----------- |
-|  +3.6% |    +3 | 100.0% | 84 → 87 | 84 → 87 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
+| Change | Delta |      % |  Sleeps | Function                    | Location    |
+| -----: | ----: | -----: | ------: | --------------------------- | ----------- |
+|  +3.6% |    +3 | 100.0% | 84 → 87 | `bpf_trace_run4 ([kernel])` | `<unknown>` |
 
 ### Total sleeps
 
@@ -473,37 +473,37 @@ Functions with the largest increase in interruptible sleeps entered directly in 
 
 Functions with the largest increase in total interruptible sleeps entered in the function and all its callees.
 
-| Change | Delta |             % |  Sleeps | Samples | Function                                    | Location            |
-| -----: | ----: | ------------: | ------: | ------: | ------------------------------------------- | ------------------- |
-|  +3.6% |    +3 |        100.0% | 84 → 87 | 84 → 87 | `bpf_trace_run4 ([kernel])`                 | `<unknown>`         |
-|  +3.6% |    +3 |        100.0% | 84 → 87 | 84 → 87 | `__schedule ([kernel])`                     | `<unknown>`         |
-|  +3.6% |    +3 |        100.0% | 84 → 87 | 84 → 87 | `schedule ([kernel])`                       | `<unknown>`         |
-|  +3.6% |    +3 |        100.0% | 84 → 87 | 84 → 87 | `futex_wait_queue ([kernel])`               | `<unknown>`         |
-|  +3.6% |    +3 |        100.0% | 84 → 87 | 84 → 87 | `__futex_wait ([kernel])`                   | `<unknown>`         |
-|  +3.6% |    +3 |        100.0% | 84 → 87 | 84 → 87 | `futex_wait ([kernel])`                     | `<unknown>`         |
-|  +3.6% |    +3 |        100.0% | 84 → 87 | 84 → 87 | `do_futex ([kernel])`                       | `<unknown>`         |
-|  +3.6% |    +3 |        100.0% | 84 → 87 | 84 → 87 | `__x64_sys_futex ([kernel])`                | `<unknown>`         |
-|  +3.6% |    +3 |        100.0% | 84 → 87 | 84 → 87 | `do_syscall_64 ([kernel])`                  | `<unknown>`         |
-|  +3.6% |    +3 |        100.0% | 84 → 87 | 84 → 87 | `entry_SYSCALL_64_after_hwframe ([kernel])` | `<unknown>`         |
-|  +3.6% |    +3 |        100.0% | 84 → 87 | 84 → 87 | `pthread_cond_wait (libc.so.6)`             | `<unknown>`         |
-|  +2.6% |    +2 | 90.5% → 89.7% | 76 → 78 | 76 → 78 | `POOL_thread`                               | `pool.c`            |
-| +12.5% |    +1 |  9.5% → 10.3% |   8 → 9 |   8 → 9 | `FIO_compressFilename_srcFile`              | `fileio.c`          |
-| +12.5% |    +1 |  9.5% → 10.3% |   8 → 9 |   8 → 9 | `FIO_compressFilename`                      | `fileio.c`          |
-| +12.5% |    +1 |  9.5% → 10.3% |   8 → 9 |   8 → 9 | `main`                                      | `zstdcli.c`         |
-| +16.7% |    +1 |   7.1% → 8.0% |   6 → 7 |   6 → 7 | `ZSTDMT_compressStream_generic`             | `zstdmt_compress.c` |
-| +16.7% |    +1 |   7.1% → 8.0% |   6 → 7 |   6 → 7 | `ZSTD_compressStream2`                      | `zstd_compress.c`   |
+| Change | Delta |             % |  Sleeps | Function                                    | Location            |
+| -----: | ----: | ------------: | ------: | ------------------------------------------- | ------------------- |
+|  +3.6% |    +3 |        100.0% | 84 → 87 | `bpf_trace_run4 ([kernel])`                 | `<unknown>`         |
+|  +3.6% |    +3 |        100.0% | 84 → 87 | `__schedule ([kernel])`                     | `<unknown>`         |
+|  +3.6% |    +3 |        100.0% | 84 → 87 | `schedule ([kernel])`                       | `<unknown>`         |
+|  +3.6% |    +3 |        100.0% | 84 → 87 | `futex_wait_queue ([kernel])`               | `<unknown>`         |
+|  +3.6% |    +3 |        100.0% | 84 → 87 | `__futex_wait ([kernel])`                   | `<unknown>`         |
+|  +3.6% |    +3 |        100.0% | 84 → 87 | `futex_wait ([kernel])`                     | `<unknown>`         |
+|  +3.6% |    +3 |        100.0% | 84 → 87 | `do_futex ([kernel])`                       | `<unknown>`         |
+|  +3.6% |    +3 |        100.0% | 84 → 87 | `__x64_sys_futex ([kernel])`                | `<unknown>`         |
+|  +3.6% |    +3 |        100.0% | 84 → 87 | `do_syscall_64 ([kernel])`                  | `<unknown>`         |
+|  +3.6% |    +3 |        100.0% | 84 → 87 | `entry_SYSCALL_64_after_hwframe ([kernel])` | `<unknown>`         |
+|  +3.6% |    +3 |        100.0% | 84 → 87 | `pthread_cond_wait (libc.so.6)`             | `<unknown>`         |
+|  +2.6% |    +2 | 90.5% → 89.7% | 76 → 78 | `POOL_thread`                               | `pool.c`            |
+| +12.5% |    +1 |  9.5% → 10.3% |   8 → 9 | `FIO_compressFilename_srcFile`              | `fileio.c`          |
+| +12.5% |    +1 |  9.5% → 10.3% |   8 → 9 | `FIO_compressFilename`                      | `fileio.c`          |
+| +12.5% |    +1 |  9.5% → 10.3% |   8 → 9 | `main`                                      | `zstdcli.c`         |
+| +16.7% |    +1 |   7.1% → 8.0% |   6 → 7 | `ZSTDMT_compressStream_generic`             | `zstdmt_compress.c` |
+| +16.7% |    +1 |   7.1% → 8.0% |   6 → 7 | `ZSTD_compressStream2`                      | `zstd_compress.c`   |
 
 ##### Kernel
 
-| Change | Delta |      % |  Sleeps | Samples | Function                                    | Location    |
-| -----: | ----: | -----: | ------: | ------: | ------------------------------------------- | ----------- |
-|  +3.6% |    +3 | 100.0% | 84 → 87 | 84 → 87 | `bpf_trace_run4 ([kernel])`                 | `<unknown>` |
-|  +3.6% |    +3 | 100.0% | 84 → 87 | 84 → 87 | `__schedule ([kernel])`                     | `<unknown>` |
-|  +3.6% |    +3 | 100.0% | 84 → 87 | 84 → 87 | `schedule ([kernel])`                       | `<unknown>` |
-|  +3.6% |    +3 | 100.0% | 84 → 87 | 84 → 87 | `futex_wait_queue ([kernel])`               | `<unknown>` |
-|  +3.6% |    +3 | 100.0% | 84 → 87 | 84 → 87 | `__futex_wait ([kernel])`                   | `<unknown>` |
-|  +3.6% |    +3 | 100.0% | 84 → 87 | 84 → 87 | `futex_wait ([kernel])`                     | `<unknown>` |
-|  +3.6% |    +3 | 100.0% | 84 → 87 | 84 → 87 | `do_futex ([kernel])`                       | `<unknown>` |
-|  +3.6% |    +3 | 100.0% | 84 → 87 | 84 → 87 | `__x64_sys_futex ([kernel])`                | `<unknown>` |
-|  +3.6% |    +3 | 100.0% | 84 → 87 | 84 → 87 | `do_syscall_64 ([kernel])`                  | `<unknown>` |
-|  +3.6% |    +3 | 100.0% | 84 → 87 | 84 → 87 | `entry_SYSCALL_64_after_hwframe ([kernel])` | `<unknown>` |
+| Change | Delta |      % |  Sleeps | Function                                    | Location    |
+| -----: | ----: | -----: | ------: | ------------------------------------------- | ----------- |
+|  +3.6% |    +3 | 100.0% | 84 → 87 | `bpf_trace_run4 ([kernel])`                 | `<unknown>` |
+|  +3.6% |    +3 | 100.0% | 84 → 87 | `__schedule ([kernel])`                     | `<unknown>` |
+|  +3.6% |    +3 | 100.0% | 84 → 87 | `schedule ([kernel])`                       | `<unknown>` |
+|  +3.6% |    +3 | 100.0% | 84 → 87 | `futex_wait_queue ([kernel])`               | `<unknown>` |
+|  +3.6% |    +3 | 100.0% | 84 → 87 | `__futex_wait ([kernel])`                   | `<unknown>` |
+|  +3.6% |    +3 | 100.0% | 84 → 87 | `futex_wait ([kernel])`                     | `<unknown>` |
+|  +3.6% |    +3 | 100.0% | 84 → 87 | `do_futex ([kernel])`                       | `<unknown>` |
+|  +3.6% |    +3 | 100.0% | 84 → 87 | `__x64_sys_futex ([kernel])`                | `<unknown>` |
+|  +3.6% |    +3 | 100.0% | 84 → 87 | `do_syscall_64 ([kernel])`                  | `<unknown>` |
+|  +3.6% |    +3 | 100.0% | 84 → 87 | `entry_SYSCALL_64_after_hwframe ([kernel])` | `<unknown>` |

--- a/examples/output/go.go.goroutine.diff.pprof.md
+++ b/examples/output/go.go.goroutine.diff.pprof.md
@@ -1,6 +1,6 @@
 # Goroutine profile diff
 
-1 goroutine.
+Recorded 1 goroutine.
 
 | Category         | Change | Delta |      % | Goroutines |
 | ---------------- | -----: | ----: | -----: | ---------: |

--- a/examples/output/go.go.goroutineleak.diff.pprof.md
+++ b/examples/output/go.go.goroutineleak.diff.pprof.md
@@ -1,6 +1,6 @@
 # Leaked goroutine profile diff
 
-3 leaked goroutines.
+Recorded 3 leaked goroutines.
 
 | Category         | Change | Delta |      % | Leaked goroutines |
 | ---------------- | -----: | ----: | -----: | ----------------: |

--- a/examples/output/go.go.threadcreate.diff.pprof.md
+++ b/examples/output/go.go.threadcreate.diff.pprof.md
@@ -1,6 +1,6 @@
 # Thread creation profile diff
 
-13 thread creations.
+Recorded 13 thread creations.
 
 | Category | Change | Delta |      % | Thread creations |
 | -------- | -----: | ----: | -----: | ---------------: |

--- a/examples/output/groovy.async-profiler.all.diff.jfr.md
+++ b/examples/output/groovy.async-profiler.all.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-6,237 samples → 8,604 samples (+2,367 samples, +38.0%).
+Collected 6,237 samples → 8,604 samples (+2,367 samples, +38.0%).
 
 | Category          | Change |  Delta |             % |       Samples |
 | ----------------- | -----: | -----: | ------------: | ------------: |

--- a/examples/output/groovy.async-profiler.cpu.diff.collapsed.md
+++ b/examples/output/groovy.async-profiler.cpu.diff.collapsed.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-5,918 samples → 6,382 samples (+464 samples, +7.8%).
+Collected 5,918 samples → 6,382 samples (+464 samples, +7.8%).
 
 | Category          | Change | Delta |             % |       Samples |
 | ----------------- | -----: | ----: | ------------: | ------------: |

--- a/examples/output/groovy.async-profiler.cpu.diff.jfr.md
+++ b/examples/output/groovy.async-profiler.cpu.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-6,001 samples → 5,827 samples (-174 samples, -2.9%).
+Collected 6,001 samples → 5,827 samples (-174 samples, -2.9%).
 
 | Category          | Change | Delta |             % |       Samples |
 | ----------------- | -----: | ----: | ------------: | ------------: |

--- a/examples/output/groovy.async-profiler.wall.diff.jfr.md
+++ b/examples/output/groovy.async-profiler.wall.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-14,309 samples → 26,323 samples (+12,014 samples, +84.0%).
+Collected 14,309 samples → 26,323 samples (+12,014 samples, +84.0%).
 
 | Category          |  Change |   Delta |             % |         Samples |
 | ----------------- | ------: | ------: | ------------: | --------------: |

--- a/examples/output/groovy.jdk.all.diff.jfr.md
+++ b/examples/output/groovy.jdk.all.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-367 samples → 311 samples (-56 samples, -15.3%).
+Collected 367 samples → 311 samples (-56 samples, -15.3%).
 
 | Category         | Change | Delta |             % |   Samples |
 | ---------------- | -----: | ----: | ------------: | --------: |

--- a/examples/output/groovy.jdk.alloc.diff.jfr.md
+++ b/examples/output/groovy.jdk.alloc.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-300 samples → 327 samples (+27 samples, +9.0%).
+Collected 300 samples → 327 samples (+27 samples, +9.0%).
 
 | Category         | Change | Delta |             % |   Samples |
 | ---------------- | -----: | ----: | ------------: | --------: |

--- a/examples/output/groovy.jdk.cpu.diff.jfr.md
+++ b/examples/output/groovy.jdk.cpu.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-321 samples → 342 samples (+21 samples, +6.5%).
+Collected 321 samples → 342 samples (+21 samples, +6.5%).
 
 | Category         | Change | Delta |             % |   Samples |
 | ---------------- | -----: | ----: | ------------: | --------: |

--- a/examples/output/groovy.jdk.live.diff.jfr.md
+++ b/examples/output/groovy.jdk.live.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-309 samples → 336 samples (+27 samples, +8.7%).
+Collected 309 samples → 336 samples (+27 samples, +8.7%).
 
 | Category         | Change | Delta |             % |   Samples |
 | ---------------- | -----: | ----: | ------------: | --------: |

--- a/examples/output/groovy.jdk.lock.diff.jfr.md
+++ b/examples/output/groovy.jdk.lock.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-368 samples → 327 samples (-41 samples, -11.1%).
+Collected 368 samples → 327 samples (-41 samples, -11.1%).
 
 | Category         | Change | Delta |             % |   Samples |
 | ---------------- | -----: | ----: | ------------: | --------: |

--- a/examples/output/java.async-profiler.all.diff.jfr.md
+++ b/examples/output/java.async-profiler.all.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-5,188 samples → 5,107 samples (-81 samples, -1.6%).
+Collected 5,188 samples → 5,107 samples (-81 samples, -1.6%).
 
 | Category          |  Change | Delta |             % |       Samples |
 | ----------------- | ------: | ----: | ------------: | ------------: |

--- a/examples/output/java.async-profiler.cpu.diff.collapsed.md
+++ b/examples/output/java.async-profiler.cpu.diff.collapsed.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-4,869 samples → 4,711 samples (-158 samples, -3.2%).
+Collected 4,869 samples → 4,711 samples (-158 samples, -3.2%).
 
 | Category         |  Change | Delta |             % |       Samples |
 | ---------------- | ------: | ----: | ------------: | ------------: |

--- a/examples/output/java.async-profiler.cpu.diff.jfr.md
+++ b/examples/output/java.async-profiler.cpu.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-4,802 samples → 4,822 samples (+20 samples, +0.4%).
+Collected 4,802 samples → 4,822 samples (+20 samples, +0.4%).
 
 | Category         | Change | Delta |             % |       Samples |
 | ---------------- | -----: | ----: | ------------: | ------------: |

--- a/examples/output/java.async-profiler.wall.diff.jfr.md
+++ b/examples/output/java.async-profiler.wall.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-5,140 samples → 4,878 samples (-262 samples, -5.1%).
+Collected 5,140 samples → 4,878 samples (-262 samples, -5.1%).
 
 | Category         |  Change | Delta |             % |       Samples |
 | ---------------- | ------: | ----: | ------------: | ------------: |

--- a/examples/output/java.jdk.all.diff.jfr.md
+++ b/examples/output/java.jdk.all.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-1,637 samples → 1,634 samples (-3 samples, -0.2%).
+Collected 1,637 samples → 1,634 samples (-3 samples, -0.2%).
 
 | Category         | Change | Delta |             % |       Samples |
 | ---------------- | -----: | ----: | ------------: | ------------: |

--- a/examples/output/java.jdk.alloc.diff.jfr.md
+++ b/examples/output/java.jdk.alloc.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-1,682 samples → 1,629 samples (-53 samples, -3.2%).
+Collected 1,682 samples → 1,629 samples (-53 samples, -3.2%).
 
 | Category         | Change | Delta |             % |       Samples |
 | ---------------- | -----: | ----: | ------------: | ------------: |

--- a/examples/output/java.jdk.cpu.diff.jfr.md
+++ b/examples/output/java.jdk.cpu.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-1,684 samples → 1,605 samples (-79 samples, -4.7%).
+Collected 1,684 samples → 1,605 samples (-79 samples, -4.7%).
 
 | Category         | Change | Delta |             % |       Samples |
 | ---------------- | -----: | ----: | ------------: | ------------: |

--- a/examples/output/java.jdk.live.diff.jfr.md
+++ b/examples/output/java.jdk.live.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-1,677 samples → 1,725 samples (+48 samples, +2.9%).
+Collected 1,677 samples → 1,725 samples (+48 samples, +2.9%).
 
 | Category         | Change | Delta |             % |       Samples |
 | ---------------- | -----: | ----: | ------------: | ------------: |

--- a/examples/output/java.jdk.lock.diff.jfr.md
+++ b/examples/output/java.jdk.lock.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-1,810 samples → 1,629 samples (-181 samples, -10.0%).
+Collected 1,810 samples → 1,629 samples (-181 samples, -10.0%).
 
 | Category         | Change | Delta |             % |       Samples |
 | ---------------- | -----: | ----: | ------------: | ------------: |

--- a/examples/output/julia.pprof-jl.cpu.diff.pprof.md
+++ b/examples/output/julia.pprof-jl.cpu.diff.pprof.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-26,284 samples → 26,316 samples (+32 samples, +0.1%).
+Collected 26,284 samples → 26,316 samples (+32 samples, +0.1%).
 
 | Category         | Change | Delta |             % |         Samples |
 | ---------------- | -----: | ----: | ------------: | --------------: |

--- a/examples/output/julia.pprof-jl.wall.diff.pprof.md
+++ b/examples/output/julia.pprof-jl.wall.diff.pprof.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-27,753 samples → 28,619 samples (+866 samples, +3.1%).
+Collected 27,753 samples → 28,619 samples (+866 samples, +3.1%).
 
 | Category         | Change | Delta |             % |         Samples |
 | ---------------- | -----: | ----: | ------------: | --------------: |

--- a/examples/output/kotlin.async-profiler.all.diff.jfr.md
+++ b/examples/output/kotlin.async-profiler.all.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-1,322 samples.
+Collected 1,322 samples.
 
 | Category         | Change | Delta |             % |   Samples |
 | ---------------- | -----: | ----: | ------------: | --------: |

--- a/examples/output/kotlin.async-profiler.cpu.diff.collapsed.md
+++ b/examples/output/kotlin.async-profiler.cpu.diff.collapsed.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-1,353 samples → 1,356 samples (+3 samples, +0.2%).
+Collected 1,353 samples → 1,356 samples (+3 samples, +0.2%).
 
 | Category         | Change | Delta |             % |   Samples |
 | ---------------- | -----: | ----: | ------------: | --------: |

--- a/examples/output/kotlin.async-profiler.cpu.diff.jfr.md
+++ b/examples/output/kotlin.async-profiler.cpu.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-1,307 samples → 1,331 samples (+24 samples, +1.8%).
+Collected 1,307 samples → 1,331 samples (+24 samples, +1.8%).
 
 | Category          |  Change | Delta |             % |   Samples |
 | ----------------- | ------: | ----: | ------------: | --------: |

--- a/examples/output/kotlin.async-profiler.wall.diff.jfr.md
+++ b/examples/output/kotlin.async-profiler.wall.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-2,694 samples → 2,710 samples (+16 samples, +0.6%).
+Collected 2,694 samples → 2,710 samples (+16 samples, +0.6%).
 
 | Category          | Change | Delta |             % |       Samples |
 | ----------------- | -----: | ----: | ------------: | ------------: |

--- a/examples/output/kotlin.jdk.all.diff.jfr.md
+++ b/examples/output/kotlin.jdk.all.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-110 samples → 108 samples (-2 samples, -1.8%).
+Collected 110 samples → 108 samples (-2 samples, -1.8%).
 
 | Category         | Change | Delta |             % | Samples |
 | ---------------- | -----: | ----: | ------------: | ------: |

--- a/examples/output/kotlin.jdk.alloc.diff.jfr.md
+++ b/examples/output/kotlin.jdk.alloc.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-133 samples → 106 samples (-27 samples, -20.3%).
+Collected 133 samples → 106 samples (-27 samples, -20.3%).
 
 | Category         | Change | Delta |             % | Samples |
 | ---------------- | -----: | ----: | ------------: | ------: |

--- a/examples/output/kotlin.jdk.cpu.diff.jfr.md
+++ b/examples/output/kotlin.jdk.cpu.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-122 samples → 113 samples (-9 samples, -7.4%).
+Collected 122 samples → 113 samples (-9 samples, -7.4%).
 
 | Category         | Change | Delta |             % | Samples |
 | ---------------- | -----: | ----: | ------------: | ------: |

--- a/examples/output/kotlin.jdk.live.diff.jfr.md
+++ b/examples/output/kotlin.jdk.live.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-117 samples → 120 samples (+3 samples, +2.6%).
+Collected 117 samples → 120 samples (+3 samples, +2.6%).
 
 | Category         | Change | Delta |             % | Samples |
 | ---------------- | -----: | ----: | ------------: | ------: |

--- a/examples/output/kotlin.jdk.lock.diff.jfr.md
+++ b/examples/output/kotlin.jdk.lock.diff.jfr.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-118 samples.
+Collected 118 samples.
 
 | Category         | Change | Delta |             % | Samples |
 | ---------------- | -----: | ----: | ------------: | ------: |

--- a/examples/output/python.py-spy.cpu.diff.collapsed.md
+++ b/examples/output/python.py-spy.cpu.diff.collapsed.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-189 samples → 196 samples (+7 samples, +3.7%).
+Collected 189 samples → 196 samples (+7 samples, +3.7%).
 
 | Category         | Change | Delta |             % |   Samples |
 | ---------------- | -----: | ----: | ------------: | --------: |

--- a/examples/output/python.py-spy.wall.diff.collapsed.md
+++ b/examples/output/python.py-spy.wall.diff.collapsed.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-175 samples → 184 samples (+9 samples, +5.1%).
+Collected 175 samples → 184 samples (+9 samples, +5.1%).
 
 | Category         |  Change | Delta |             % |   Samples |
 | ---------------- | ------: | ----: | ------------: | --------: |

--- a/examples/output/ruby.rbspy.cpu.diff.collapsed.md
+++ b/examples/output/ruby.rbspy.cpu.diff.collapsed.md
@@ -1,6 +1,6 @@
 # Sampling profile diff
 
-133 samples → 131 samples (-2 samples, -1.5%).
+Collected 133 samples → 131 samples (-2 samples, -1.5%).
 
 | Category         | Change | Delta |             % | Samples |
 | ---------------- | -----: | ----: | ------------: | ------: |

--- a/src/formats/systing/index.test.ts
+++ b/src/formats/systing/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { chunk, streamOf } from '../../helpers/testing.ts'
+import { diffProfiles } from '../../index.ts'
 import {
   selfSleepsTables,
   selfTimeTables,
@@ -303,15 +304,14 @@ describe(`convert`, () => {
     ])
     expect(summaryLines(md)).toEqual([
       `Took 6.0ms over 6 samples (1.0ms per sample).`,
-      `Slept 2 times over 2 samples (1 time per sample).`,
-      `Slept 5 times over 5 samples (1 time per sample).`,
+      `Slept 2 times.`,
+      `Slept 5 times.`,
     ])
     expect(selfSleepsTables(md)).toEqual([
       [
         {
           '%': `100.0%`,
           Sleeps: `2`,
-          Samples: `2`,
           Function: `do_nanosleep ([kernel])`,
           Location: `<unknown>`,
         },
@@ -320,7 +320,6 @@ describe(`convert`, () => {
         {
           '%': `100.0%`,
           Sleeps: `5`,
-          Samples: `5`,
           Function: `do_nanosleep ([kernel])`,
           Location: `<unknown>`,
         },
@@ -331,7 +330,6 @@ describe(`convert`, () => {
         {
           '%': `100.0%`,
           Sleeps: `2`,
-          Samples: `2`,
           Function: `do_nanosleep ([kernel])`,
           Location: `<unknown>`,
         },
@@ -340,7 +338,6 @@ describe(`convert`, () => {
         {
           '%': `100.0%`,
           Sleeps: `5`,
-          Samples: `5`,
           Function: `do_nanosleep ([kernel])`,
           Location: `<unknown>`,
         },
@@ -396,7 +393,7 @@ describe(`convert`, () => {
     ])
     expect(summaryLines(md)).toEqual([
       `Took 2.0ms over 2 samples (1.0ms per sample).`,
-      `Slept 3 times over 3 samples (1 time per sample).`,
+      `Slept 3 times.`,
     ])
   })
 
@@ -441,9 +438,42 @@ describe(`convert`, () => {
     )
 
     expect(profileTitles(md)).toEqual([`Interruptible sleep profile`])
+    expect(summaryLines(md)).toEqual([`Slept 4 times.`])
+  })
+
+  test(`a sleep diff names the sleeps it counts`, () => {
+    const sleeps = (count: number) => [
+      [`f`, 0, `do_nanosleep ([kernel]) <0xffff2>`],
+      [`s`, 0, [0]],
+      [`x`, 1, 0, 2, count],
+    ]
+
+    const md = diffProfiles(
+      { data: makeSysting(sleeps(4)), format: `systing` },
+      { data: makeSysting(sleeps(6)), format: `systing` },
+      { baseURL: `/`, showEntry: () => true },
+    )
+
+    expect(profileTitles(md)).toEqual([`Interruptible sleep profile diff`])
     expect(summaryLines(md)).toEqual([
-      `Slept 4 times over 4 samples (1 time per sample).`,
+      `Slept 4 times → 6 times (+2 times, +50.0%).`,
     ])
+  })
+
+  test(`rejects a diff of the two sleep kinds, naming both`, () => {
+    const sleeps = (eventType: number) => [
+      [`f`, 0, `do_nanosleep ([kernel]) <0xffff2>`],
+      [`s`, 0, [0]],
+      [`x`, 1, 0, eventType, 4],
+    ]
+
+    expect(() =>
+      diffProfiles(
+        { data: makeSysting(sleeps(0)), format: `systing` },
+        { data: makeSysting(sleeps(2)), format: `systing` },
+        { baseURL: `/`, showEntry: () => true },
+      ),
+    ).toThrow(`got: uninterruptible sleep and interruptible sleep`)
   })
 
   test(`a recording without sampling provenance ranks by sample count alone`, () => {

--- a/src/formats/systing/parse.ts
+++ b/src/formats/systing/parse.ts
@@ -4,7 +4,7 @@ import type {
   Observation,
 } from '../../modalities/call-stack-profile/index.ts'
 import { determineMetric, SAMPLES } from '../../modalities/metric.ts'
-import type { Metric } from '../../modalities/metric.ts'
+import type { CountMetric, Metric } from '../../modalities/metric.ts'
 import type { StackFrame } from '../../modalities/stack-frame.ts'
 import { FormatParseError } from '../error.ts'
 
@@ -226,7 +226,7 @@ class SystingProfileBuilder {
     }
     observations.push({
       id: stackId,
-      values: kind === `cpu` ? this.#cpuValues : SLEEP_SAMPLE_VALUES,
+      values: kind === `cpu` ? this.#cpuValues : NO_VALUES,
       // Export stacks are already leaf-first (callee to caller), the
       // aggregator's order; parseSystingHeader rejects any other declared
       // stack_order.
@@ -246,12 +246,14 @@ class SystingProfileBuilder {
       if (!observations) {
         continue
       }
-      const metric = kind === `cpu` ? this.#cpuMetric : SLEEP_METRICS.get(kind)
+      // The sample period weights CPU samples alone, so only the CPU profile
+      // has a metric, and only its observations have values.
+      const metric = kind === `cpu` ? this.#cpuMetric : undefined
       profiles.push({
         type: `call-stack-profile`,
         frames: this.#frames,
         metrics: metric ? [metric] : [],
-        countMetric: SAMPLES,
+        countMetric: SLEEP_COUNT_METRICS.get(kind) ?? SAMPLES,
         observations,
       })
     }
@@ -260,41 +262,41 @@ class SystingProfileBuilder {
 }
 
 /**
- * Sleep events are occurrences (a thread entered the state with this stack),
- * not durations, so their metric is a count of sleeps: one per sample, scaled
- * by the tally's count. The metric exists to title and label the sleep
- * profiles distinctly; its totals always equal the sample counts.
+ * A sleep event is an occurrence rather than a duration, because it records a
+ * thread entering the state with this stack. A sleep profile therefore has no
+ * metric and counts sleeps. Each kind has its own count metric, so the profiles
+ * are titled distinctly. A diff of two of them states which is which.
  */
-const SLEEP_METRICS: ReadonlyMap<SystingEventKind, Metric> = new Map([
+const SLEEP_COUNT_METRICS: ReadonlyMap<SystingEventKind, CountMetric> = new Map(
   [
-    `uninterruptible_sleep`,
-    {
-      type: `count`,
-      proseUnit: `time`,
-      phrases: {
-        titleNoun: `uninterruptible sleep`,
-        columnNoun: `sleeps`,
-        pastTenseVerb: `slept`,
-        pastParticipleVerbPhrase: `uninterruptible sleeps entered`,
+    [
+      `uninterruptible_sleep`,
+      {
+        type: `count`,
+        proseUnit: `time`,
+        phrases: {
+          titleNoun: `uninterruptible sleep`,
+          columnNoun: `sleeps`,
+          pastTenseVerb: `slept`,
+          pastParticipleVerbPhrase: `uninterruptible sleeps entered`,
+        },
       },
-    },
-  ],
-  [
-    `interruptible_sleep`,
-    {
-      type: `count`,
-      proseUnit: `time`,
-      phrases: {
-        titleNoun: `interruptible sleep`,
-        columnNoun: `sleeps`,
-        pastTenseVerb: `slept`,
-        pastParticipleVerbPhrase: `interruptible sleeps entered`,
+    ],
+    [
+      `interruptible_sleep`,
+      {
+        type: `count`,
+        proseUnit: `time`,
+        phrases: {
+          titleNoun: `interruptible sleep`,
+          columnNoun: `sleeps`,
+          pastTenseVerb: `slept`,
+          pastParticipleVerbPhrase: `interruptible sleeps entered`,
+        },
       },
-    },
+    ],
   ],
-])
-
-const SLEEP_SAMPLE_VALUES = [1]
+)
 
 const NO_VALUES: number[] = []
 

--- a/src/modalities/call-stack-profile/diff.ts
+++ b/src/modalities/call-stack-profile/diff.ts
@@ -84,7 +84,7 @@ const matchDiffedCountMetrics = (
 
   if (ranksByCount) {
     throw new ProfilerMdError(
-      `cannot diff profiles with no metrics in common that count different things, got: ${describeCounts(base)} and ${describeCounts(current)}`,
+      `cannot diff profiles with no metrics in common that count different things, got: ${describeCounts(base, current)} and ${describeCounts(current, base)}`,
     )
   }
   return null
@@ -93,15 +93,20 @@ const matchDiffedCountMetrics = (
 // A count metric's column noun names the counted thing ("samples", "objects").
 // A time or size count metric measures a quantity instead, so its title noun
 // ("wall time") names that quantity where its column noun ("time") would name
-// only the unit.
-const describeCounts = ({
-  countMetric,
-}: AggregatedCallStackProfile): string => {
+// only the unit. Two profiles counting different things can share a column
+// noun ("sleeps"), which their title nouns ("interruptible sleep") separate.
+const describeCounts = (
+  { countMetric }: AggregatedCallStackProfile,
+  { countMetric: otherCountMetric }: AggregatedCallStackProfile,
+): string => {
   if (!countMetric) {
     return `nothing`
   }
   const { titleNoun, columnNoun } = countMetric.phrases
-  return countMetric.type === `count` ? columnNoun : titleNoun
+  return countMetric.type === `count` &&
+    columnNoun !== otherCountMetric?.phrases.columnNoun
+    ? columnNoun
+    : titleNoun
 }
 
 /**

--- a/src/modalities/call-stack-profile/format.ts
+++ b/src/modalities/call-stack-profile/format.ts
@@ -817,12 +817,7 @@ const formatDiffSummaryLine = (
     )}${formatChange(baseCount, currentCount, magnitude =>
       formatProseValueDelta(magnitude, metric),
     )}`
-    // A count of things contains their noun ("129 samples"), while a count
-    // measuring a quantity requires the metric's verb to state what the
-    // quantity is of.
-    return metric.type === `count`
-      ? `${counted}.`
-      : `${capitalizeFirst(metric.phrases.pastTenseVerb)} ${counted}.`
+    return `${capitalizeFirst(metric.phrases.pastTenseVerb)} ${counted}.`
   }
 
   const valueParts = metrics.map(({ metric, baseIndex, currentIndex }) => {


### PR DESCRIPTION
A sleep profile's only metric was a constant 1 per sample, so the summary read "Slept 69 times over 69 samples (1 time per sample)", stating the same number three ways.

Closes #343