### PR TITLE
fix(memray): count allocations instead of samples

### DIFF
--- a/docs/formats/memray.md
+++ b/docs/formats/memray.md
@@ -12,7 +12,9 @@ memory from those still live at the end. This is what `memray flamegraph` and
 `memray flamegraph --leaks` report.
 
 The measures count different allocations, so a capture converts to a profile
-each, and a sample is one allocation that measure counts.
+each, counting each stack's allocations under that measure. Because memray
+records every allocation, the output states bytes per allocation rather than a
+sampling rate.
 
 A capture written with `--aggregate` states each stack's peak and leaked totals
 instead of every allocation, and converts to the same profile without the

--- a/examples/output/python.memray.aggregated.base.memray.bin.md
+++ b/examples/output/python.memray.aggregated.base.memray.bin.md
@@ -1,12 +1,12 @@
 # Peak memory profile
 
-Held 78.6 MiB over 22,694 samples (3.55 KiB per sample).
+Held 78.6 MiB over 22,694 allocations (3.55 KiB per allocation).
 
-| Category         |     % |     Size | Samples |
-| ---------------- | ----: | -------: | ------: |
-| Ours             | 81.6% | 64.2 MiB |  21,445 |
-| Standard library | 16.7% | 13.2 MiB |   1,015 |
-| Third-party      |  1.6% | 1.27 MiB |     234 |
+| Category         |     % |     Size | Allocations |
+| ---------------- | ----: | -------: | ----------: |
+| Ours             | 81.6% | 64.2 MiB |      21,445 |
+| Standard library | 16.7% | 13.2 MiB |       1,015 |
+| Third-party      |  1.6% | 1.27 MiB |         234 |
 
 ## Hottest functions
 
@@ -14,105 +14,105 @@ Held 78.6 MiB over 22,694 samples (3.55 KiB per sample).
 
 Functions ranked by bytes held at peak memory directly in the function body, excluding callees.
 
-|     % |     Size | Samples | Function                         | Location                                               |
-| ----: | -------: | ------: | -------------------------------- | ------------------------------------------------------ |
-| 21.9% | 17.2 MiB |  20,789 | `mark`                           | `black/brackets.py:70`                                 |
-| 11.6% | 9.12 MiB |     142 | `parse`                          | `/usr/lib/python3.11/ast.py:33`                        |
-|  9.0% |  7.1 MiB |       4 | `assert_equivalent`              | `black/__init__.py:1524`                               |
-|  8.9% |    7 MiB |       7 | `__new__`                        | `blib2to3/pytree.py:81`                                |
-|  7.8% | 6.14 MiB |     201 | `update_sibling_maps`            | `blib2to3/pytree.py:369`                               |
-|  7.6% |    6 MiB |       6 | `changed`                        | `blib2to3/pytree.py:171`                               |
-|  5.1% |    4 MiB |       4 | `__init__`                       | `<string>:2`                                           |
-|  3.9% | 3.05 MiB |      59 | `_stringify_ast`                 | `black/parsing.py:174`                                 |
-|  3.8% |    3 MiB |       3 | `_stringify_ast_with_new_parent` | `black/parsing.py:166`                                 |
-|  3.8% |    3 MiB |       3 | `push`                           | `blib2to3/pgen2/parse.py:386`                          |
-|  2.5% |    2 MiB |       3 | `visit_default`                  | `black/linegen.py:134`                                 |
-|  1.3% | 1.01 MiB |      11 | `<module>`                       | `/venv/lib/python3.11/site-packages/click/parser.py:1` |
-|  1.3% |    1 MiB |       5 | `__init__`                       | `blib2to3/pytree.py:248`                               |
-|  1.3% |    1 MiB |       3 | `_create_fn`                     | `/usr/lib/python3.11/dataclasses.py:413`               |
-|  1.3% |    1 MiB |       1 | `prefix`                         | `blib2to3/pytree.py:480`                               |
-|  1.3% |    1 MiB |       1 | `generate_comments`              | `black/comments.py:52`                                 |
-|  1.3% |    1 MiB |       1 | `debug`                          | `/usr/lib/python3.11/logging/__init__.py:1467`         |
-|  1.3% |    1 MiB |       1 | `__str__`                        | `black/lines.py:490`                                   |
-|  1.3% |    1 MiB |       1 | `generate_tokens`                | `blib2to3/pgen2/tokenize.py:565`                       |
-|  1.3% |    1 MiB |       1 | `__getitem__`                    | `/usr/lib/python3.11/re/_parser.py:162`                |
+|     % |     Size | Allocations | Function                         | Location                                               |
+| ----: | -------: | ----------: | -------------------------------- | ------------------------------------------------------ |
+| 21.9% | 17.2 MiB |      20,789 | `mark`                           | `black/brackets.py:70`                                 |
+| 11.6% | 9.12 MiB |         142 | `parse`                          | `/usr/lib/python3.11/ast.py:33`                        |
+|  9.0% |  7.1 MiB |           4 | `assert_equivalent`              | `black/__init__.py:1524`                               |
+|  8.9% |    7 MiB |           7 | `__new__`                        | `blib2to3/pytree.py:81`                                |
+|  7.8% | 6.14 MiB |         201 | `update_sibling_maps`            | `blib2to3/pytree.py:369`                               |
+|  7.6% |    6 MiB |           6 | `changed`                        | `blib2to3/pytree.py:171`                               |
+|  5.1% |    4 MiB |           4 | `__init__`                       | `<string>:2`                                           |
+|  3.9% | 3.05 MiB |          59 | `_stringify_ast`                 | `black/parsing.py:174`                                 |
+|  3.8% |    3 MiB |           3 | `_stringify_ast_with_new_parent` | `black/parsing.py:166`                                 |
+|  3.8% |    3 MiB |           3 | `push`                           | `blib2to3/pgen2/parse.py:386`                          |
+|  2.5% |    2 MiB |           3 | `visit_default`                  | `black/linegen.py:134`                                 |
+|  1.3% | 1.01 MiB |          11 | `<module>`                       | `/venv/lib/python3.11/site-packages/click/parser.py:1` |
+|  1.3% |    1 MiB |           5 | `__init__`                       | `blib2to3/pytree.py:248`                               |
+|  1.3% |    1 MiB |           3 | `_create_fn`                     | `/usr/lib/python3.11/dataclasses.py:413`               |
+|  1.3% |    1 MiB |           1 | `prefix`                         | `blib2to3/pytree.py:480`                               |
+|  1.3% |    1 MiB |           1 | `generate_comments`              | `black/comments.py:52`                                 |
+|  1.3% |    1 MiB |           1 | `debug`                          | `/usr/lib/python3.11/logging/__init__.py:1467`         |
+|  1.3% |    1 MiB |           1 | `__str__`                        | `black/lines.py:490`                                   |
+|  1.3% |    1 MiB |           1 | `generate_tokens`                | `blib2to3/pgen2/tokenize.py:565`                       |
+|  1.3% |    1 MiB |           1 | `__getitem__`                    | `/usr/lib/python3.11/re/_parser.py:162`                |
 
 #### Categories
 
 ##### Ours
 
-|     % |     Size | Samples | Function                         | Location                         |
-| ----: | -------: | ------: | -------------------------------- | -------------------------------- |
-| 21.9% | 17.2 MiB |  20,789 | `mark`                           | `black/brackets.py:70`           |
-|  9.0% |  7.1 MiB |       4 | `assert_equivalent`              | `black/__init__.py:1524`         |
-|  8.9% |    7 MiB |       7 | `__new__`                        | `blib2to3/pytree.py:81`          |
-|  7.8% | 6.14 MiB |     201 | `update_sibling_maps`            | `blib2to3/pytree.py:369`         |
-|  7.6% |    6 MiB |       6 | `changed`                        | `blib2to3/pytree.py:171`         |
-|  5.1% |    4 MiB |       4 | `__init__`                       | `<string>:2`                     |
-|  3.9% | 3.05 MiB |      59 | `_stringify_ast`                 | `black/parsing.py:174`           |
-|  3.8% |    3 MiB |       3 | `_stringify_ast_with_new_parent` | `black/parsing.py:166`           |
-|  3.8% |    3 MiB |       3 | `push`                           | `blib2to3/pgen2/parse.py:386`    |
-|  2.5% |    2 MiB |       3 | `visit_default`                  | `black/linegen.py:134`           |
-|  1.3% |    1 MiB |       5 | `__init__`                       | `blib2to3/pytree.py:248`         |
-|  1.3% |    1 MiB |       1 | `prefix`                         | `blib2to3/pytree.py:480`         |
-|  1.3% |    1 MiB |       1 | `generate_comments`              | `black/comments.py:52`           |
-|  1.3% |    1 MiB |       1 | `__str__`                        | `black/lines.py:490`             |
-|  1.3% |    1 MiB |       1 | `generate_tokens`                | `blib2to3/pgen2/tokenize.py:565` |
-|  0.3% |  225 KiB |       5 | `_format_str_once`               | `black/__init__.py:1236`         |
-|  0.1% | 57.2 KiB |      65 | `normalize_string_prefix`        | `black/strings.py:143`           |
-|  0.1% | 41.5 KiB |      16 | `copy`                           | `blib2to3/pgen2/grammar.py:131`  |
-| <0.1% |   32 KiB |       1 | `classify`                       | `blib2to3/pgen2/parse.py:336`    |
-| <0.1% | 25.3 KiB |      40 | `make_first`                     | `blib2to3/pgen2/pgen.py:74`      |
+|     % |     Size | Allocations | Function                         | Location                         |
+| ----: | -------: | ----------: | -------------------------------- | -------------------------------- |
+| 21.9% | 17.2 MiB |      20,789 | `mark`                           | `black/brackets.py:70`           |
+|  9.0% |  7.1 MiB |           4 | `assert_equivalent`              | `black/__init__.py:1524`         |
+|  8.9% |    7 MiB |           7 | `__new__`                        | `blib2to3/pytree.py:81`          |
+|  7.8% | 6.14 MiB |         201 | `update_sibling_maps`            | `blib2to3/pytree.py:369`         |
+|  7.6% |    6 MiB |           6 | `changed`                        | `blib2to3/pytree.py:171`         |
+|  5.1% |    4 MiB |           4 | `__init__`                       | `<string>:2`                     |
+|  3.9% | 3.05 MiB |          59 | `_stringify_ast`                 | `black/parsing.py:174`           |
+|  3.8% |    3 MiB |           3 | `_stringify_ast_with_new_parent` | `black/parsing.py:166`           |
+|  3.8% |    3 MiB |           3 | `push`                           | `blib2to3/pgen2/parse.py:386`    |
+|  2.5% |    2 MiB |           3 | `visit_default`                  | `black/linegen.py:134`           |
+|  1.3% |    1 MiB |           5 | `__init__`                       | `blib2to3/pytree.py:248`         |
+|  1.3% |    1 MiB |           1 | `prefix`                         | `blib2to3/pytree.py:480`         |
+|  1.3% |    1 MiB |           1 | `generate_comments`              | `black/comments.py:52`           |
+|  1.3% |    1 MiB |           1 | `__str__`                        | `black/lines.py:490`             |
+|  1.3% |    1 MiB |           1 | `generate_tokens`                | `blib2to3/pgen2/tokenize.py:565` |
+|  0.3% |  225 KiB |           5 | `_format_str_once`               | `black/__init__.py:1236`         |
+|  0.1% | 57.2 KiB |          65 | `normalize_string_prefix`        | `black/strings.py:143`           |
+|  0.1% | 41.5 KiB |          16 | `copy`                           | `blib2to3/pgen2/grammar.py:131`  |
+| <0.1% |   32 KiB |           1 | `classify`                       | `blib2to3/pgen2/parse.py:336`    |
+| <0.1% | 25.3 KiB |          40 | `make_first`                     | `blib2to3/pgen2/pgen.py:74`      |
 
 ##### Standard library
 
-|     % |     Size | Samples | Function            | Location                                          |
-| ----: | -------: | ------: | ------------------- | ------------------------------------------------- |
-| 11.6% | 9.12 MiB |     142 | `parse`             | `/usr/lib/python3.11/ast.py:33`                   |
-|  1.3% |    1 MiB |       3 | `_create_fn`        | `/usr/lib/python3.11/dataclasses.py:413`          |
-|  1.3% |    1 MiB |       1 | `debug`             | `/usr/lib/python3.11/logging/__init__.py:1467`    |
-|  1.3% |    1 MiB |       1 | `__getitem__`       | `/usr/lib/python3.11/re/_parser.py:162`           |
-|  0.7% |  560 KiB |     606 | `_compile_bytecode` | `<frozen importlib._bootstrap_external>:727`      |
-|  0.3% |  222 KiB |       1 | `decode`            | `<frozen codecs>:319`                             |
-|  0.1% | 75.7 KiB |      79 | `__new__`           | `<frozen abc>:105`                                |
-| <0.1% | 24.1 KiB |      27 | `__new__`           | `/usr/lib/python3.11/enum.py:488`                 |
-| <0.1% | 22.6 KiB |      12 | `compile`           | `/usr/lib/python3.11/re/_compiler.py:738`         |
-| <0.1% | 19.8 KiB |      12 | `<module>`          | `/usr/lib/python3.11/tomllib/_parser.py:1`        |
-| <0.1% | 17.4 KiB |      21 | `__new__`           | `/usr/lib/python3.11/typing.py:2891`              |
-| <0.1% |   12 KiB |       3 | `inner`             | `/usr/lib/python3.11/typing.py:338`               |
-| <0.1% |    8 KiB |       4 | `_fill_cache`       | `<frozen importlib._bootstrap_external>:1655`     |
-| <0.1% | 7.97 KiB |       1 | `_parse_sub`        | `/usr/lib/python3.11/re/_parser.py:447`           |
-| <0.1% | 6.73 KiB |       8 | `__setattr__`       | `/usr/lib/python3.11/enum.py:831`                 |
-| <0.1% | 5.63 KiB |       6 | `namedtuple`        | `/usr/lib/python3.11/collections/__init__.py:348` |
-| <0.1% | 5.61 KiB |       3 | `_parse`            | `/usr/lib/python3.11/re/_parser.py:507`           |
-| <0.1% | 5.32 KiB |       2 | `_code`             | `/usr/lib/python3.11/re/_compiler.py:571`         |
-| <0.1% | 4.73 KiB |       6 | `<module>`          | `/usr/lib/python3.11/pkgutil.py:1`                |
-| <0.1% | 2.85 KiB |       1 | `wrap`              | `/usr/lib/python3.11/dataclasses.py:1209`         |
+|     % |     Size | Allocations | Function            | Location                                          |
+| ----: | -------: | ----------: | ------------------- | ------------------------------------------------- |
+| 11.6% | 9.12 MiB |         142 | `parse`             | `/usr/lib/python3.11/ast.py:33`                   |
+|  1.3% |    1 MiB |           3 | `_create_fn`        | `/usr/lib/python3.11/dataclasses.py:413`          |
+|  1.3% |    1 MiB |           1 | `debug`             | `/usr/lib/python3.11/logging/__init__.py:1467`    |
+|  1.3% |    1 MiB |           1 | `__getitem__`       | `/usr/lib/python3.11/re/_parser.py:162`           |
+|  0.7% |  560 KiB |         606 | `_compile_bytecode` | `<frozen importlib._bootstrap_external>:727`      |
+|  0.3% |  222 KiB |           1 | `decode`            | `<frozen codecs>:319`                             |
+|  0.1% | 75.7 KiB |          79 | `__new__`           | `<frozen abc>:105`                                |
+| <0.1% | 24.1 KiB |          27 | `__new__`           | `/usr/lib/python3.11/enum.py:488`                 |
+| <0.1% | 22.6 KiB |          12 | `compile`           | `/usr/lib/python3.11/re/_compiler.py:738`         |
+| <0.1% | 19.8 KiB |          12 | `<module>`          | `/usr/lib/python3.11/tomllib/_parser.py:1`        |
+| <0.1% | 17.4 KiB |          21 | `__new__`           | `/usr/lib/python3.11/typing.py:2891`              |
+| <0.1% |   12 KiB |           3 | `inner`             | `/usr/lib/python3.11/typing.py:338`               |
+| <0.1% |    8 KiB |           4 | `_fill_cache`       | `<frozen importlib._bootstrap_external>:1655`     |
+| <0.1% | 7.97 KiB |           1 | `_parse_sub`        | `/usr/lib/python3.11/re/_parser.py:447`           |
+| <0.1% | 6.73 KiB |           8 | `__setattr__`       | `/usr/lib/python3.11/enum.py:831`                 |
+| <0.1% | 5.63 KiB |           6 | `namedtuple`        | `/usr/lib/python3.11/collections/__init__.py:348` |
+| <0.1% | 5.61 KiB |           3 | `_parse`            | `/usr/lib/python3.11/re/_parser.py:507`           |
+| <0.1% | 5.32 KiB |           2 | `_code`             | `/usr/lib/python3.11/re/_compiler.py:571`         |
+| <0.1% | 4.73 KiB |           6 | `<module>`          | `/usr/lib/python3.11/pkgutil.py:1`                |
+| <0.1% | 2.85 KiB |           1 | `wrap`              | `/usr/lib/python3.11/dataclasses.py:1209`         |
 
 ##### Third-party
 
-|     % |     Size | Samples | Function              | Location                                                                   |
-| ----: | -------: | ------: | --------------------- | -------------------------------------------------------------------------- |
-|  1.3% | 1.01 MiB |      11 | `<module>`            | `/venv/lib/python3.11/site-packages/click/parser.py:1`                     |
-|  0.1% | 44.3 KiB |      31 | `__init__`            | `/venv/lib/python3.11/site-packages/click/core.py:2883`                    |
-|  0.1% |   42 KiB |       7 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                   |
-| <0.1% |   25 KiB |      22 | `<module>`            | `/venv/lib/python3.11/site-packages/click/core.py:1`                       |
-| <0.1% |   15 KiB |      18 | `<module>`            | `/venv/lib/python3.11/site-packages/mypy_extensions.py:1`                  |
-| <0.1% | 13.4 KiB |      15 | `<module>`            | `/venv/lib/python3.11/site-packages/click/exceptions.py:1`                 |
-| <0.1% | 9.61 KiB |       9 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/version.py:1`                |
-| <0.1% | 7.08 KiB |       8 | `<module>`            | `/venv/lib/python3.11/site-packages/click/utils.py:1`                      |
-| <0.1% | 6.48 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/util.py:1`                    |
-| <0.1% | 6.24 KiB |       5 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                |
-| <0.1% |  5.8 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/click/_compat.py:1`                    |
-| <0.1% | 3.82 KiB |       1 | `Specifier`           | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`           |
-| <0.1% | 3.79 KiB |       3 | `new_func`            | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                |
-| <0.1% | 3.72 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`                 |
-| <0.1% | 3.56 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                  |
-| <0.1% | 3.37 KiB |       5 | `handle_parse_result` | `/venv/lib/python3.11/site-packages/click/core.py:2663`                    |
-| <0.1% | 3.19 KiB |       1 | `<module>`            | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                   |
-| <0.1% | 3.19 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`                |
-| <0.1% | 2.81 KiB |       3 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1` |
-| <0.1% | 2.76 KiB |       2 | `<module>`            | `/venv/lib/python3.11/site-packages/click/types.py:1`                      |
+|     % |     Size | Allocations | Function              | Location                                                                   |
+| ----: | -------: | ----------: | --------------------- | -------------------------------------------------------------------------- |
+|  1.3% | 1.01 MiB |          11 | `<module>`            | `/venv/lib/python3.11/site-packages/click/parser.py:1`                     |
+|  0.1% | 44.3 KiB |          31 | `__init__`            | `/venv/lib/python3.11/site-packages/click/core.py:2883`                    |
+|  0.1% |   42 KiB |           7 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                   |
+| <0.1% |   25 KiB |          22 | `<module>`            | `/venv/lib/python3.11/site-packages/click/core.py:1`                       |
+| <0.1% |   15 KiB |          18 | `<module>`            | `/venv/lib/python3.11/site-packages/mypy_extensions.py:1`                  |
+| <0.1% | 13.4 KiB |          15 | `<module>`            | `/venv/lib/python3.11/site-packages/click/exceptions.py:1`                 |
+| <0.1% | 9.61 KiB |           9 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/version.py:1`                |
+| <0.1% | 7.08 KiB |           8 | `<module>`            | `/venv/lib/python3.11/site-packages/click/utils.py:1`                      |
+| <0.1% | 6.48 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/util.py:1`                    |
+| <0.1% | 6.24 KiB |           5 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                |
+| <0.1% |  5.8 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/click/_compat.py:1`                    |
+| <0.1% | 3.82 KiB |           1 | `Specifier`           | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`           |
+| <0.1% | 3.79 KiB |           3 | `new_func`            | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                |
+| <0.1% | 3.72 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`                 |
+| <0.1% | 3.56 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                  |
+| <0.1% | 3.37 KiB |           5 | `handle_parse_result` | `/venv/lib/python3.11/site-packages/click/core.py:2663`                    |
+| <0.1% | 3.19 KiB |           1 | `<module>`            | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                   |
+| <0.1% | 3.19 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`                |
+| <0.1% | 2.81 KiB |           3 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1` |
+| <0.1% | 2.76 KiB |           2 | `<module>`            | `/venv/lib/python3.11/site-packages/click/types.py:1`                      |
 
 #### Lines
 
@@ -120,440 +120,440 @@ Lines ranked by contribution to each function's self size.
 
 ##### `mark` (`black/brackets.py:70`)
 
-|      % |     Size | Samples | Location                |
-| -----: | -------: | ------: | ----------------------- |
-| 100.0% | 17.2 MiB |  20,788 | `black/brackets.py:112` |
-|  <0.1% | 1.49 KiB |       1 | `black/brackets.py:114` |
+|      % |     Size | Allocations | Location                |
+| -----: | -------: | ----------: | ----------------------- |
+| 100.0% | 17.2 MiB |      20,788 | `black/brackets.py:112` |
+|  <0.1% | 1.49 KiB |           1 | `black/brackets.py:114` |
 
 ##### `parse` (`/usr/lib/python3.11/ast.py:33`)
 
-|      % |     Size | Samples | Location                        |
-| -----: | -------: | ------: | ------------------------------- |
-| 100.0% | 9.12 MiB |     142 | `/usr/lib/python3.11/ast.py:50` |
+|      % |     Size | Allocations | Location                        |
+| -----: | -------: | ----------: | ------------------------------- |
+| 100.0% | 9.12 MiB |         142 | `/usr/lib/python3.11/ast.py:50` |
 
 ##### `assert_equivalent` (`black/__init__.py:1524`)
 
-|     % |     Size | Samples | Location                 |
-| ----: | -------: | ------: | ------------------------ |
-| 55.4% | 3.93 MiB |       2 | `black/__init__.py:1547` |
-| 44.6% | 3.17 MiB |       2 | `black/__init__.py:1546` |
+|     % |     Size | Allocations | Location                 |
+| ----: | -------: | ----------: | ------------------------ |
+| 55.4% | 3.93 MiB |           2 | `black/__init__.py:1547` |
+| 44.6% | 3.17 MiB |           2 | `black/__init__.py:1546` |
 
 ##### `__new__` (`blib2to3/pytree.py:81`)
 
-|      % |  Size | Samples | Location                |
-| -----: | ----: | ------: | ----------------------- |
-| 100.0% | 7 MiB |       7 | `blib2to3/pytree.py:84` |
+|      % |  Size | Allocations | Location                |
+| -----: | ----: | ----------: | ----------------------- |
+| 100.0% | 7 MiB |           7 | `blib2to3/pytree.py:84` |
 
 ##### `update_sibling_maps` (`blib2to3/pytree.py:369`)
 
-|     % |     Size | Samples | Location                 |
-| ----: | -------: | ------: | ------------------------ |
-| 82.5% | 5.07 MiB |      98 | `blib2to3/pytree.py:377` |
-| 17.4% | 1.07 MiB |      94 | `blib2to3/pytree.py:376` |
-|  0.1% | 4.99 KiB |       9 | `blib2to3/pytree.py:379` |
+|     % |     Size | Allocations | Location                 |
+| ----: | -------: | ----------: | ------------------------ |
+| 82.5% | 5.07 MiB |          98 | `blib2to3/pytree.py:377` |
+| 17.4% | 1.07 MiB |          94 | `blib2to3/pytree.py:376` |
+|  0.1% | 4.99 KiB |           9 | `blib2to3/pytree.py:379` |
 
 ##### `changed` (`blib2to3/pytree.py:171`)
 
-|     % |  Size | Samples | Location                 |
-| ----: | ----: | ------: | ------------------------ |
-| 83.3% | 5 MiB |       5 | `blib2to3/pytree.py:175` |
-| 16.7% | 1 MiB |       1 | `blib2to3/pytree.py:176` |
+|     % |  Size | Allocations | Location                 |
+| ----: | ----: | ----------: | ------------------------ |
+| 83.3% | 5 MiB |           5 | `blib2to3/pytree.py:175` |
+| 16.7% | 1 MiB |           1 | `blib2to3/pytree.py:176` |
 
 ##### `__init__` (`<string>:2`)
 
-|     % |  Size | Samples | Location     |
-| ----: | ----: | ------: | ------------ |
-| 50.0% | 2 MiB |       2 | `<string>:8` |
-| 25.0% | 1 MiB |       1 | `<string>:5` |
-| 25.0% | 1 MiB |       1 | `<string>:7` |
+|     % |  Size | Allocations | Location     |
+| ----: | ----: | ----------: | ------------ |
+| 50.0% | 2 MiB |           2 | `<string>:8` |
+| 25.0% | 1 MiB |           1 | `<string>:5` |
+| 25.0% | 1 MiB |           1 | `<string>:7` |
 
 ##### `_stringify_ast` (`black/parsing.py:174`)
 
-|     % |     Size | Samples | Location               |
-| ----: | -------: | ------: | ---------------------- |
-| 34.3% | 1.05 MiB |      57 | `black/parsing.py:240` |
-| 32.8% |    1 MiB |       1 | `black/parsing.py:244` |
-| 32.8% |    1 MiB |       1 | `black/parsing.py:197` |
+|     % |     Size | Allocations | Location               |
+| ----: | -------: | ----------: | ---------------------- |
+| 34.3% | 1.05 MiB |          57 | `black/parsing.py:240` |
+| 32.8% |    1 MiB |           1 | `black/parsing.py:244` |
+| 32.8% |    1 MiB |           1 | `black/parsing.py:197` |
 
 ##### `_stringify_ast_with_new_parent` (`black/parsing.py:166`)
 
-|      % |  Size | Samples | Location               |
-| -----: | ----: | ------: | ---------------------- |
-| 100.0% | 3 MiB |       3 | `black/parsing.py:170` |
+|      % |  Size | Allocations | Location               |
+| -----: | ----: | ----------: | ---------------------- |
+| 100.0% | 3 MiB |           3 | `black/parsing.py:170` |
 
 ##### `push` (`blib2to3/pgen2/parse.py:386`)
 
-|      % |  Size | Samples | Location                      |
-| -----: | ----: | ------: | ----------------------------- |
-| 100.0% | 3 MiB |       3 | `blib2to3/pgen2/parse.py:394` |
+|      % |  Size | Allocations | Location                      |
+| -----: | ----: | ----------: | ----------------------------- |
+| 100.0% | 3 MiB |           3 | `blib2to3/pgen2/parse.py:394` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|      % |  Size | Samples | Location               |
-| -----: | ----: | ------: | ---------------------- |
-| 100.0% | 2 MiB |       2 | `black/linegen.py:158` |
-|  <0.1% | 702 B |       1 | `black/linegen.py:144` |
+|      % |  Size | Allocations | Location               |
+| -----: | ----: | ----------: | ---------------------- |
+| 100.0% | 2 MiB |           2 | `black/linegen.py:158` |
+|  <0.1% | 702 B |           1 | `black/linegen.py:144` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`)
 
-|     % |     Size | Samples | Location                                                 |
-| ----: | -------: | ------: | -------------------------------------------------------- |
-| 99.4% |    1 MiB |       3 | `/venv/lib/python3.11/site-packages/click/parser.py:185` |
-|  0.2% | 2.29 KiB |       3 | `/venv/lib/python3.11/site-packages/click/parser.py:224` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:127` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:216` |
-|  0.1% |    768 B |       1 | `/venv/lib/python3.11/site-packages/click/parser.py:51`  |
+|     % |     Size | Allocations | Location                                                 |
+| ----: | -------: | ----------: | -------------------------------------------------------- |
+| 99.4% |    1 MiB |           3 | `/venv/lib/python3.11/site-packages/click/parser.py:185` |
+|  0.2% | 2.29 KiB |           3 | `/venv/lib/python3.11/site-packages/click/parser.py:224` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:127` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:216` |
+|  0.1% |    768 B |           1 | `/venv/lib/python3.11/site-packages/click/parser.py:51`  |
 
 ##### `__init__` (`blib2to3/pytree.py:248`)
 
-|      % |  Size | Samples | Location                 |
-| -----: | ----: | ------: | ------------------------ |
-| 100.0% | 1 MiB |       5 | `blib2to3/pytree.py:266` |
+|      % |  Size | Allocations | Location                 |
+| -----: | ----: | ----------: | ------------------------ |
+| 100.0% | 1 MiB |           5 | `blib2to3/pytree.py:266` |
 
 ##### `_create_fn` (`/usr/lib/python3.11/dataclasses.py:413`)
 
-|      % |  Size | Samples | Location                                 |
-| -----: | ----: | ------: | ---------------------------------------- |
-| 100.0% | 1 MiB |       3 | `/usr/lib/python3.11/dataclasses.py:433` |
+|      % |  Size | Allocations | Location                                 |
+| -----: | ----: | ----------: | ---------------------------------------- |
+| 100.0% | 1 MiB |           3 | `/usr/lib/python3.11/dataclasses.py:433` |
 
 ##### `prefix` (`blib2to3/pytree.py:480`)
 
-|      % |  Size | Samples | Location                 |
-| -----: | ----: | ------: | ------------------------ |
-| 100.0% | 1 MiB |       1 | `blib2to3/pytree.py:482` |
+|      % |  Size | Allocations | Location                 |
+| -----: | ----: | ----------: | ------------------------ |
+| 100.0% | 1 MiB |           1 | `blib2to3/pytree.py:482` |
 
 ##### `generate_comments` (`black/comments.py:52`)
 
-|      % |  Size | Samples | Location               |
-| -----: | ----: | ------: | ---------------------- |
-| 100.0% | 1 MiB |       1 | `black/comments.py:76` |
+|      % |  Size | Allocations | Location               |
+| -----: | ----: | ----------: | ---------------------- |
+| 100.0% | 1 MiB |           1 | `black/comments.py:76` |
 
 ##### `debug` (`/usr/lib/python3.11/logging/__init__.py:1467`)
 
-|      % |  Size | Samples | Location                                       |
-| -----: | ----: | ------: | ---------------------------------------------- |
-| 100.0% | 1 MiB |       1 | `/usr/lib/python3.11/logging/__init__.py:1476` |
+|      % |  Size | Allocations | Location                                       |
+| -----: | ----: | ----------: | ---------------------------------------------- |
+| 100.0% | 1 MiB |           1 | `/usr/lib/python3.11/logging/__init__.py:1476` |
 
 ##### `__str__` (`black/lines.py:490`)
 
-|      % |  Size | Samples | Location             |
-| -----: | ----: | ------: | -------------------- |
-| 100.0% | 1 MiB |       1 | `black/lines.py:500` |
+|      % |  Size | Allocations | Location             |
+| -----: | ----: | ----------: | -------------------- |
+| 100.0% | 1 MiB |           1 | `black/lines.py:500` |
 
 ##### `generate_tokens` (`blib2to3/pgen2/tokenize.py:565`)
 
-|      % |  Size | Samples | Location                         |
-| -----: | ----: | ------: | -------------------------------- |
-| 100.0% | 1 MiB |       1 | `blib2to3/pgen2/tokenize.py:972` |
+|      % |  Size | Allocations | Location                         |
+| -----: | ----: | ----------: | -------------------------------- |
+| 100.0% | 1 MiB |           1 | `blib2to3/pgen2/tokenize.py:972` |
 
 ##### `__getitem__` (`/usr/lib/python3.11/re/_parser.py:162`)
 
-|      % |  Size | Samples | Location                                |
-| -----: | ----: | ------: | --------------------------------------- |
-| 100.0% | 1 MiB |       1 | `/usr/lib/python3.11/re/_parser.py:164` |
+|      % |  Size | Allocations | Location                                |
+| -----: | ----: | ----------: | --------------------------------------- |
+| 100.0% | 1 MiB |           1 | `/usr/lib/python3.11/re/_parser.py:164` |
 
 ##### `_compile_bytecode` (`<frozen importlib._bootstrap_external>:727`)
 
-|      % |    Size | Samples | Location                                     |
-| -----: | ------: | ------: | -------------------------------------------- |
-| 100.0% | 560 KiB |     606 | `<frozen importlib._bootstrap_external>:729` |
+|      % |    Size | Allocations | Location                                     |
+| -----: | ------: | ----------: | -------------------------------------------- |
+| 100.0% | 560 KiB |         606 | `<frozen importlib._bootstrap_external>:729` |
 
 ##### `_format_str_once` (`black/__init__.py:1236`)
 
-|     % |     Size | Samples | Location                 |
-| ----: | -------: | ------: | ------------------------ |
-| 98.6% |  222 KiB |       1 | `black/__init__.py:1287` |
-|  0.5% | 1.07 KiB |       1 | `black/__init__.py:1271` |
-|  0.3% |    800 B |       1 | `black/__init__.py:1239` |
-|  0.3% |    644 B |       1 | `black/__init__.py:1269` |
-|  0.3% |    638 B |       1 | `black/__init__.py:1244` |
+|     % |     Size | Allocations | Location                 |
+| ----: | -------: | ----------: | ------------------------ |
+| 98.6% |  222 KiB |           1 | `black/__init__.py:1287` |
+|  0.5% | 1.07 KiB |           1 | `black/__init__.py:1271` |
+|  0.3% |    800 B |           1 | `black/__init__.py:1239` |
+|  0.3% |    644 B |           1 | `black/__init__.py:1269` |
+|  0.3% |    638 B |           1 | `black/__init__.py:1244` |
 
 ##### `decode` (`<frozen codecs>:319`)
 
-|      % |    Size | Samples | Location              |
-| -----: | ------: | ------: | --------------------- |
-| 100.0% | 222 KiB |       1 | `<frozen codecs>:322` |
+|      % |    Size | Allocations | Location              |
+| -----: | ------: | ----------: | --------------------- |
+| 100.0% | 222 KiB |           1 | `<frozen codecs>:322` |
 
 ##### `__new__` (`<frozen abc>:105`)
 
-|      % |     Size | Samples | Location           |
-| -----: | -------: | ------: | ------------------ |
-| 100.0% | 75.7 KiB |      79 | `<frozen abc>:106` |
+|      % |     Size | Allocations | Location           |
+| -----: | -------: | ----------: | ------------------ |
+| 100.0% | 75.7 KiB |          79 | `<frozen abc>:106` |
 
 ##### `normalize_string_prefix` (`black/strings.py:143`)
 
-|      % |     Size | Samples | Location               |
-| -----: | -------: | ------: | ---------------------- |
-| 100.0% | 57.2 KiB |      65 | `black/strings.py:158` |
+|      % |     Size | Allocations | Location               |
+| -----: | -------: | ----------: | ---------------------- |
+| 100.0% | 57.2 KiB |          65 | `black/strings.py:158` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|     % |   Size | Samples | Location                                                |
-| ----: | -----: | ------: | ------------------------------------------------------- |
-| 97.1% | 43 KiB |      29 | `/venv/lib/python3.11/site-packages/click/core.py:3023` |
-|  1.6% |  704 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2905` |
-|  1.4% |  614 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2907` |
+|     % |   Size | Allocations | Location                                                |
+| ----: | -----: | ----------: | ------------------------------------------------------- |
+| 97.1% | 43 KiB |          29 | `/venv/lib/python3.11/site-packages/click/core.py:3023` |
+|  1.6% |  704 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2905` |
+|  1.4% |  614 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2907` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|     % |     Size | Samples | Location                                                   |
-| ----: | -------: | ------: | ---------------------------------------------------------- |
-| 89.8% | 37.7 KiB |       3 | `/venv/lib/python3.11/site-packages/packaging/tags.py:118` |
-|  3.5% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:322` |
-|  2.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:101` |
-|  2.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:110` |
-|  2.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:93`  |
+|     % |     Size | Allocations | Location                                                   |
+| ----: | -------: | ----------: | ---------------------------------------------------------- |
+| 89.8% | 37.7 KiB |           3 | `/venv/lib/python3.11/site-packages/packaging/tags.py:118` |
+|  3.5% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:322` |
+|  2.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:101` |
+|  2.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:110` |
+|  2.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:93`  |
 
 ##### `copy` (`blib2to3/pgen2/grammar.py:131`)
 
-|     % |     Size | Samples | Location                        |
-| ----: | -------: | ------: | ------------------------------- |
-| 88.2% | 36.6 KiB |      12 | `blib2to3/pgen2/grammar.py:145` |
-|  7.6% | 3.16 KiB |       2 | `blib2to3/pgen2/grammar.py:146` |
-|  4.2% | 1.75 KiB |       2 | `blib2to3/pgen2/grammar.py:147` |
+|     % |     Size | Allocations | Location                        |
+| ----: | -------: | ----------: | ------------------------------- |
+| 88.2% | 36.6 KiB |          12 | `blib2to3/pgen2/grammar.py:145` |
+|  7.6% | 3.16 KiB |           2 | `blib2to3/pgen2/grammar.py:146` |
+|  4.2% | 1.75 KiB |           2 | `blib2to3/pgen2/grammar.py:147` |
 
 ##### `classify` (`blib2to3/pgen2/parse.py:336`)
 
-|      % |   Size | Samples | Location                      |
-| -----: | -----: | ------: | ----------------------------- |
-| 100.0% | 32 KiB |       1 | `blib2to3/pgen2/parse.py:343` |
+|      % |   Size | Allocations | Location                      |
+| -----: | -----: | ----------: | ----------------------------- |
+| 100.0% | 32 KiB |           1 | `blib2to3/pgen2/parse.py:343` |
 
 ##### `make_first` (`blib2to3/pgen2/pgen.py:74`)
 
-|      % |     Size | Samples | Location                    |
-| -----: | -------: | ------: | --------------------------- |
-| 100.0% | 25.3 KiB |      40 | `blib2to3/pgen2/pgen.py:81` |
+|      % |     Size | Allocations | Location                    |
+| -----: | -------: | ----------: | --------------------------- |
+| 100.0% | 25.3 KiB |          40 | `blib2to3/pgen2/pgen.py:81` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 30.4% |  7.6 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:204`  |
-| 19.2% | 4.79 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:956`  |
-| 15.7% | 3.92 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:1587` |
-|  9.5% | 2.37 KiB |       3 | `/venv/lib/python3.11/site-packages/click/core.py:2057` |
-|  6.8% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/core.py:2050` |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 30.4% |  7.6 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:204`  |
+| 19.2% | 4.79 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:956`  |
+| 15.7% | 3.92 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:1587` |
+|  9.5% | 2.37 KiB |           3 | `/venv/lib/python3.11/site-packages/click/core.py:2057` |
+|  6.8% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/core.py:2050` |
 
 ##### `__new__` (`/usr/lib/python3.11/enum.py:488`)
 
-|      % |     Size | Samples | Location                          |
-| -----: | -------: | ------: | --------------------------------- |
-| 100.0% | 24.1 KiB |      27 | `/usr/lib/python3.11/enum.py:554` |
+|      % |     Size | Allocations | Location                          |
+| -----: | -------: | ----------: | --------------------------------- |
+| 100.0% | 24.1 KiB |          27 | `/usr/lib/python3.11/enum.py:554` |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|      % |     Size | Samples | Location                                  |
-| -----: | -------: | ------: | ----------------------------------------- |
-| 100.0% | 22.6 KiB |      12 | `/usr/lib/python3.11/re/_compiler.py:759` |
+|      % |     Size | Allocations | Location                                  |
+| -----: | -------: | ----------: | ----------------------------------------- |
+| 100.0% | 22.6 KiB |          12 | `/usr/lib/python3.11/re/_compiler.py:759` |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/_parser.py:1`)
 
-|     % |  Size | Samples | Location                                    |
-| ----: | ----: | ------: | ------------------------------------------- |
-| 20.2% | 4 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:37` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:38` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:27` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:22` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:26` |
+|     % |  Size | Allocations | Location                                    |
+| ----: | ----: | ----------: | ------------------------------------------- |
+| 20.2% | 4 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:37` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:38` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:27` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:22` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:26` |
 
 ##### `__new__` (`/usr/lib/python3.11/typing.py:2891`)
 
-|      % |     Size | Samples | Location                             |
-| -----: | -------: | ------: | ------------------------------------ |
-| 100.0% | 17.4 KiB |      21 | `/usr/lib/python3.11/typing.py:2909` |
+|      % |     Size | Allocations | Location                             |
+| -----: | -------: | ----------: | ------------------------------------ |
+| 100.0% | 17.4 KiB |          21 | `/usr/lib/python3.11/typing.py:2909` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/mypy_extensions.py:1`)
 
-|     % |     Size | Samples | Location                                                    |
-| ----: | -------: | ------: | ----------------------------------------------------------- |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:205` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:198` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:167` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:154` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:175` |
+|     % |     Size | Allocations | Location                                                    |
+| ----: | -------: | ----------: | ----------------------------------------------------------- |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:205` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:198` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:167` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:154` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:175` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/exceptions.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 18.4% | 2.45 KiB |       3 | `/venv/lib/python3.11/site-packages/click/exceptions.py:114` |
-| 11.5% | 1.53 KiB |       2 | `/venv/lib/python3.11/site-packages/click/exceptions.py:366` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:68`  |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:362` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:342` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 18.4% | 2.45 KiB |           3 | `/venv/lib/python3.11/site-packages/click/exceptions.py:114` |
+| 11.5% | 1.53 KiB |           2 | `/venv/lib/python3.11/site-packages/click/exceptions.py:366` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:68`  |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:362` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:342` |
 
 ##### `inner` (`/usr/lib/python3.11/typing.py:338`)
 
-|      % |   Size | Samples | Location                            |
-| -----: | -----: | ------: | ----------------------------------- |
-| 100.0% | 12 KiB |       3 | `/usr/lib/python3.11/typing.py:341` |
+|      % |   Size | Allocations | Location                            |
+| -----: | -----: | ----------: | ----------------------------------- |
+| 100.0% | 12 KiB |           3 | `/usr/lib/python3.11/typing.py:341` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/version.py:1`)
 
-|     % |     Size | Samples | Location                                                      |
-| ----: | -------: | ------: | ------------------------------------------------------------- |
-| 38.2% | 3.68 KiB |       3 | `/venv/lib/python3.11/site-packages/packaging/version.py:340` |
-| 15.5% | 1.49 KiB |       2 | `/venv/lib/python3.11/site-packages/packaging/version.py:124` |
-| 15.4% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:285` |
-| 11.3% | 1.09 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:228` |
-|  9.8% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:134` |
+|     % |     Size | Allocations | Location                                                      |
+| ----: | -------: | ----------: | ------------------------------------------------------------- |
+| 38.2% | 3.68 KiB |           3 | `/venv/lib/python3.11/site-packages/packaging/version.py:340` |
+| 15.5% | 1.49 KiB |           2 | `/venv/lib/python3.11/site-packages/packaging/version.py:124` |
+| 15.4% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:285` |
+| 11.3% | 1.09 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:228` |
+|  9.8% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:134` |
 
 ##### `_fill_cache` (`<frozen importlib._bootstrap_external>:1655`)
 
-|      % |  Size | Samples | Location                                      |
-| -----: | ----: | ------: | --------------------------------------------- |
-| 100.0% | 8 KiB |       4 | `<frozen importlib._bootstrap_external>:1667` |
+|      % |  Size | Allocations | Location                                      |
+| -----: | ----: | ----------: | --------------------------------------------- |
+| 100.0% | 8 KiB |           4 | `<frozen importlib._bootstrap_external>:1667` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|      % |     Size | Samples | Location                                |
-| -----: | -------: | ------: | --------------------------------------- |
-| 100.0% | 7.97 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:455` |
+|      % |     Size | Allocations | Location                                |
+| -----: | -------: | ----------: | --------------------------------------- |
+| 100.0% | 7.97 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:455` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/utils.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 44.8% | 3.17 KiB |       3 | `/venv/lib/python3.11/site-packages/click/utils.py:522` |
-| 31.4% | 2.22 KiB |       3 | `/venv/lib/python3.11/site-packages/click/utils.py:207` |
-| 23.8% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/utils.py:113` |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 44.8% | 3.17 KiB |           3 | `/venv/lib/python3.11/site-packages/click/utils.py:522` |
+| 31.4% | 2.22 KiB |           3 | `/venv/lib/python3.11/site-packages/click/utils.py:207` |
+| 23.8% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/utils.py:113` |
 
 ##### `__setattr__` (`/usr/lib/python3.11/enum.py:831`)
 
-|      % |     Size | Samples | Location                          |
-| -----: | -------: | ------: | --------------------------------- |
-| 100.0% | 6.73 KiB |       8 | `/usr/lib/python3.11/enum.py:842` |
+|      % |     Size | Allocations | Location                          |
+| -----: | -------: | ----------: | --------------------------------- |
+| 100.0% | 6.73 KiB |           8 | `/usr/lib/python3.11/enum.py:842` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/util.py:1`)
 
-|     % |     Size | Samples | Location                                                  |
-| ----: | -------: | ------: | --------------------------------------------------------- |
-| 22.9% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:254` |
-| 16.9% | 1.09 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:765` |
-| 16.3% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:710` |
-| 15.1% |   1000 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:741` |
-| 14.5% |    960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:604` |
+|     % |     Size | Allocations | Location                                                  |
+| ----: | -------: | ----------: | --------------------------------------------------------- |
+| 22.9% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:254` |
+| 16.9% | 1.09 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:765` |
+| 16.3% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:710` |
+| 15.1% |   1000 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:741` |
+| 14.5% |    960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:604` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|     % |     Size | Samples | Location                                                      |
-| ----: | -------: | ------: | ------------------------------------------------------------- |
-| 23.8% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:681` |
-| 23.0% | 1.43 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:44`  |
-| 19.4% | 1.21 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:63`  |
-| 16.9% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:179` |
-| 16.9% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:236` |
+|     % |     Size | Allocations | Location                                                      |
+| ----: | -------: | ----------: | ------------------------------------------------------------- |
+| 23.8% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:681` |
+| 23.0% | 1.43 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:44`  |
+| 19.4% | 1.21 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:63`  |
+| 16.9% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:179` |
+| 16.9% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:236` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/_compat.py:1`)
 
-|     % |     Size | Samples | Location                                                  |
-| ----: | -------: | ------: | --------------------------------------------------------- |
-| 29.1% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/_compat.py:82`  |
-| 29.1% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/_compat.py:452` |
-| 25.6% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/click/_compat.py:344` |
-| 16.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/_compat.py:56`  |
+|     % |     Size | Allocations | Location                                                  |
+| ----: | -------: | ----------: | --------------------------------------------------------- |
+| 29.1% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/_compat.py:82`  |
+| 29.1% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/_compat.py:452` |
+| 25.6% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/click/_compat.py:344` |
+| 16.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/_compat.py:56`  |
 
 ##### `namedtuple` (`/usr/lib/python3.11/collections/__init__.py:348`)
 
-|      % |     Size | Samples | Location                                          |
-| -----: | -------: | ------: | ------------------------------------------------- |
-| 100.0% | 5.63 KiB |       6 | `/usr/lib/python3.11/collections/__init__.py:501` |
+|      % |     Size | Allocations | Location                                          |
+| -----: | -------: | ----------: | ------------------------------------------------- |
+| 100.0% | 5.63 KiB |           6 | `/usr/lib/python3.11/collections/__init__.py:501` |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|     % |     Size | Samples | Location                                |
-| ----: | -------: | ------: | --------------------------------------- |
-| 43.4% | 2.43 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:539` |
-| 33.9% |  1.9 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:568` |
-| 22.7% | 1.28 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:838` |
+|     % |     Size | Allocations | Location                                |
+| ----: | -------: | ----------: | --------------------------------------- |
+| 43.4% | 2.43 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:539` |
+| 33.9% |  1.9 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:568` |
+| 22.7% | 1.28 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:838` |
 
 ##### `_code` (`/usr/lib/python3.11/re/_compiler.py:571`)
 
-|     % |     Size | Samples | Location                                  |
-| ----: | -------: | ------: | ----------------------------------------- |
-| 81.6% | 4.34 KiB |       1 | `/usr/lib/python3.11/re/_compiler.py:580` |
-| 18.4% |   1002 B |       1 | `/usr/lib/python3.11/re/_compiler.py:577` |
+|     % |     Size | Allocations | Location                                  |
+| ----: | -------: | ----------: | ----------------------------------------- |
+| 81.6% | 4.34 KiB |           1 | `/usr/lib/python3.11/re/_compiler.py:580` |
+| 18.4% |   1002 B |           1 | `/usr/lib/python3.11/re/_compiler.py:577` |
 
 ##### `<module>` (`/usr/lib/python3.11/pkgutil.py:1`)
 
-|     % |     Size | Samples | Location                             |
-| ----: | -------: | ------: | ------------------------------------ |
-| 35.7% | 1.69 KiB |       2 | `/usr/lib/python3.11/pkgutil.py:194` |
-| 35.7% | 1.69 KiB |       2 | `/usr/lib/python3.11/pkgutil.py:269` |
-| 15.9% |    768 B |       1 | `/usr/lib/python3.11/pkgutil.py:137` |
-| 12.8% |    620 B |       1 | `/usr/lib/python3.11/pkgutil.py:184` |
+|     % |     Size | Allocations | Location                             |
+| ----: | -------: | ----------: | ------------------------------------ |
+| 35.7% | 1.69 KiB |           2 | `/usr/lib/python3.11/pkgutil.py:194` |
+| 35.7% | 1.69 KiB |           2 | `/usr/lib/python3.11/pkgutil.py:269` |
+| 15.9% |    768 B |           1 | `/usr/lib/python3.11/pkgutil.py:137` |
+| 12.8% |    620 B |           1 | `/usr/lib/python3.11/pkgutil.py:184` |
 
 ##### `Specifier` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`)
 
-|      % |     Size | Samples | Location                                                         |
-| -----: | -------: | ------: | ---------------------------------------------------------------- |
-| 100.0% | 3.82 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:340` |
+|      % |     Size | Allocations | Location                                                         |
+| -----: | -------: | ----------: | ---------------------------------------------------------------- |
+| 100.0% | 3.82 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:340` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Location                                                    |
-| -----: | -------: | ------: | ----------------------------------------------------------- |
-| 100.0% | 3.79 KiB |       3 | `/venv/lib/python3.11/site-packages/click/decorators.py:34` |
+|      % |     Size | Allocations | Location                                                    |
+| -----: | -------: | ----------: | ----------------------------------------------------------- |
+| 100.0% | 3.79 KiB |           3 | `/venv/lib/python3.11/site-packages/click/decorators.py:34` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 46.4% | 1.73 KiB |       2 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:29`  |
-| 27.3% | 1.02 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:90`  |
-| 26.3% |   1000 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:245` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 46.4% | 1.73 KiB |           2 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:29`  |
+| 27.3% | 1.02 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:90`  |
+| 26.3% |   1000 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:245` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|     % |  Size | Samples | Location                                                   |
-| ----: | ----: | ------: | ---------------------------------------------------------- |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:62` |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:46` |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:54` |
-| 21.1% | 768 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:27` |
+|     % |  Size | Allocations | Location                                                   |
+| ----: | ----: | ----------: | ---------------------------------------------------------- |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:62` |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:46` |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:54` |
+| 21.1% | 768 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:27` |
 
 ##### `handle_parse_result` (`/venv/lib/python3.11/site-packages/click/core.py:2663`)
 
-|     % |    Size | Samples | Location                                                |
-| ----: | ------: | ------: | ------------------------------------------------------- |
-| 38.5% | 1.3 KiB |       2 | `/venv/lib/python3.11/site-packages/click/core.py:2686` |
-| 22.3% |   768 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2740` |
-| 22.3% |   768 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2739` |
-| 17.0% |   586 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2711` |
+|     % |    Size | Allocations | Location                                                |
+| ----: | ------: | ----------: | ------------------------------------------------------- |
+| 38.5% | 1.3 KiB |           2 | `/venv/lib/python3.11/site-packages/click/core.py:2686` |
+| 22.3% |   768 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2740` |
+| 22.3% |   768 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2739` |
+| 17.0% |   586 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2711` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|      % |     Size | Samples | Location                                                  |
-| -----: | -------: | ------: | --------------------------------------------------------- |
-| 100.0% | 3.19 KiB |       1 | `/venv/lib/python3.11/site-packages/click/__init__.py:74` |
+|      % |     Size | Allocations | Location                                                  |
+| -----: | -------: | ----------: | --------------------------------------------------------- |
+| 100.0% | 3.19 KiB |           1 | `/venv/lib/python3.11/site-packages/click/__init__.py:74` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 76.5% | 2.44 KiB |       3 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:55` |
-| 23.5% |    768 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:14` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 76.5% | 2.44 KiB |           3 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:55` |
+| 23.5% |    768 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:14` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|      % |     Size | Samples | Location                                  |
-| -----: | -------: | ------: | ----------------------------------------- |
-| 100.0% | 2.85 KiB |       1 | `/usr/lib/python3.11/dataclasses.py:1210` |
+|      % |     Size | Allocations | Location                                  |
+| -----: | -------: | ----------: | ----------------------------------------- |
+| 100.0% | 2.85 KiB |           1 | `/usr/lib/python3.11/dataclasses.py:1210` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1`)
 
-|     % |  Size | Samples | Location                                                                     |
-| ----: | ----: | ------: | ---------------------------------------------------------------------------- |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:22`  |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:205` |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:197` |
+|     % |  Size | Allocations | Location                                                                     |
+| ----: | ----: | ----------: | ---------------------------------------------------------------------------- |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:22`  |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:205` |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:197` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 53.7% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/click/types.py:464` |
-| 46.3% | 1.28 KiB |       1 | `/venv/lib/python3.11/site-packages/click/types.py:37`  |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 53.7% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/click/types.py:464` |
+| 46.3% | 1.28 KiB |           1 | `/venv/lib/python3.11/site-packages/click/types.py:37`  |
 
 #### Callers
 
@@ -561,485 +561,485 @@ Callers ranked by contribution to each function's self size. Inlining can make c
 
 ##### `mark` (`black/brackets.py:70`)
 
-|      % |     Size | Samples | Caller   | Location            |
-| -----: | -------: | ------: | -------- | ------------------- |
-| 100.0% | 17.2 MiB |  20,789 | `append` | `black/lines.py:63` |
+|      % |     Size | Allocations | Caller   | Location            |
+| -----: | -------: | ----------: | -------- | ------------------- |
+| 100.0% | 17.2 MiB |      20,789 | `append` | `black/lines.py:63` |
 
 ##### `parse` (`/usr/lib/python3.11/ast.py:33`)
 
-|      % |     Size | Samples | Caller                  | Location               |
-| -----: | -------: | ------: | ----------------------- | ---------------------- |
-| 100.0% | 9.12 MiB |     142 | `_parse_single_version` | `black/parsing.py:117` |
+|      % |     Size | Allocations | Caller                  | Location               |
+| -----: | -------: | ----------: | ----------------------- | ---------------------- |
+| 100.0% | 9.12 MiB |         142 | `_parse_single_version` | `black/parsing.py:117` |
 
 ##### `assert_equivalent` (`black/__init__.py:1524`)
 
-|      % |    Size | Samples | Caller                            | Location                 |
-| -----: | ------: | ------: | --------------------------------- | ------------------------ |
-| 100.0% | 7.1 MiB |       4 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+|      % |    Size | Allocations | Caller                            | Location                 |
+| -----: | ------: | ----------: | --------------------------------- | ------------------------ |
+| 100.0% | 7.1 MiB |           4 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
 
 ##### `__new__` (`blib2to3/pytree.py:81`)
 
-|     % |  Size | Samples | Caller    | Location                 |
-| ----: | ----: | ------: | --------- | ------------------------ |
-| 85.7% | 6 MiB |       6 | `convert` | `blib2to3/pytree.py:486` |
-| 14.3% | 1 MiB |       1 | `clone`   | `blib2to3/pytree.py:452` |
+|     % |  Size | Allocations | Caller    | Location                 |
+| ----: | ----: | ----------: | --------- | ------------------------ |
+| 85.7% | 6 MiB |           6 | `convert` | `blib2to3/pytree.py:486` |
+| 14.3% | 1 MiB |           1 | `clone`   | `blib2to3/pytree.py:452` |
 
 ##### `update_sibling_maps` (`blib2to3/pytree.py:369`)
 
-|      % |     Size | Samples | Caller         | Location                 |
-| -----: | -------: | ------: | -------------- | ------------------------ |
-| 100.0% | 6.14 MiB |     201 | `prev_sibling` | `blib2to3/pytree.py:207` |
+|      % |     Size | Allocations | Caller         | Location                 |
+| -----: | -------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 6.14 MiB |         201 | `prev_sibling` | `blib2to3/pytree.py:207` |
 
 ##### `changed` (`blib2to3/pytree.py:171`)
 
-|     % |  Size | Samples | Caller    | Location                 |
-| ----: | ----: | ------: | --------- | ------------------------ |
-| 83.3% | 5 MiB |       5 | `changed` | `blib2to3/pytree.py:171` |
-| 16.7% | 1 MiB |       1 | `prefix`  | `blib2to3/pytree.py:480` |
+|     % |  Size | Allocations | Caller    | Location                 |
+| ----: | ----: | ----------: | --------- | ------------------------ |
+| 83.3% | 5 MiB |           5 | `changed` | `blib2to3/pytree.py:171` |
+| 16.7% | 1 MiB |           1 | `prefix`  | `blib2to3/pytree.py:480` |
 
 ##### `__init__` (`<string>:2`)
 
-|     % |  Size | Samples | Caller            | Location                |
-| ----: | ----: | ------: | ----------------- | ----------------------- |
-| 75.0% | 3 MiB |       3 | `__init__`        | `<string>:2`            |
-| 25.0% | 1 MiB |       1 | `delimiter_split` | `black/linegen.py:1203` |
+|     % |  Size | Allocations | Caller            | Location                |
+| ----: | ----: | ----------: | ----------------- | ----------------------- |
+| 75.0% | 3 MiB |           3 | `__init__`        | `<string>:2`            |
+| 25.0% | 1 MiB |           1 | `delimiter_split` | `black/linegen.py:1203` |
 
 ##### `_stringify_ast` (`black/parsing.py:174`)
 
-|      % |     Size | Samples | Caller                           | Location               |
-| -----: | -------: | ------: | -------------------------------- | ---------------------- |
-| 100.0% | 3.05 MiB |      59 | `_stringify_ast_with_new_parent` | `black/parsing.py:166` |
+|      % |     Size | Allocations | Caller                           | Location               |
+| -----: | -------: | ----------: | -------------------------------- | ---------------------- |
+| 100.0% | 3.05 MiB |          59 | `_stringify_ast_with_new_parent` | `black/parsing.py:166` |
 
 ##### `_stringify_ast_with_new_parent` (`black/parsing.py:166`)
 
-|      % |  Size | Samples | Caller           | Location               |
-| -----: | ----: | ------: | ---------------- | ---------------------- |
-| 100.0% | 3 MiB |       3 | `_stringify_ast` | `black/parsing.py:174` |
+|      % |  Size | Allocations | Caller           | Location               |
+| -----: | ----: | ----------: | ---------------- | ---------------------- |
+| 100.0% | 3 MiB |           3 | `_stringify_ast` | `black/parsing.py:174` |
 
 ##### `push` (`blib2to3/pgen2/parse.py:386`)
 
-|      % |  Size | Samples | Caller      | Location                      |
-| -----: | ----: | ------: | ----------- | ----------------------------- |
-| 100.0% | 3 MiB |       3 | `_addtoken` | `blib2to3/pgen2/parse.py:290` |
+|      % |  Size | Allocations | Caller      | Location                      |
+| -----: | ----: | ----------: | ----------- | ----------------------------- |
+| 100.0% | 3 MiB |           3 | `_addtoken` | `blib2to3/pgen2/parse.py:290` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|      % |  Size | Samples | Caller         | Location               |
-| -----: | ----: | ------: | -------------- | ---------------------- |
-| 100.0% | 2 MiB |       2 | `visit`        | `black/nodes.py:163`   |
-|  <0.1% | 702 B |       1 | `visit_STRING` | `black/linegen.py:413` |
+|      % |  Size | Allocations | Caller         | Location               |
+| -----: | ----: | ----------: | -------------- | ---------------------- |
+| 100.0% | 2 MiB |           2 | `visit`        | `black/nodes.py:163`   |
+|  <0.1% | 702 B |           1 | `visit_STRING` | `black/linegen.py:413` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 1.01 MiB |      11 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 1.01 MiB |          11 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__init__` (`blib2to3/pytree.py:248`)
 
-|      % |  Size | Samples | Caller    | Location                 |
-| -----: | ----: | ------: | --------- | ------------------------ |
-| 100.0% | 1 MiB |       5 | `convert` | `blib2to3/pytree.py:486` |
+|      % |  Size | Allocations | Caller    | Location                 |
+| -----: | ----: | ----------: | --------- | ------------------------ |
+| 100.0% | 1 MiB |           5 | `convert` | `blib2to3/pytree.py:486` |
 
 ##### `_create_fn` (`/usr/lib/python3.11/dataclasses.py:413`)
 
-|     % |  Size | Samples | Caller     | Location                                 |
-| ----: | ----: | ------: | ---------- | ---------------------------------------- |
-| 99.9% | 1 MiB |       1 | `_init_fn` | `/usr/lib/python3.11/dataclasses.py:528` |
-| <0.1% | 341 B |       1 | `_cmp_fn`  | `/usr/lib/python3.11/dataclasses.py:624` |
-| <0.1% | 336 B |       1 | `_repr_fn` | `/usr/lib/python3.11/dataclasses.py:588` |
+|     % |  Size | Allocations | Caller     | Location                                 |
+| ----: | ----: | ----------: | ---------- | ---------------------------------------- |
+| 99.9% | 1 MiB |           1 | `_init_fn` | `/usr/lib/python3.11/dataclasses.py:528` |
+| <0.1% | 341 B |           1 | `_cmp_fn`  | `/usr/lib/python3.11/dataclasses.py:624` |
+| <0.1% | 336 B |           1 | `_repr_fn` | `/usr/lib/python3.11/dataclasses.py:588` |
 
 ##### `prefix` (`blib2to3/pytree.py:480`)
 
-|      % |  Size | Samples | Caller   | Location            |
-| -----: | ----: | ------: | -------- | ------------------- |
-| 100.0% | 1 MiB |       1 | `append` | `black/lines.py:63` |
+|      % |  Size | Allocations | Caller   | Location            |
+| -----: | ----: | ----------: | -------- | ------------------- |
+| 100.0% | 1 MiB |           1 | `append` | `black/lines.py:63` |
 
 ##### `generate_comments` (`black/comments.py:52`)
 
-|      % |  Size | Samples | Caller          | Location               |
-| -----: | ----: | ------: | --------------- | ---------------------- |
-| 100.0% | 1 MiB |       1 | `visit_default` | `black/linegen.py:134` |
+|      % |  Size | Allocations | Caller          | Location               |
+| -----: | ----: | ----------: | --------------- | ---------------------- |
+| 100.0% | 1 MiB |           1 | `visit_default` | `black/linegen.py:134` |
 
 ##### `debug` (`/usr/lib/python3.11/logging/__init__.py:1467`)
 
-|      % |  Size | Samples | Caller         | Location                       |
-| -----: | ----: | ------: | -------------- | ------------------------------ |
-| 100.0% | 1 MiB |       1 | `parse_tokens` | `blib2to3/pgen2/driver.py:114` |
+|      % |  Size | Allocations | Caller         | Location                       |
+| -----: | ----: | ----------: | -------------- | ------------------------------ |
+| 100.0% | 1 MiB |           1 | `parse_tokens` | `blib2to3/pgen2/driver.py:114` |
 
 ##### `__str__` (`black/lines.py:490`)
 
-|      % |  Size | Samples | Caller           | Location              |
-| -----: | ----: | ------: | ---------------- | --------------------- |
-| 100.0% | 1 MiB |       1 | `line_to_string` | `black/lines.py:1073` |
+|      % |  Size | Allocations | Caller           | Location              |
+| -----: | ----: | ----------: | ---------------- | --------------------- |
+| 100.0% | 1 MiB |           1 | `line_to_string` | `black/lines.py:1073` |
 
 ##### `generate_tokens` (`blib2to3/pgen2/tokenize.py:565`)
 
-|      % |  Size | Samples | Caller     | Location                      |
-| -----: | ----: | ------: | ---------- | ----------------------------- |
-| 100.0% | 1 MiB |       1 | `__next__` | `blib2to3/pgen2/driver.py:80` |
+|      % |  Size | Allocations | Caller     | Location                      |
+| -----: | ----: | ----------: | ---------- | ----------------------------- |
+| 100.0% | 1 MiB |           1 | `__next__` | `blib2to3/pgen2/driver.py:80` |
 
 ##### `__getitem__` (`/usr/lib/python3.11/re/_parser.py:162`)
 
-|      % |  Size | Samples | Caller   | Location                                |
-| -----: | ----: | ------: | -------- | --------------------------------------- |
-| 100.0% | 1 MiB |       1 | `_parse` | `/usr/lib/python3.11/re/_parser.py:507` |
+|      % |  Size | Allocations | Caller   | Location                                |
+| -----: | ----: | ----------: | -------- | --------------------------------------- |
+| 100.0% | 1 MiB |           1 | `_parse` | `/usr/lib/python3.11/re/_parser.py:507` |
 
 ##### `_compile_bytecode` (`<frozen importlib._bootstrap_external>:727`)
 
-|      % |    Size | Samples | Caller     | Location                                      |
-| -----: | ------: | ------: | ---------- | --------------------------------------------- |
-| 100.0% | 560 KiB |     606 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
+|      % |    Size | Allocations | Caller     | Location                                      |
+| -----: | ------: | ----------: | ---------- | --------------------------------------------- |
+| 100.0% | 560 KiB |         606 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `_format_str_once` (`black/__init__.py:1236`)
 
-|      % |    Size | Samples | Caller       | Location                 |
-| -----: | ------: | ------: | ------------ | ------------------------ |
-| 100.0% | 225 KiB |       5 | `format_str` | `black/__init__.py:1189` |
+|      % |    Size | Allocations | Caller       | Location                 |
+| -----: | ------: | ----------: | ------------ | ------------------------ |
+| 100.0% | 225 KiB |           5 | `format_str` | `black/__init__.py:1189` |
 
 ##### `decode` (`<frozen codecs>:319`)
 
-|      % |    Size | Samples | Caller         | Location                 |
-| -----: | ------: | ------: | -------------- | ------------------------ |
-| 100.0% | 222 KiB |       1 | `decode_bytes` | `black/__init__.py:1290` |
+|      % |    Size | Allocations | Caller         | Location                 |
+| -----: | ------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 222 KiB |           1 | `decode_bytes` | `black/__init__.py:1290` |
 
 ##### `__new__` (`<frozen abc>:105`)
 
-|     % |     Size | Samples | Caller     | Location                                                       |
-| ----: | -------: | ------: | ---------- | -------------------------------------------------------------- |
-| 50.5% | 38.2 KiB |      45 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`          |
-| 23.1% | 17.5 KiB |      18 | `<module>` | `black/trans.py:1`                                             |
-| 18.3% | 13.9 KiB |       9 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`           |
-|  8.0% | 6.07 KiB |       7 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
+|     % |     Size | Allocations | Caller     | Location                                                       |
+| ----: | -------: | ----------: | ---------- | -------------------------------------------------------------- |
+| 50.5% | 38.2 KiB |          45 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`          |
+| 23.1% | 17.5 KiB |          18 | `<module>` | `black/trans.py:1`                                             |
+| 18.3% | 13.9 KiB |           9 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`           |
+|  8.0% | 6.07 KiB |           7 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
 
 ##### `normalize_string_prefix` (`black/strings.py:143`)
 
-|      % |     Size | Samples | Caller         | Location               |
-| -----: | -------: | ------: | -------------- | ---------------------- |
-| 100.0% | 57.2 KiB |      65 | `visit_STRING` | `black/linegen.py:413` |
+|      % |     Size | Allocations | Caller         | Location               |
+| -----: | -------: | ----------: | -------------- | ---------------------- |
+| 100.0% | 57.2 KiB |          65 | `visit_STRING` | `black/linegen.py:413` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|      % |     Size | Samples | Caller      | Location                                                     |
-| -----: | -------: | ------: | ----------- | ------------------------------------------------------------ |
-| 100.0% | 44.3 KiB |      31 | `decorator` | `/venv/lib/python3.11/site-packages/click/decorators.py:373` |
+|      % |     Size | Allocations | Caller      | Location                                                     |
+| -----: | -------: | ----------: | ----------- | ------------------------------------------------------------ |
+| 100.0% | 44.3 KiB |          31 | `decorator` | `/venv/lib/python3.11/site-packages/click/decorators.py:373` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 42 KiB |       7 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 42 KiB |           7 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `copy` (`blib2to3/pgen2/grammar.py:131`)
 
-|      % |     Size | Samples | Caller       | Location                 |
-| -----: | -------: | ------: | ------------ | ------------------------ |
-| 100.0% | 41.5 KiB |      16 | `initialize` | `blib2to3/pygram.py:165` |
+|      % |     Size | Allocations | Caller       | Location                 |
+| -----: | -------: | ----------: | ------------ | ------------------------ |
+| 100.0% | 41.5 KiB |          16 | `initialize` | `blib2to3/pygram.py:165` |
 
 ##### `classify` (`blib2to3/pgen2/parse.py:336`)
 
-|      % |   Size | Samples | Caller     | Location                      |
-| -----: | -----: | ------: | ---------- | ----------------------------- |
-| 100.0% | 32 KiB |       1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
+|      % |   Size | Allocations | Caller     | Location                      |
+| -----: | -----: | ----------: | ---------- | ----------------------------- |
+| 100.0% | 32 KiB |           1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
 
 ##### `make_first` (`blib2to3/pgen2/pgen.py:74`)
 
-|      % |     Size | Samples | Caller         | Location                    |
-| -----: | -------: | ------: | -------------- | --------------------------- |
-| 100.0% | 25.3 KiB |      40 | `make_grammar` | `blib2to3/pgen2/pgen.py:49` |
+|      % |     Size | Allocations | Caller         | Location                    |
+| -----: | -------: | ----------: | -------------- | --------------------------- |
+| 100.0% | 25.3 KiB |          40 | `make_grammar` | `blib2to3/pgen2/pgen.py:49` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 25 KiB |      22 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 25 KiB |          22 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__new__` (`/usr/lib/python3.11/enum.py:488`)
 
-|     % |     Size | Samples | Caller     | Location                                                     |
-| ----: | -------: | ------: | ---------- | ------------------------------------------------------------ |
-| 31.7% | 7.64 KiB |       9 | `<module>` | `black/mode.py:1`                                            |
-| 16.2% | 3.89 KiB |       4 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/_elffile.py:1` |
-| 13.7% |  3.3 KiB |       3 | `<module>` | `/venv/lib/python3.11/site-packages/click/_utils.py:1`       |
-| 10.1% | 2.44 KiB |       3 | `<module>` | `black/__init__.py:1`                                        |
-|  7.2% | 1.74 KiB |       2 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`         |
+|     % |     Size | Allocations | Caller     | Location                                                     |
+| ----: | -------: | ----------: | ---------- | ------------------------------------------------------------ |
+| 31.7% | 7.64 KiB |           9 | `<module>` | `black/mode.py:1`                                            |
+| 16.2% | 3.89 KiB |           4 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/_elffile.py:1` |
+| 13.7% |  3.3 KiB |           3 | `<module>` | `/venv/lib/python3.11/site-packages/click/_utils.py:1`       |
+| 10.1% | 2.44 KiB |           3 | `<module>` | `black/__init__.py:1`                                        |
+|  7.2% | 1.74 KiB |           2 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`         |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|      % |     Size | Samples | Caller     | Location                                 |
-| -----: | -------: | ------: | ---------- | ---------------------------------------- |
-| 100.0% | 22.6 KiB |      12 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
+|      % |     Size | Allocations | Caller     | Location                                 |
+| -----: | -------: | ----------: | ---------- | ---------------------------------------- |
+| 100.0% | 22.6 KiB |          12 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/_parser.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 19.8 KiB |      12 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 19.8 KiB |          12 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__new__` (`/usr/lib/python3.11/typing.py:2891`)
 
-|     % |     Size | Samples | Caller     | Location                                                    |
-| ----: | -------: | ------: | ---------- | ----------------------------------------------------------- |
-| 90.3% | 15.7 KiB |      19 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`       |
-|  9.7% | 1.69 KiB |       2 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/version.py:1` |
+|     % |     Size | Allocations | Caller     | Location                                                    |
+| ----: | -------: | ----------: | ---------- | ----------------------------------------------------------- |
+| 90.3% | 15.7 KiB |          19 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`       |
+|  9.7% | 1.69 KiB |           2 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/version.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/mypy_extensions.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 15 KiB |      18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 15 KiB |          18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/exceptions.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 13.4 KiB |      15 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 13.4 KiB |          15 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `inner` (`/usr/lib/python3.11/typing.py:338`)
 
-|     % |     Size | Samples | Caller        | Location                                              |
-| ----: | -------: | ------: | ------------- | ----------------------------------------------------- |
-| 75.3% | 9.02 KiB |       1 | `Line`        | `black/lines.py:49`                                   |
-| 17.9% | 2.15 KiB |       1 | `__getitem__` | `/usr/lib/python3.11/typing.py:467`                   |
-|  6.7% |    826 B |       1 | `<module>`    | `/venv/lib/python3.11/site-packages/click/types.py:1` |
+|     % |     Size | Allocations | Caller        | Location                                              |
+| ----: | -------: | ----------: | ------------- | ----------------------------------------------------- |
+| 75.3% | 9.02 KiB |           1 | `Line`        | `black/lines.py:49`                                   |
+| 17.9% | 2.15 KiB |           1 | `__getitem__` | `/usr/lib/python3.11/typing.py:467`                   |
+|  6.7% |    826 B |           1 | `<module>`    | `/venv/lib/python3.11/site-packages/click/types.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/version.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 9.61 KiB |       9 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 9.61 KiB |           9 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `_fill_cache` (`<frozen importlib._bootstrap_external>:1655`)
 
-|      % |  Size | Samples | Caller      | Location                                      |
-| -----: | ----: | ------: | ----------- | --------------------------------------------- |
-| 100.0% | 8 KiB |       4 | `find_spec` | `<frozen importlib._bootstrap_external>:1604` |
+|      % |  Size | Allocations | Caller      | Location                                      |
+| -----: | ----: | ----------: | ----------- | --------------------------------------------- |
+| 100.0% | 8 KiB |           4 | `find_spec` | `<frozen importlib._bootstrap_external>:1604` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|      % |     Size | Samples | Caller  | Location                                |
-| -----: | -------: | ------: | ------- | --------------------------------------- |
-| 100.0% | 7.97 KiB |       1 | `parse` | `/usr/lib/python3.11/re/_parser.py:970` |
+|      % |     Size | Allocations | Caller  | Location                                |
+| -----: | -------: | ----------: | ------- | --------------------------------------- |
+| 100.0% | 7.97 KiB |           1 | `parse` | `/usr/lib/python3.11/re/_parser.py:970` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/utils.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 7.08 KiB |       8 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 7.08 KiB |           8 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__setattr__` (`/usr/lib/python3.11/enum.py:831`)
 
-|     % |     Size | Samples | Caller         | Location                          |
-| ----: | -------: | ------: | -------------- | --------------------------------- |
-| 66.6% | 4.48 KiB |       5 | `__set_name__` | `/usr/lib/python3.11/enum.py:237` |
-| 33.4% | 2.25 KiB |       3 | `__new__`      | `/usr/lib/python3.11/enum.py:488` |
+|     % |     Size | Allocations | Caller         | Location                          |
+| ----: | -------: | ----------: | -------------- | --------------------------------- |
+| 66.6% | 4.48 KiB |           5 | `__set_name__` | `/usr/lib/python3.11/enum.py:237` |
+| 33.4% | 2.25 KiB |           3 | `__new__`      | `/usr/lib/python3.11/enum.py:488` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/util.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 6.48 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 6.48 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 6.24 KiB |       5 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 6.24 KiB |           5 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/_compat.py:1`)
 
-|      % |    Size | Samples | Caller                      | Location                            |
-| -----: | ------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 5.8 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |    Size | Allocations | Caller                      | Location                            |
+| -----: | ------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 5.8 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `namedtuple` (`/usr/lib/python3.11/collections/__init__.py:348`)
 
-|     % |     Size | Samples | Caller          | Location                             |
-| ----: | -------: | ------: | --------------- | ------------------------------------ |
-| 83.3% | 4.69 KiB |       5 | `_make_nmtuple` | `/usr/lib/python3.11/typing.py:2795` |
-| 16.7% |    960 B |       1 | `<module>`      | `/usr/lib/python3.11/pkgutil.py:1`   |
+|     % |     Size | Allocations | Caller          | Location                             |
+| ----: | -------: | ----------: | --------------- | ------------------------------------ |
+| 83.3% | 4.69 KiB |           5 | `_make_nmtuple` | `/usr/lib/python3.11/typing.py:2795` |
+| 16.7% |    960 B |           1 | `<module>`      | `/usr/lib/python3.11/pkgutil.py:1`   |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|      % |     Size | Samples | Caller       | Location                                |
-| -----: | -------: | ------: | ------------ | --------------------------------------- |
-| 100.0% | 5.61 KiB |       3 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
+|      % |     Size | Allocations | Caller       | Location                                |
+| -----: | -------: | ----------: | ------------ | --------------------------------------- |
+| 100.0% | 5.61 KiB |           3 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
 
 ##### `_code` (`/usr/lib/python3.11/re/_compiler.py:571`)
 
-|      % |     Size | Samples | Caller    | Location                                  |
-| -----: | -------: | ------: | --------- | ----------------------------------------- |
-| 100.0% | 5.32 KiB |       2 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
+|      % |     Size | Allocations | Caller    | Location                                  |
+| -----: | -------: | ----------: | --------- | ----------------------------------------- |
+| 100.0% | 5.32 KiB |           2 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
 
 ##### `<module>` (`/usr/lib/python3.11/pkgutil.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 4.73 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 4.73 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `Specifier` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`)
 
-|      % |     Size | Samples | Caller     | Location                                                       |
-| -----: | -------: | ------: | ---------- | -------------------------------------------------------------- |
-| 100.0% | 3.82 KiB |       1 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
+|      % |     Size | Allocations | Caller     | Location                                                       |
+| -----: | -------: | ----------: | ---------- | -------------------------------------------------------------- |
+| 100.0% | 3.82 KiB |           1 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Caller   | Location                                               |
-| -----: | -------: | ------: | -------- | ------------------------------------------------------ |
-| 100.0% | 3.79 KiB |       3 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
+|      % |     Size | Allocations | Caller   | Location                                               |
+| -----: | -------: | ----------: | -------- | ------------------------------------------------------ |
+| 100.0% | 3.79 KiB |           3 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.72 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.72 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.56 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.56 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `handle_parse_result` (`/venv/lib/python3.11/site-packages/click/core.py:2663`)
 
-|      % |     Size | Samples | Caller       | Location                                                |
-| -----: | -------: | ------: | ------------ | ------------------------------------------------------- |
-| 100.0% | 3.37 KiB |       5 | `parse_args` | `/venv/lib/python3.11/site-packages/click/core.py:1303` |
+|      % |     Size | Allocations | Caller       | Location                                                |
+| -----: | -------: | ----------: | ------------ | ------------------------------------------------------- |
+| 100.0% | 3.37 KiB |           5 | `parse_args` | `/venv/lib/python3.11/site-packages/click/core.py:1303` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.19 KiB |       1 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.19 KiB |           1 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.19 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.19 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|      % |     Size | Samples | Caller     | Location                                                   |
-| -----: | -------: | ------: | ---------- | ---------------------------------------------------------- |
-| 100.0% | 2.85 KiB |       1 | `<module>` | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1` |
+|      % |     Size | Allocations | Caller     | Location                                                   |
+| -----: | -------: | ----------: | ---------- | ---------------------------------------------------------- |
+| 100.0% | 2.85 KiB |           1 | `<module>` | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.81 KiB |       3 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.81 KiB |           3 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.76 KiB |       2 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.76 KiB |           2 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ### Total size
 
 Functions ranked by total bytes held at peak memory in the function and all its callees.
 
-|      % |     Size | Samples | Function               | Location                                                       |
-| -----: | -------: | ------: | ---------------------- | -------------------------------------------------------------- |
-| 100.0% | 78.6 MiB |  22,694 | `_run_tracker`         | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
-| 100.0% | 78.6 MiB |  22,693 | `run_module`           | `<frozen runpy>:201`                                           |
-|  94.5% | 74.3 MiB |  21,393 | `__call__`             | `/venv/lib/python3.11/site-packages/click/core.py:1567`        |
-|  94.5% | 74.3 MiB |  21,393 | `patched_main`         | `black/__init__.py:1594`                                       |
-|  94.5% | 74.3 MiB |  21,393 | `<module>`             | `black/__main__.py:1`                                          |
-|  94.5% | 74.3 MiB |  21,393 | `_run_code`            | `<frozen runpy>:65`                                            |
-|  94.5% | 74.3 MiB |  21,393 | `_run_module_code`     | `<frozen runpy>:91`                                            |
-|  94.5% | 74.3 MiB |  21,392 | `main`                 | `/venv/lib/python3.11/site-packages/click/core.py:1422`        |
-|  94.5% | 74.2 MiB |  21,373 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:1339`        |
-|  94.5% | 74.2 MiB |  21,370 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:853`         |
-|  94.5% | 74.2 MiB |  21,368 | `new_func`             | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
-|  94.5% | 74.2 MiB |  21,365 | `main`                 | `black/__init__.py:244`                                        |
-|  94.5% | 74.2 MiB |  21,361 | `reformat_one`         | `black/__init__.py:860`                                        |
-|  94.5% | 74.2 MiB |  21,358 | `format_file_in_place` | `black/__init__.py:917`                                        |
-|  94.2% |   74 MiB |  21,355 | `format_file_contents` | `black/__init__.py:1054`                                       |
-|  65.9% | 51.8 MiB |  21,146 | `format_str`           | `black/__init__.py:1189`                                       |
-|  65.9% | 51.8 MiB |  21,145 | `_format_str_once`     | `black/__init__.py:1236`                                       |
-|  46.4% | 36.4 MiB |  21,087 | `visit`                | `black/nodes.py:163`                                           |
-|  46.4% | 36.4 MiB |  21,085 | `visit_default`        | `black/linegen.py:134`                                         |
-|  46.4% | 36.4 MiB |  21,085 | `visit_default`        | `black/nodes.py:187`                                           |
+|      % |     Size | Allocations | Function               | Location                                                       |
+| -----: | -------: | ----------: | ---------------------- | -------------------------------------------------------------- |
+| 100.0% | 78.6 MiB |      22,694 | `_run_tracker`         | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
+| 100.0% | 78.6 MiB |      22,693 | `run_module`           | `<frozen runpy>:201`                                           |
+|  94.5% | 74.3 MiB |      21,393 | `__call__`             | `/venv/lib/python3.11/site-packages/click/core.py:1567`        |
+|  94.5% | 74.3 MiB |      21,393 | `patched_main`         | `black/__init__.py:1594`                                       |
+|  94.5% | 74.3 MiB |      21,393 | `<module>`             | `black/__main__.py:1`                                          |
+|  94.5% | 74.3 MiB |      21,393 | `_run_code`            | `<frozen runpy>:65`                                            |
+|  94.5% | 74.3 MiB |      21,393 | `_run_module_code`     | `<frozen runpy>:91`                                            |
+|  94.5% | 74.3 MiB |      21,392 | `main`                 | `/venv/lib/python3.11/site-packages/click/core.py:1422`        |
+|  94.5% | 74.2 MiB |      21,373 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:1339`        |
+|  94.5% | 74.2 MiB |      21,370 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:853`         |
+|  94.5% | 74.2 MiB |      21,368 | `new_func`             | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
+|  94.5% | 74.2 MiB |      21,365 | `main`                 | `black/__init__.py:244`                                        |
+|  94.5% | 74.2 MiB |      21,361 | `reformat_one`         | `black/__init__.py:860`                                        |
+|  94.5% | 74.2 MiB |      21,358 | `format_file_in_place` | `black/__init__.py:917`                                        |
+|  94.2% |   74 MiB |      21,355 | `format_file_contents` | `black/__init__.py:1054`                                       |
+|  65.9% | 51.8 MiB |      21,146 | `format_str`           | `black/__init__.py:1189`                                       |
+|  65.9% | 51.8 MiB |      21,145 | `_format_str_once`     | `black/__init__.py:1236`                                       |
+|  46.4% | 36.4 MiB |      21,087 | `visit`                | `black/nodes.py:163`                                           |
+|  46.4% | 36.4 MiB |      21,085 | `visit_default`        | `black/linegen.py:134`                                         |
+|  46.4% | 36.4 MiB |      21,085 | `visit_default`        | `black/nodes.py:187`                                           |
 
 #### Categories
 
 ##### Ours
 
-|     % |     Size | Samples | Function                          | Location                 |
-| ----: | -------: | ------: | --------------------------------- | ------------------------ |
-| 94.5% | 74.3 MiB |  21,393 | `patched_main`                    | `black/__init__.py:1594` |
-| 94.5% | 74.3 MiB |  21,393 | `<module>`                        | `black/__main__.py:1`    |
-| 94.5% | 74.2 MiB |  21,365 | `main`                            | `black/__init__.py:244`  |
-| 94.5% | 74.2 MiB |  21,361 | `reformat_one`                    | `black/__init__.py:860`  |
-| 94.5% | 74.2 MiB |  21,358 | `format_file_in_place`            | `black/__init__.py:917`  |
-| 94.2% |   74 MiB |  21,355 | `format_file_contents`            | `black/__init__.py:1054` |
-| 65.9% | 51.8 MiB |  21,146 | `format_str`                      | `black/__init__.py:1189` |
-| 65.9% | 51.8 MiB |  21,145 | `_format_str_once`                | `black/__init__.py:1236` |
-| 46.4% | 36.4 MiB |  21,087 | `visit`                           | `black/nodes.py:163`     |
-| 46.4% | 36.4 MiB |  21,085 | `visit_default`                   | `black/linegen.py:134`   |
-| 46.4% | 36.4 MiB |  21,085 | `visit_default`                   | `black/nodes.py:187`     |
-| 46.0% | 36.2 MiB |  20,714 | `visit_stmt`                      | `black/linegen.py:199`   |
-| 45.6% | 35.8 MiB |  20,273 | `visit_funcdef`                   | `black/linegen.py:254`   |
-| 45.5% | 35.7 MiB |  20,147 | `visit_suite`                     | `black/linegen.py:288`   |
-| 31.6% | 24.8 MiB |  13,403 | `visit_simple_stmt`               | `black/linegen.py:295`   |
-| 30.9% | 24.3 MiB |  20,889 | `append`                          | `black/lines.py:63`      |
-| 28.3% | 22.3 MiB |     209 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
-| 28.3% | 22.3 MiB |     208 | `assert_equivalent`               | `black/__init__.py:1524` |
-| 21.9% | 17.2 MiB |  20,789 | `mark`                            | `black/brackets.py:70`   |
-| 21.5% | 16.9 MiB |  10,808 | `visit_power`                     | `black/linegen.py:341`   |
+|     % |     Size | Allocations | Function                          | Location                 |
+| ----: | -------: | ----------: | --------------------------------- | ------------------------ |
+| 94.5% | 74.3 MiB |      21,393 | `patched_main`                    | `black/__init__.py:1594` |
+| 94.5% | 74.3 MiB |      21,393 | `<module>`                        | `black/__main__.py:1`    |
+| 94.5% | 74.2 MiB |      21,365 | `main`                            | `black/__init__.py:244`  |
+| 94.5% | 74.2 MiB |      21,361 | `reformat_one`                    | `black/__init__.py:860`  |
+| 94.5% | 74.2 MiB |      21,358 | `format_file_in_place`            | `black/__init__.py:917`  |
+| 94.2% |   74 MiB |      21,355 | `format_file_contents`            | `black/__init__.py:1054` |
+| 65.9% | 51.8 MiB |      21,146 | `format_str`                      | `black/__init__.py:1189` |
+| 65.9% | 51.8 MiB |      21,145 | `_format_str_once`                | `black/__init__.py:1236` |
+| 46.4% | 36.4 MiB |      21,087 | `visit`                           | `black/nodes.py:163`     |
+| 46.4% | 36.4 MiB |      21,085 | `visit_default`                   | `black/linegen.py:134`   |
+| 46.4% | 36.4 MiB |      21,085 | `visit_default`                   | `black/nodes.py:187`     |
+| 46.0% | 36.2 MiB |      20,714 | `visit_stmt`                      | `black/linegen.py:199`   |
+| 45.6% | 35.8 MiB |      20,273 | `visit_funcdef`                   | `black/linegen.py:254`   |
+| 45.5% | 35.7 MiB |      20,147 | `visit_suite`                     | `black/linegen.py:288`   |
+| 31.6% | 24.8 MiB |      13,403 | `visit_simple_stmt`               | `black/linegen.py:295`   |
+| 30.9% | 24.3 MiB |      20,889 | `append`                          | `black/lines.py:63`      |
+| 28.3% | 22.3 MiB |         209 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+| 28.3% | 22.3 MiB |         208 | `assert_equivalent`               | `black/__init__.py:1524` |
+| 21.9% | 17.2 MiB |      20,789 | `mark`                            | `black/brackets.py:70`   |
+| 21.5% | 16.9 MiB |      10,808 | `visit_power`                     | `black/linegen.py:341`   |
 
 ##### Standard library
 
-|      % |     Size | Samples | Function                    | Location                                     |
-| -----: | -------: | ------: | --------------------------- | -------------------------------------------- |
-| 100.0% | 78.6 MiB |  22,693 | `run_module`                | `<frozen runpy>:201`                         |
-|  94.5% | 74.3 MiB |  21,393 | `_run_code`                 | `<frozen runpy>:65`                          |
-|  94.5% | 74.3 MiB |  21,393 | `_run_module_code`          | `<frozen runpy>:91`                          |
-|  11.6% | 9.12 MiB |     142 | `parse`                     | `/usr/lib/python3.11/ast.py:33`              |
-|   5.5% | 4.32 MiB |   1,299 | `_get_module_details`       | `<frozen runpy>:105`                         |
-|   5.5% | 4.31 MiB |   1,292 | `_find_and_load`            | `<frozen importlib._bootstrap>:1167`         |
-|   5.5% | 4.31 MiB |   1,290 | `_find_and_load_unlocked`   | `<frozen importlib._bootstrap>:1122`         |
-|   5.5% | 4.31 MiB |   1,289 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`          |
-|   5.5% | 4.31 MiB |   1,287 | `exec_module`               | `<frozen importlib._bootstrap_external>:934` |
-|   5.4% | 4.28 MiB |   1,257 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`          |
-|   1.7% |  1.3 MiB |     318 | `_handle_fromlist`          | `<frozen importlib._bootstrap>:1209`         |
-|   1.3% | 1.05 MiB |      26 | `compile`                   | `/usr/lib/python3.11/re/__init__.py:225`     |
-|   1.3% | 1.05 MiB |      25 | `_compile`                  | `/usr/lib/python3.11/re/__init__.py:272`     |
-|   1.3% | 1.05 MiB |      24 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`    |
-|   1.3% | 1.01 MiB |       6 | `parse`                     | `/usr/lib/python3.11/re/_parser.py:970`      |
-|   1.3% | 1.01 MiB |      15 | `wrap`                      | `/usr/lib/python3.11/dataclasses.py:1209`    |
-|   1.3% | 1.01 MiB |       5 | `_parse_sub`                | `/usr/lib/python3.11/re/_parser.py:447`      |
-|   1.3% | 1.01 MiB |      14 | `_process_class`            | `/usr/lib/python3.11/dataclasses.py:884`     |
-|   1.3% | 1.01 MiB |      11 | `dataclass`                 | `/usr/lib/python3.11/dataclasses.py:1192`    |
-|   1.3% | 1.01 MiB |       4 | `_parse`                    | `/usr/lib/python3.11/re/_parser.py:507`      |
+|      % |     Size | Allocations | Function                    | Location                                     |
+| -----: | -------: | ----------: | --------------------------- | -------------------------------------------- |
+| 100.0% | 78.6 MiB |      22,693 | `run_module`                | `<frozen runpy>:201`                         |
+|  94.5% | 74.3 MiB |      21,393 | `_run_code`                 | `<frozen runpy>:65`                          |
+|  94.5% | 74.3 MiB |      21,393 | `_run_module_code`          | `<frozen runpy>:91`                          |
+|  11.6% | 9.12 MiB |         142 | `parse`                     | `/usr/lib/python3.11/ast.py:33`              |
+|   5.5% | 4.32 MiB |       1,299 | `_get_module_details`       | `<frozen runpy>:105`                         |
+|   5.5% | 4.31 MiB |       1,292 | `_find_and_load`            | `<frozen importlib._bootstrap>:1167`         |
+|   5.5% | 4.31 MiB |       1,290 | `_find_and_load_unlocked`   | `<frozen importlib._bootstrap>:1122`         |
+|   5.5% | 4.31 MiB |       1,289 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`          |
+|   5.5% | 4.31 MiB |       1,287 | `exec_module`               | `<frozen importlib._bootstrap_external>:934` |
+|   5.4% | 4.28 MiB |       1,257 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`          |
+|   1.7% |  1.3 MiB |         318 | `_handle_fromlist`          | `<frozen importlib._bootstrap>:1209`         |
+|   1.3% | 1.05 MiB |          26 | `compile`                   | `/usr/lib/python3.11/re/__init__.py:225`     |
+|   1.3% | 1.05 MiB |          25 | `_compile`                  | `/usr/lib/python3.11/re/__init__.py:272`     |
+|   1.3% | 1.05 MiB |          24 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`    |
+|   1.3% | 1.01 MiB |           6 | `parse`                     | `/usr/lib/python3.11/re/_parser.py:970`      |
+|   1.3% | 1.01 MiB |          15 | `wrap`                      | `/usr/lib/python3.11/dataclasses.py:1209`    |
+|   1.3% | 1.01 MiB |           5 | `_parse_sub`                | `/usr/lib/python3.11/re/_parser.py:447`      |
+|   1.3% | 1.01 MiB |          14 | `_process_class`            | `/usr/lib/python3.11/dataclasses.py:884`     |
+|   1.3% | 1.01 MiB |          11 | `dataclass`                 | `/usr/lib/python3.11/dataclasses.py:1192`    |
+|   1.3% | 1.01 MiB |           4 | `_parse`                    | `/usr/lib/python3.11/re/_parser.py:507`      |
 
 ##### Third-party
 
-|      % |     Size | Samples | Function       | Location                                                                         |
-| -----: | -------: | ------: | -------------- | -------------------------------------------------------------------------------- |
-| 100.0% | 78.6 MiB |  22,694 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40`                   |
-|  94.5% | 74.3 MiB |  21,393 | `__call__`     | `/venv/lib/python3.11/site-packages/click/core.py:1567`                          |
-|  94.5% | 74.3 MiB |  21,392 | `main`         | `/venv/lib/python3.11/site-packages/click/core.py:1422`                          |
-|  94.5% | 74.2 MiB |  21,373 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339`                          |
-|  94.5% | 74.2 MiB |  21,370 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:853`                           |
-|  94.5% | 74.2 MiB |  21,368 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                      |
-|   1.7% | 1.31 MiB |     304 | `<module>`     | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                         |
-|   1.6% | 1.23 MiB |     233 | `<module>`     | `/venv/lib/python3.11/site-packages/click/core.py:1`                             |
-|   1.3% | 1.02 MiB |      24 | `<module>`     | `/venv/lib/python3.11/site-packages/click/formatting.py:1`                       |
-|   1.3% | 1.01 MiB |      11 | `<module>`     | `/venv/lib/python3.11/site-packages/click/parser.py:1`                           |
-|   0.2% |  173 KiB |     141 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`                   |
-|   0.2% |  125 KiB |     127 | `<module>`     | `/venv/lib/python3.11/site-packages/click/types.py:1`                            |
-|   0.1% | 99.6 KiB |      72 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                        |
-|   0.1% | 93.8 KiB |     119 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`                      |
-|   0.1% | 91.5 KiB |     115 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`                     |
-|   0.1% | 74.5 KiB |      43 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                         |
-|   0.1% | 65.5 KiB |      84 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`                 |
-|   0.1% | 47.3 KiB |      33 | `decorator`    | `/venv/lib/python3.11/site-packages/click/decorators.py:373`                     |
-|   0.1% | 46.9 KiB |      59 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1` |
-|   0.1% | 45.5 KiB |      32 | `__init__`     | `/venv/lib/python3.11/site-packages/click/core.py:2883`                          |
+|      % |     Size | Allocations | Function       | Location                                                                         |
+| -----: | -------: | ----------: | -------------- | -------------------------------------------------------------------------------- |
+| 100.0% | 78.6 MiB |      22,694 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40`                   |
+|  94.5% | 74.3 MiB |      21,393 | `__call__`     | `/venv/lib/python3.11/site-packages/click/core.py:1567`                          |
+|  94.5% | 74.3 MiB |      21,392 | `main`         | `/venv/lib/python3.11/site-packages/click/core.py:1422`                          |
+|  94.5% | 74.2 MiB |      21,373 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339`                          |
+|  94.5% | 74.2 MiB |      21,370 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:853`                           |
+|  94.5% | 74.2 MiB |      21,368 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                      |
+|   1.7% | 1.31 MiB |         304 | `<module>`     | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                         |
+|   1.6% | 1.23 MiB |         233 | `<module>`     | `/venv/lib/python3.11/site-packages/click/core.py:1`                             |
+|   1.3% | 1.02 MiB |          24 | `<module>`     | `/venv/lib/python3.11/site-packages/click/formatting.py:1`                       |
+|   1.3% | 1.01 MiB |          11 | `<module>`     | `/venv/lib/python3.11/site-packages/click/parser.py:1`                           |
+|   0.2% |  173 KiB |         141 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`                   |
+|   0.2% |  125 KiB |         127 | `<module>`     | `/venv/lib/python3.11/site-packages/click/types.py:1`                            |
+|   0.1% | 99.6 KiB |          72 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                        |
+|   0.1% | 93.8 KiB |         119 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`                      |
+|   0.1% | 91.5 KiB |         115 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`                     |
+|   0.1% | 74.5 KiB |          43 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                         |
+|   0.1% | 65.5 KiB |          84 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`                 |
+|   0.1% | 47.3 KiB |          33 | `decorator`    | `/venv/lib/python3.11/site-packages/click/decorators.py:373`                     |
+|   0.1% | 46.9 KiB |          59 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1` |
+|   0.1% | 45.5 KiB |          32 | `__init__`     | `/venv/lib/python3.11/site-packages/click/core.py:2883`                          |
 
 #### Callees
 
@@ -1047,396 +1047,396 @@ Callees ranked by contribution to each function's total size. Inlining can make 
 
 ##### `_run_tracker` (`/venv/lib/python3.11/site-packages/memray/commands/run.py:40`)
 
-|      % |     Size | Samples | Callee       | Location             |
-| -----: | -------: | ------: | ------------ | -------------------- |
-| 100.0% | 78.6 MiB |  22,693 | `run_module` | `<frozen runpy>:201` |
+|      % |     Size | Allocations | Callee       | Location             |
+| -----: | -------: | ----------: | ------------ | -------------------- |
+| 100.0% | 78.6 MiB |      22,693 | `run_module` | `<frozen runpy>:201` |
 
 ##### `run_module` (`<frozen runpy>:201`)
 
-|     % |     Size | Samples | Callee                | Location             |
-| ----: | -------: | ------: | --------------------- | -------------------- |
-| 94.5% | 74.3 MiB |  21,393 | `_run_module_code`    | `<frozen runpy>:91`  |
-|  5.5% | 4.32 MiB |   1,299 | `_get_module_details` | `<frozen runpy>:105` |
+|     % |     Size | Allocations | Callee                | Location             |
+| ----: | -------: | ----------: | --------------------- | -------------------- |
+| 94.5% | 74.3 MiB |      21,393 | `_run_module_code`    | `<frozen runpy>:91`  |
+|  5.5% | 4.32 MiB |       1,299 | `_get_module_details` | `<frozen runpy>:105` |
 
 ##### `__call__` (`/venv/lib/python3.11/site-packages/click/core.py:1567`)
 
-|      % |     Size | Samples | Callee | Location                                                |
-| -----: | -------: | ------: | ------ | ------------------------------------------------------- |
-| 100.0% | 74.3 MiB |  21,392 | `main` | `/venv/lib/python3.11/site-packages/click/core.py:1422` |
+|      % |     Size | Allocations | Callee | Location                                                |
+| -----: | -------: | ----------: | ------ | ------------------------------------------------------- |
+| 100.0% | 74.3 MiB |      21,392 | `main` | `/venv/lib/python3.11/site-packages/click/core.py:1422` |
 
 ##### `patched_main` (`black/__init__.py:1594`)
 
-|      % |     Size | Samples | Callee     | Location                                                |
-| -----: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 100.0% | 74.3 MiB |  21,393 | `__call__` | `/venv/lib/python3.11/site-packages/click/core.py:1567` |
+|      % |     Size | Allocations | Callee     | Location                                                |
+| -----: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 100.0% | 74.3 MiB |      21,393 | `__call__` | `/venv/lib/python3.11/site-packages/click/core.py:1567` |
 
 ##### `<module>` (`black/__main__.py:1`)
 
-|      % |     Size | Samples | Callee         | Location                 |
-| -----: | -------: | ------: | -------------- | ------------------------ |
-| 100.0% | 74.3 MiB |  21,393 | `patched_main` | `black/__init__.py:1594` |
+|      % |     Size | Allocations | Callee         | Location                 |
+| -----: | -------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 74.3 MiB |      21,393 | `patched_main` | `black/__init__.py:1594` |
 
 ##### `_run_code` (`<frozen runpy>:65`)
 
-|      % |     Size | Samples | Callee     | Location              |
-| -----: | -------: | ------: | ---------- | --------------------- |
-| 100.0% | 74.3 MiB |  21,393 | `<module>` | `black/__main__.py:1` |
+|      % |     Size | Allocations | Callee     | Location              |
+| -----: | -------: | ----------: | ---------- | --------------------- |
+| 100.0% | 74.3 MiB |      21,393 | `<module>` | `black/__main__.py:1` |
 
 ##### `_run_module_code` (`<frozen runpy>:91`)
 
-|      % |     Size | Samples | Callee      | Location            |
-| -----: | -------: | ------: | ----------- | ------------------- |
-| 100.0% | 74.3 MiB |  21,393 | `_run_code` | `<frozen runpy>:65` |
+|      % |     Size | Allocations | Callee      | Location            |
+| -----: | -------: | ----------: | ----------- | ------------------- |
+| 100.0% | 74.3 MiB |      21,393 | `_run_code` | `<frozen runpy>:65` |
 
 ##### `main` (`/venv/lib/python3.11/site-packages/click/core.py:1422`)
 
-|      % |     Size | Samples | Callee         | Location                                                |
-| -----: | -------: | ------: | -------------- | ------------------------------------------------------- |
-| 100.0% | 74.2 MiB |  21,373 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339` |
-|  <0.1% | 14.1 KiB |      17 | `make_context` | `/venv/lib/python3.11/site-packages/click/core.py:1266` |
-|  <0.1% |     32 B |       1 | `__enter__`    | `/venv/lib/python3.11/site-packages/click/core.py:545`  |
+|      % |     Size | Allocations | Callee         | Location                                                |
+| -----: | -------: | ----------: | -------------- | ------------------------------------------------------- |
+| 100.0% | 74.2 MiB |      21,373 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339` |
+|  <0.1% | 14.1 KiB |          17 | `make_context` | `/venv/lib/python3.11/site-packages/click/core.py:1266` |
+|  <0.1% |     32 B |           1 | `__enter__`    | `/venv/lib/python3.11/site-packages/click/core.py:545`  |
 
 ##### `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:1339`)
 
-|      % |     Size | Samples | Callee   | Location                                               |
-| -----: | -------: | ------: | -------- | ------------------------------------------------------ |
-| 100.0% | 74.2 MiB |  21,370 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
+|      % |     Size | Allocations | Callee   | Location                                               |
+| -----: | -------: | ----------: | -------- | ------------------------------------------------------ |
+| 100.0% | 74.2 MiB |      21,370 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
 
 ##### `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`)
 
-|      % |     Size | Samples | Callee     | Location                                                    |
-| -----: | -------: | ------: | ---------- | ----------------------------------------------------------- |
-| 100.0% | 74.2 MiB |  21,368 | `new_func` | `/venv/lib/python3.11/site-packages/click/decorators.py:33` |
+|      % |     Size | Allocations | Callee     | Location                                                    |
+| -----: | -------: | ----------: | ---------- | ----------------------------------------------------------- |
+| 100.0% | 74.2 MiB |      21,368 | `new_func` | `/venv/lib/python3.11/site-packages/click/decorators.py:33` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Callee | Location                |
-| -----: | -------: | ------: | ------ | ----------------------- |
-| 100.0% | 74.2 MiB |  21,365 | `main` | `black/__init__.py:244` |
+|      % |     Size | Allocations | Callee | Location                |
+| -----: | -------: | ----------: | ------ | ----------------------- |
+| 100.0% | 74.2 MiB |      21,365 | `main` | `black/__init__.py:244` |
 
 ##### `main` (`black/__init__.py:244`)
 
-|      % |     Size | Samples | Callee         | Location                |
-| -----: | -------: | ------: | -------------- | ----------------------- |
-| 100.0% | 74.2 MiB |  21,361 | `reformat_one` | `black/__init__.py:860` |
-|  <0.1% | 2.06 KiB |       2 | `get_sources`  | `black/__init__.py:724` |
+|      % |     Size | Allocations | Callee         | Location                |
+| -----: | -------: | ----------: | -------------- | ----------------------- |
+| 100.0% | 74.2 MiB |      21,361 | `reformat_one` | `black/__init__.py:860` |
+|  <0.1% | 2.06 KiB |           2 | `get_sources`  | `black/__init__.py:724` |
 
 ##### `reformat_one` (`black/__init__.py:860`)
 
-|      % |     Size | Samples | Callee                 | Location                |
-| -----: | -------: | ------: | ---------------------- | ----------------------- |
-| 100.0% | 74.2 MiB |  21,358 | `format_file_in_place` | `black/__init__.py:917` |
-|  <0.1% | 1.13 KiB |       1 | `read`                 | `black/cache.py:60`     |
+|      % |     Size | Allocations | Callee                 | Location                |
+| -----: | -------: | ----------: | ---------------------- | ----------------------- |
+| 100.0% | 74.2 MiB |      21,358 | `format_file_in_place` | `black/__init__.py:917` |
+|  <0.1% | 1.13 KiB |           1 | `read`                 | `black/cache.py:60`     |
 
 ##### `format_file_in_place` (`black/__init__.py:917`)
 
-|     % |    Size | Samples | Callee                 | Location                 |
-| ----: | ------: | ------: | ---------------------- | ------------------------ |
-| 99.7% |  74 MiB |  21,355 | `format_file_contents` | `black/__init__.py:1054` |
-|  0.3% | 223 KiB |       2 | `decode_bytes`         | `black/__init__.py:1290` |
+|     % |    Size | Allocations | Callee                 | Location                 |
+| ----: | ------: | ----------: | ---------------------- | ------------------------ |
+| 99.7% |  74 MiB |      21,355 | `format_file_contents` | `black/__init__.py:1054` |
+|  0.3% | 223 KiB |           2 | `decode_bytes`         | `black/__init__.py:1290` |
 
 ##### `format_file_contents` (`black/__init__.py:1054`)
 
-|     % |     Size | Samples | Callee                            | Location                 |
-| ----: | -------: | ------: | --------------------------------- | ------------------------ |
-| 69.9% | 51.8 MiB |  21,146 | `format_str`                      | `black/__init__.py:1189` |
-| 30.1% | 22.3 MiB |     209 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+|     % |     Size | Allocations | Callee                            | Location                 |
+| ----: | -------: | ----------: | --------------------------------- | ------------------------ |
+| 69.9% | 51.8 MiB |      21,146 | `format_str`                      | `black/__init__.py:1189` |
+| 30.1% | 22.3 MiB |         209 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
 
 ##### `format_str` (`black/__init__.py:1189`)
 
-|      % |     Size | Samples | Callee             | Location                 |
-| -----: | -------: | ------: | ------------------ | ------------------------ |
-| 100.0% | 51.8 MiB |  21,145 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |     Size | Allocations | Callee             | Location                 |
+| -----: | -------: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 51.8 MiB |      21,145 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `_format_str_once` (`black/__init__.py:1236`)
 
-|     % |     Size | Samples | Callee                   | Location                 |
-| ----: | -------: | ------: | ------------------------ | ------------------------ |
-| 70.4% | 36.4 MiB |  21,087 | `visit`                  | `black/nodes.py:163`     |
-| 23.3% |   12 MiB |      31 | `lib2to3_parse`          | `black/parsing.py:55`    |
-|  5.8% | 3.01 MiB |      15 | `transform_line`         | `black/linegen.py:601`   |
-| <0.1% | 19.9 KiB |       3 | `normalize_fmt_off`      | `black/comments.py:168`  |
-| <0.1% | 3.49 KiB |       1 | `detect_target_versions` | `black/__init__.py:1464` |
+|     % |     Size | Allocations | Callee                   | Location                 |
+| ----: | -------: | ----------: | ------------------------ | ------------------------ |
+| 70.4% | 36.4 MiB |      21,087 | `visit`                  | `black/nodes.py:163`     |
+| 23.3% |   12 MiB |          31 | `lib2to3_parse`          | `black/parsing.py:55`    |
+|  5.8% | 3.01 MiB |          15 | `transform_line`         | `black/linegen.py:601`   |
+| <0.1% | 19.9 KiB |           3 | `normalize_fmt_off`      | `black/comments.py:168`  |
+| <0.1% | 3.49 KiB |           1 | `detect_target_versions` | `black/__init__.py:1464` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|      % |     Size | Samples | Callee              | Location               |
-| -----: | -------: | ------: | ------------------- | ---------------------- |
-| 100.0% | 36.4 MiB |  21,085 | `visit_default`     | `black/linegen.py:134` |
-|  99.2% | 36.2 MiB |  20,714 | `visit_stmt`        | `black/linegen.py:199` |
-|  98.3% | 35.8 MiB |  20,273 | `visit_funcdef`     | `black/linegen.py:254` |
-|  98.1% | 35.7 MiB |  20,147 | `visit_suite`       | `black/linegen.py:288` |
-|  68.1% | 24.8 MiB |  13,403 | `visit_simple_stmt` | `black/linegen.py:295` |
+|      % |     Size | Allocations | Callee              | Location               |
+| -----: | -------: | ----------: | ------------------- | ---------------------- |
+| 100.0% | 36.4 MiB |      21,085 | `visit_default`     | `black/linegen.py:134` |
+|  99.2% | 36.2 MiB |      20,714 | `visit_stmt`        | `black/linegen.py:199` |
+|  98.3% | 35.8 MiB |      20,273 | `visit_funcdef`     | `black/linegen.py:254` |
+|  98.1% | 35.7 MiB |      20,147 | `visit_suite`       | `black/linegen.py:288` |
+|  68.1% | 24.8 MiB |      13,403 | `visit_simple_stmt` | `black/linegen.py:295` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|      % |     Size | Samples | Callee              | Location               |
-| -----: | -------: | ------: | ------------------- | ---------------------- |
-| 100.0% | 36.4 MiB |  21,085 | `visit_default`     | `black/nodes.py:187`   |
-|  66.6% | 24.3 MiB |  20,889 | `append`            | `black/lines.py:63`    |
-|  16.5% |    6 MiB |       6 | `generate_comments` | `black/comments.py:52` |
+|      % |     Size | Allocations | Callee              | Location               |
+| -----: | -------: | ----------: | ------------------- | ---------------------- |
+| 100.0% | 36.4 MiB |      21,085 | `visit_default`     | `black/nodes.py:187`   |
+|  66.6% | 24.3 MiB |      20,889 | `append`            | `black/lines.py:63`    |
+|  16.5% |    6 MiB |           6 | `generate_comments` | `black/comments.py:52` |
 
 ##### `visit_default` (`black/nodes.py:187`)
 
-|      % |     Size | Samples | Callee  | Location             |
-| -----: | -------: | ------: | ------- | -------------------- |
-| 100.0% | 36.4 MiB |  21,085 | `visit` | `black/nodes.py:163` |
+|      % |     Size | Allocations | Callee  | Location             |
+| -----: | -------: | ----------: | ------- | -------------------- |
+| 100.0% | 36.4 MiB |      21,085 | `visit` | `black/nodes.py:163` |
 
 ##### `visit_stmt` (`black/linegen.py:199`)
 
-|      % |     Size | Samples | Callee                       | Location                |
-| -----: | -------: | ------: | ---------------------------- | ----------------------- |
-| 100.0% | 36.2 MiB |  20,712 | `visit`                      | `black/nodes.py:163`    |
-|   2.8% |    1 MiB |       2 | `normalize_invisible_parens` | `black/linegen.py:1328` |
+|      % |     Size | Allocations | Callee                       | Location                |
+| -----: | -------: | ----------: | ---------------------------- | ----------------------- |
+| 100.0% | 36.2 MiB |      20,712 | `visit`                      | `black/nodes.py:163`    |
+|   2.8% |    1 MiB |           2 | `normalize_invisible_parens` | `black/linegen.py:1328` |
 
 ##### `visit_funcdef` (`black/linegen.py:254`)
 
-|      % |     Size | Samples | Callee  | Location             |
-| -----: | -------: | ------: | ------- | -------------------- |
-| 100.0% | 35.8 MiB |  20,273 | `visit` | `black/nodes.py:163` |
+|      % |     Size | Allocations | Callee  | Location             |
+| -----: | -------: | ----------: | ------- | -------------------- |
+| 100.0% | 35.8 MiB |      20,273 | `visit` | `black/nodes.py:163` |
 
 ##### `visit_suite` (`black/linegen.py:288`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 35.7 MiB |  20,147 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 35.7 MiB |      20,147 | `visit_default` | `black/linegen.py:134` |
 
 ##### `visit_simple_stmt` (`black/linegen.py:295`)
 
-|     % |     Size | Samples | Callee          | Location               |
-| ----: | -------: | ------: | --------------- | ---------------------- |
-| 96.0% | 23.8 MiB |  13,402 | `visit_default` | `black/linegen.py:134` |
-|  4.0% |    1 MiB |       1 | `line`          | `black/linegen.py:109` |
+|     % |     Size | Allocations | Callee          | Location               |
+| ----: | -------: | ----------: | --------------- | ---------------------- |
+| 96.0% | 23.8 MiB |      13,402 | `visit_default` | `black/linegen.py:134` |
+|  4.0% |    1 MiB |           1 | `line`          | `black/linegen.py:109` |
 
 ##### `append` (`black/lines.py:63`)
 
-|     % |     Size | Samples | Callee       | Location                 |
-| ----: | -------: | ------: | ------------ | ------------------------ |
-| 70.9% | 17.2 MiB |  20,789 | `mark`       | `black/brackets.py:70`   |
-| 24.9% | 6.05 MiB |      95 | `whitespace` | `black/nodes.py:194`     |
-|  4.1% |    1 MiB |       1 | `prefix`     | `blib2to3/pytree.py:480` |
+|     % |     Size | Allocations | Callee       | Location                 |
+| ----: | -------: | ----------: | ------------ | ------------------------ |
+| 70.9% | 17.2 MiB |      20,789 | `mark`       | `black/brackets.py:70`   |
+| 24.9% | 6.05 MiB |          95 | `whitespace` | `black/nodes.py:194`     |
+|  4.1% |    1 MiB |           1 | `prefix`     | `blib2to3/pytree.py:480` |
 
 ##### `check_stability_and_equivalence` (`black/__init__.py:1037`)
 
-|      % |     Size | Samples | Callee              | Location                 |
-| -----: | -------: | ------: | ------------------- | ------------------------ |
-| 100.0% | 22.3 MiB |     208 | `assert_equivalent` | `black/__init__.py:1524` |
+|      % |     Size | Allocations | Callee              | Location                 |
+| -----: | -------: | ----------: | ------------------- | ------------------------ |
+| 100.0% | 22.3 MiB |         208 | `assert_equivalent` | `black/__init__.py:1524` |
 
 ##### `assert_equivalent` (`black/__init__.py:1524`)
 
-|     % |     Size | Samples | Callee           | Location               |
-| ----: | -------: | ------: | ---------------- | ---------------------- |
-| 41.0% | 9.12 MiB |     142 | `parse_ast`      | `black/parsing.py:129` |
-| 27.2% | 6.05 MiB |      62 | `_stringify_ast` | `black/parsing.py:174` |
+|     % |     Size | Allocations | Callee           | Location               |
+| ----: | -------: | ----------: | ---------------- | ---------------------- |
+| 41.0% | 9.12 MiB |         142 | `parse_ast`      | `black/parsing.py:129` |
+| 27.2% | 6.05 MiB |          62 | `_stringify_ast` | `black/parsing.py:174` |
 
 ##### `visit_power` (`black/linegen.py:341`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 16.9 MiB |  10,807 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 16.9 MiB |      10,807 | `visit_default` | `black/linegen.py:134` |
 
 ##### `_get_module_details` (`<frozen runpy>:105`)
 
-|     % |     Size | Samples | Callee                | Location                             |
-| ----: | -------: | ------: | --------------------- | ------------------------------------ |
-| 99.9% | 4.31 MiB |   1,292 | `_find_and_load`      | `<frozen importlib._bootstrap>:1167` |
-| 99.9% | 4.31 MiB |   1,292 | `_get_module_details` | `<frozen runpy>:105`                 |
-|  0.1% | 5.66 KiB |       6 | `find_spec`           | `<frozen importlib.util>:73`         |
+|     % |     Size | Allocations | Callee                | Location                             |
+| ----: | -------: | ----------: | --------------------- | ------------------------------------ |
+| 99.9% | 4.31 MiB |       1,292 | `_find_and_load`      | `<frozen importlib._bootstrap>:1167` |
+| 99.9% | 4.31 MiB |       1,292 | `_get_module_details` | `<frozen runpy>:105`                 |
+|  0.1% | 5.66 KiB |           6 | `find_spec`           | `<frozen importlib.util>:73`         |
 
 ##### `_find_and_load` (`<frozen importlib._bootstrap>:1167`)
 
-|      % |     Size | Samples | Callee                    | Location                             |
-| -----: | -------: | ------: | ------------------------- | ------------------------------------ |
-| 100.0% | 4.31 MiB |   1,290 | `_find_and_load_unlocked` | `<frozen importlib._bootstrap>:1122` |
-|  <0.1% |    560 B |       1 | `__enter__`               | `<frozen importlib._bootstrap>:169`  |
+|      % |     Size | Allocations | Callee                    | Location                             |
+| -----: | -------: | ----------: | ------------------------- | ------------------------------------ |
+| 100.0% | 4.31 MiB |       1,290 | `_find_and_load_unlocked` | `<frozen importlib._bootstrap>:1122` |
+|  <0.1% |    560 B |           1 | `__enter__`               | `<frozen importlib._bootstrap>:169`  |
 
 ##### `_find_and_load_unlocked` (`<frozen importlib._bootstrap>:1122`)
 
-|      % |     Size | Samples | Callee                      | Location                             |
-| -----: | -------: | ------: | --------------------------- | ------------------------------------ |
-| 100.0% | 4.31 MiB |   1,289 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`  |
-|   0.8% | 37.2 KiB |      47 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`  |
-|   0.2% | 7.48 KiB |       4 | `_find_spec`                | `<frozen importlib._bootstrap>:1056` |
+|      % |     Size | Allocations | Callee                      | Location                             |
+| -----: | -------: | ----------: | --------------------------- | ------------------------------------ |
+| 100.0% | 4.31 MiB |       1,289 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`  |
+|   0.8% | 37.2 KiB |          47 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`  |
+|   0.2% | 7.48 KiB |           4 | `_find_spec`                | `<frozen importlib._bootstrap>:1056` |
 
 ##### `_load_unlocked` (`<frozen importlib._bootstrap>:666`)
 
-|      % |     Size | Samples | Callee             | Location                                     |
-| -----: | -------: | ------: | ------------------ | -------------------------------------------- |
-| 100.0% | 4.31 MiB |   1,287 | `exec_module`      | `<frozen importlib._bootstrap_external>:934` |
-|  <0.1% | 1.83 KiB |       2 | `module_from_spec` | `<frozen importlib._bootstrap>:566`          |
+|      % |     Size | Allocations | Callee             | Location                                     |
+| -----: | -------: | ----------: | ------------------ | -------------------------------------------- |
+| 100.0% | 4.31 MiB |       1,287 | `exec_module`      | `<frozen importlib._bootstrap_external>:934` |
+|  <0.1% | 1.83 KiB |           2 | `module_from_spec` | `<frozen importlib._bootstrap>:566`          |
 
 ##### `exec_module` (`<frozen importlib._bootstrap_external>:934`)
 
-|     % |     Size | Samples | Callee                      | Location                                      |
-| ----: | -------: | ------: | --------------------------- | --------------------------------------------- |
-| 99.3% | 4.28 MiB |   1,257 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
-| 12.7% |  560 KiB |     606 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
+|     % |     Size | Allocations | Callee                      | Location                                      |
+| ----: | -------: | ----------: | --------------------------- | --------------------------------------------- |
+| 99.3% | 4.28 MiB |       1,257 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
+| 12.7% |  560 KiB |         606 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`)
 
-|      % |     Size | Samples | Callee           | Location                                                 |
-| -----: | -------: | ------: | ---------------- | -------------------------------------------------------- |
-| 100.0% | 4.28 MiB |   1,257 | `<module>`       | `black/__init__.py:1`                                    |
-|  53.8% |  2.3 MiB |     270 | `<module>`       | `black/comments.py:1`                                    |
-|  30.7% | 1.31 MiB |     329 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                     |
-|  30.5% | 1.31 MiB |     304 | `<module>`       | `/venv/lib/python3.11/site-packages/click/__init__.py:1` |
-|  30.1% | 1.29 MiB |     255 | `<module>`       | `black/nodes.py:1`                                       |
+|      % |     Size | Allocations | Callee           | Location                                                 |
+| -----: | -------: | ----------: | ---------------- | -------------------------------------------------------- |
+| 100.0% | 4.28 MiB |       1,257 | `<module>`       | `black/__init__.py:1`                                    |
+|  53.8% |  2.3 MiB |         270 | `<module>`       | `black/comments.py:1`                                    |
+|  30.7% | 1.31 MiB |         329 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                     |
+|  30.5% | 1.31 MiB |         304 | `<module>`       | `/venv/lib/python3.11/site-packages/click/__init__.py:1` |
+|  30.1% | 1.29 MiB |         255 | `<module>`       | `black/nodes.py:1`                                       |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|     % |    Size | Samples | Callee           | Location                             |
-| ----: | ------: | ------: | ---------------- | ------------------------------------ |
-| 99.8% | 1.3 MiB |     303 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |    Size | Allocations | Callee           | Location                             |
+| ----: | ------: | ----------: | ---------------- | ------------------------------------ |
+| 99.8% | 1.3 MiB |         303 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `_handle_fromlist` (`<frozen importlib._bootstrap>:1209`)
 
-|      % |    Size | Samples | Callee                      | Location                            |
-| -----: | ------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 1.3 MiB |     318 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |    Size | Allocations | Callee                      | Location                            |
+| -----: | ------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 1.3 MiB |         318 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|     % |     Size | Samples | Callee             | Location                                               |
-| ----: | -------: | ------: | ------------------ | ------------------------------------------------------ |
-| 85.5% | 1.05 MiB |      53 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167`                   |
-| 11.1% |  140 KiB |     145 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209`                   |
-|  1.1% | 13.9 KiB |       9 | `__new__`          | `<frozen abc>:105`                                     |
-|  0.2% | 2.49 KiB |       3 | `__new__`          | `/usr/lib/python3.11/enum.py:488`                      |
-|  0.1% |    768 B |       1 | `Context`          | `/venv/lib/python3.11/site-packages/click/core.py:204` |
+|     % |     Size | Allocations | Callee             | Location                                               |
+| ----: | -------: | ----------: | ------------------ | ------------------------------------------------------ |
+| 85.5% | 1.05 MiB |          53 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167`                   |
+| 11.1% |  140 KiB |         145 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209`                   |
+|  1.1% | 13.9 KiB |           9 | `__new__`          | `<frozen abc>:105`                                     |
+|  0.2% | 2.49 KiB |           3 | `__new__`          | `/usr/lib/python3.11/enum.py:488`                      |
+|  0.1% |    768 B |           1 | `Context`          | `/venv/lib/python3.11/site-packages/click/core.py:204` |
 
 ##### `compile` (`/usr/lib/python3.11/re/__init__.py:225`)
 
-|     % |     Size | Samples | Callee     | Location                                 |
-| ----: | -------: | ------: | ---------- | ---------------------------------------- |
-| 99.9% | 1.05 MiB |      25 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
+|     % |     Size | Allocations | Callee     | Location                                 |
+| ----: | -------: | ----------: | ---------- | ---------------------------------------- |
+| 99.9% | 1.05 MiB |          25 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
 
 ##### `_compile` (`/usr/lib/python3.11/re/__init__.py:272`)
 
-|     % |     Size | Samples | Callee    | Location                                  |
-| ----: | -------: | ------: | --------- | ----------------------------------------- |
-| 99.9% | 1.05 MiB |      24 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
-|  0.1% |    698 B |       1 | `__and__` | `/usr/lib/python3.11/enum.py:1504`        |
+|     % |     Size | Allocations | Callee    | Location                                  |
+| ----: | -------: | ----------: | --------- | ----------------------------------------- |
+| 99.9% | 1.05 MiB |          24 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
+|  0.1% |    698 B |           1 | `__and__` | `/usr/lib/python3.11/enum.py:1504`        |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|     % |     Size | Samples | Callee  | Location                                  |
-| ----: | -------: | ------: | ------- | ----------------------------------------- |
-| 97.0% | 1.01 MiB |       6 | `parse` | `/usr/lib/python3.11/re/_parser.py:970`   |
-|  0.9% |  9.5 KiB |       6 | `_code` | `/usr/lib/python3.11/re/_compiler.py:571` |
+|     % |     Size | Allocations | Callee  | Location                                  |
+| ----: | -------: | ----------: | ------- | ----------------------------------------- |
+| 97.0% | 1.01 MiB |           6 | `parse` | `/usr/lib/python3.11/re/_parser.py:970`   |
+|  0.9% |  9.5 KiB |           6 | `_code` | `/usr/lib/python3.11/re/_compiler.py:571` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 99.8% | 1.02 MiB |      22 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 99.8% | 1.02 MiB |          22 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `parse` (`/usr/lib/python3.11/re/_parser.py:970`)
 
-|     % |     Size | Samples | Callee       | Location                                |
-| ----: | -------: | ------: | ------------ | --------------------------------------- |
-| 99.9% | 1.01 MiB |       5 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
+|     % |     Size | Allocations | Callee       | Location                                |
+| ----: | -------: | ----------: | ------------ | --------------------------------------- |
+| 99.9% | 1.01 MiB |           5 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|     % |     Size | Samples | Callee           | Location                                 |
-| ----: | -------: | ------: | ---------------- | ---------------------------------------- |
-| 99.7% | 1.01 MiB |      14 | `_process_class` | `/usr/lib/python3.11/dataclasses.py:884` |
+|     % |     Size | Allocations | Callee           | Location                                 |
+| ----: | -------: | ----------: | ---------------- | ---------------------------------------- |
+| 99.7% | 1.01 MiB |          14 | `_process_class` | `/usr/lib/python3.11/dataclasses.py:884` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|     % |     Size | Samples | Callee   | Location                                |
-| ----: | -------: | ------: | -------- | --------------------------------------- |
-| 99.2% | 1.01 MiB |       4 | `_parse` | `/usr/lib/python3.11/re/_parser.py:507` |
+|     % |     Size | Allocations | Callee   | Location                                |
+| ----: | -------: | ----------: | -------- | --------------------------------------- |
+| 99.2% | 1.01 MiB |           4 | `_parse` | `/usr/lib/python3.11/re/_parser.py:507` |
 
 ##### `_process_class` (`/usr/lib/python3.11/dataclasses.py:884`)
 
-|     % |    Size | Samples | Callee               | Location                                 |
-| ----: | ------: | ------: | -------------------- | ---------------------------------------- |
-| 98.9% |   1 MiB |       1 | `_init_fn`           | `/usr/lib/python3.11/dataclasses.py:528` |
-|  0.6% | 6.5 KiB |       5 | `signature`          | `/usr/lib/python3.11/inspect.py:3277`    |
-|  0.1% | 1.5 KiB |       2 | `_set_new_attribute` | `/usr/lib/python3.11/dataclasses.py:827` |
-| <0.1% |   341 B |       1 | `_cmp_fn`            | `/usr/lib/python3.11/dataclasses.py:624` |
-| <0.1% |   336 B |       1 | `_repr_fn`           | `/usr/lib/python3.11/dataclasses.py:588` |
+|     % |    Size | Allocations | Callee               | Location                                 |
+| ----: | ------: | ----------: | -------------------- | ---------------------------------------- |
+| 98.9% |   1 MiB |           1 | `_init_fn`           | `/usr/lib/python3.11/dataclasses.py:528` |
+|  0.6% | 6.5 KiB |           5 | `signature`          | `/usr/lib/python3.11/inspect.py:3277`    |
+|  0.1% | 1.5 KiB |           2 | `_set_new_attribute` | `/usr/lib/python3.11/dataclasses.py:827` |
+| <0.1% |   341 B |           1 | `_cmp_fn`            | `/usr/lib/python3.11/dataclasses.py:624` |
+| <0.1% |   336 B |           1 | `_repr_fn`           | `/usr/lib/python3.11/dataclasses.py:588` |
 
 ##### `dataclass` (`/usr/lib/python3.11/dataclasses.py:1192`)
 
-|      % |     Size | Samples | Callee | Location                                  |
-| -----: | -------: | ------: | ------ | ----------------------------------------- |
-| 100.0% | 1.01 MiB |      11 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
+|      % |     Size | Allocations | Callee | Location                                  |
+| -----: | -------: | ----------: | ------ | ----------------------------------------- |
+| 100.0% | 1.01 MiB |          11 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|     % |  Size | Samples | Callee        | Location                                |
-| ----: | ----: | ------: | ------------- | --------------------------------------- |
-| 99.6% | 1 MiB |       2 | `_parse_sub`  | `/usr/lib/python3.11/re/_parser.py:447` |
-| 99.5% | 1 MiB |       1 | `__getitem__` | `/usr/lib/python3.11/re/_parser.py:162` |
+|     % |  Size | Allocations | Callee        | Location                                |
+| ----: | ----: | ----------: | ------------- | --------------------------------------- |
+| 99.6% | 1 MiB |           2 | `_parse_sub`  | `/usr/lib/python3.11/re/_parser.py:447` |
+| 99.5% | 1 MiB |           1 | `__getitem__` | `/usr/lib/python3.11/re/_parser.py:162` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                                                         |
-| ----: | -------: | ------: | ---------------- | ---------------------------------------------------------------- |
-| 90.2% |  156 KiB |     130 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                             |
-|  4.9% |  8.5 KiB |       2 | `Specifier`      | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220` |
-|  3.5% | 6.07 KiB |       7 | `__new__`        | `<frozen abc>:105`                                               |
+|     % |     Size | Allocations | Callee           | Location                                                         |
+| ----: | -------: | ----------: | ---------------- | ---------------------------------------------------------------- |
+| 90.2% |  156 KiB |         130 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                             |
+|  4.9% |  8.5 KiB |           2 | `Specifier`      | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220` |
+|  3.5% | 6.07 KiB |           7 | `__new__`        | `<frozen abc>:105`                                               |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 53.0% | 66.2 KiB |      58 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
-| 30.6% | 38.2 KiB |      45 | `__new__`        | `<frozen abc>:105`                   |
-| 12.6% | 15.7 KiB |      19 | `__new__`        | `/usr/lib/python3.11/typing.py:2891` |
-|  1.1% | 1.42 KiB |       2 | `inner`          | `/usr/lib/python3.11/typing.py:338`  |
-|  0.4% |    542 B |       1 | `__init__`       | `/usr/lib/python3.11/typing.py:992`  |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 53.0% | 66.2 KiB |          58 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+| 30.6% | 38.2 KiB |          45 | `__new__`        | `<frozen abc>:105`                   |
+| 12.6% | 15.7 KiB |          19 | `__new__`        | `/usr/lib/python3.11/typing.py:2891` |
+|  1.1% | 1.42 KiB |           2 | `inner`          | `/usr/lib/python3.11/typing.py:338`  |
+|  0.4% |    542 B |           1 | `__init__`       | `/usr/lib/python3.11/typing.py:992`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 96.4% | 96.1 KiB |      68 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 96.4% | 96.1 KiB |          68 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 99.2% | 93.1 KiB |     118 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 99.2% | 93.1 KiB |         118 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`)
 
-|     % |   Size | Samples | Callee           | Location                             |
-| ----: | -----: | ------: | ---------------- | ------------------------------------ |
-| 97.3% | 89 KiB |     112 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |   Size | Allocations | Callee           | Location                             |
+| ----: | -----: | ----------: | ---------------- | ------------------------------------ |
+| 97.3% | 89 KiB |         112 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|     % |     Size | Samples | Callee             | Location                             |
-| ----: | -------: | ------: | ------------------ | ------------------------------------ |
-| 22.4% | 16.7 KiB |      17 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167` |
-| 21.2% | 15.8 KiB |      19 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209` |
+|     % |     Size | Allocations | Callee             | Location                             |
+| ----: | -------: | ----------: | ------------------ | ------------------------------------ |
+| 22.4% | 16.7 KiB |          17 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167` |
+| 21.2% | 15.8 KiB |          19 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 98.9% | 64.8 KiB |      83 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 98.9% | 64.8 KiB |          83 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `decorator` (`/venv/lib/python3.11/site-packages/click/decorators.py:373`)
 
-|     % |     Size | Samples | Callee     | Location                                                |
-| ----: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 96.2% | 45.5 KiB |      32 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2883` |
+|     % |     Size | Allocations | Callee     | Location                                                |
+| ----: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 96.2% | 45.5 KiB |          32 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2883` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 94.8% | 44.5 KiB |      56 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 94.8% | 44.5 KiB |          56 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|    % |     Size | Samples | Callee     | Location                                                |
-| ---: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 2.6% | 1.17 KiB |       1 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2237` |
+|    % |     Size | Allocations | Callee     | Location                                                |
+| ---: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 2.6% | 1.17 KiB |           1 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2237` |
 
 ## Hottest call stacks
 
@@ -1444,38 +1444,38 @@ Call stacks ranked by bytes held at peak memory in their leaf frame.
 
 Common call stack: `run_module` (`<frozen runpy>:201`) ← `_run_tracker` (`/venv/lib/python3.11/site-packages/memray/commands/run.py:40`)
 
-|     % |     Size | Samples | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| ----: | -------: | ------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 11.6% | 9.12 MiB |     142 | `parse` (`/usr/lib/python3.11/ast.py:33`) ← `_parse_single_version` (`black/parsing.py:117`) ← `parse_ast` (129) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-|  9.0% |  7.1 MiB |       4 | `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-|  6.4% |    5 MiB |       5 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `shift` (`blib2to3/pgen2/parse.py:373`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-|  3.8% |    3 MiB |       3 | `_stringify_ast_with_new_parent` (`black/parsing.py:166`) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-|  3.8% |    3 MiB |       3 | `push` (`blib2to3/pgen2/parse.py:386`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-|  2.6% | 2.04 MiB |      43 | `_stringify_ast` (`black/parsing.py:174`) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-|  2.5% |    2 MiB |       2 | `__init__` (`<string>:2`) ← `__init__` (2) ← `line` (`black/linegen.py:109`) ← `visit_INDENT` (179) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-|  2.0% | 1.56 MiB |     767 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-|  1.4% | 1.09 MiB |     125 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                             |
-|  1.3% | 1.01 MiB |      11 | `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                             |
-|  1.3% |    1 MiB |       5 | `__init__` (`blib2to3/pytree.py:248`) ← `convert` (486) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-|  1.3% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `changed` (171) ← `prefix` (480) ← `prefix` (329) ← `wrap_in_parentheses` (`black/nodes.py:935`) ← `normalize_invisible_parens` (`black/linegen.py:1328`) ← `visit_stmt` (199) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-|  1.3% |    1 MiB |       1 | `_create_fn` (`/usr/lib/python3.11/dataclasses.py:413`) ← `_init_fn` (528) ← `_process_class` (884) ← `wrap` (1209) ← `dataclass` (1192) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-|  1.3% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                    |
-|  1.3% |    1 MiB |       1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-|  1.3% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-|  1.3% |    1 MiB |       1 | `__init__` (`<string>:2`) ← `__init__` (2) ← `line` (`black/linegen.py:109`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-|  1.3% |    1 MiB |       1 | `debug` (`/usr/lib/python3.11/logging/__init__.py:1467`) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-|  1.3% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
-|  1.3% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
+|     % |     Size | Allocations | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| ----: | -------: | ----------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 11.6% | 9.12 MiB |         142 | `parse` (`/usr/lib/python3.11/ast.py:33`) ← `_parse_single_version` (`black/parsing.py:117`) ← `parse_ast` (129) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+|  9.0% |  7.1 MiB |           4 | `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+|  6.4% |    5 MiB |           5 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `shift` (`blib2to3/pgen2/parse.py:373`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+|  3.8% |    3 MiB |           3 | `_stringify_ast_with_new_parent` (`black/parsing.py:166`) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+|  3.8% |    3 MiB |           3 | `push` (`blib2to3/pgen2/parse.py:386`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+|  2.6% | 2.04 MiB |          43 | `_stringify_ast` (`black/parsing.py:174`) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+|  2.5% |    2 MiB |           2 | `__init__` (`<string>:2`) ← `__init__` (2) ← `line` (`black/linegen.py:109`) ← `visit_INDENT` (179) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+|  2.0% | 1.56 MiB |         767 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+|  1.4% | 1.09 MiB |         125 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                             |
+|  1.3% | 1.01 MiB |          11 | `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                             |
+|  1.3% |    1 MiB |           5 | `__init__` (`blib2to3/pytree.py:248`) ← `convert` (486) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+|  1.3% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `changed` (171) ← `prefix` (480) ← `prefix` (329) ← `wrap_in_parentheses` (`black/nodes.py:935`) ← `normalize_invisible_parens` (`black/linegen.py:1328`) ← `visit_stmt` (199) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+|  1.3% |    1 MiB |           1 | `_create_fn` (`/usr/lib/python3.11/dataclasses.py:413`) ← `_init_fn` (528) ← `_process_class` (884) ← `wrap` (1209) ← `dataclass` (1192) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+|  1.3% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                    |
+|  1.3% |    1 MiB |           1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+|  1.3% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+|  1.3% |    1 MiB |           1 | `__init__` (`<string>:2`) ← `__init__` (2) ← `line` (`black/linegen.py:109`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+|  1.3% |    1 MiB |           1 | `debug` (`/usr/lib/python3.11/logging/__init__.py:1467`) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+|  1.3% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
+|  1.3% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
 
 # Leaked memory profile
 
-Leaked 55.9 MiB over 22,489 samples (2.55 KiB per sample).
+Leaked 55.9 MiB over 22,489 allocations (2.55 KiB per allocation).
 
-| Category         |     % |     Size | Samples |
-| ---------------- | ----: | -------: | ------: |
-| Ours             | 85.6% | 47.9 MiB |  21,383 |
-| Standard library | 12.2% | 6.83 MiB |     876 |
-| Third-party      |  2.2% | 1.23 MiB |     230 |
+| Category         |     % |     Size | Allocations |
+| ---------------- | ----: | -------: | ----------: |
+| Ours             | 85.6% | 47.9 MiB |      21,383 |
+| Standard library | 12.2% | 6.83 MiB |         876 |
+| Third-party      |  2.2% | 1.23 MiB |         230 |
 
 ## Hottest functions
 
@@ -1483,105 +1483,105 @@ Leaked 55.9 MiB over 22,489 samples (2.55 KiB per sample).
 
 Functions ranked by bytes never freed directly in the function body, excluding callees.
 
-|     % |     Size | Samples | Function                         | Location                                               |
-| ----: | -------: | ------: | -------------------------------- | ------------------------------------------------------ |
-| 29.0% | 16.2 MiB |  20,788 | `mark`                           | `black/brackets.py:70`                                 |
-| 12.5% |    7 MiB |       7 | `__new__`                        | `blib2to3/pytree.py:81`                                |
-|  9.2% | 5.14 MiB |     200 | `update_sibling_maps`            | `blib2to3/pytree.py:369`                               |
-|  8.9% |    5 MiB |       5 | `changed`                        | `blib2to3/pytree.py:171`                               |
-|  5.4% | 3.01 MiB |       4 | `parse`                          | `/usr/lib/python3.11/ast.py:33`                        |
-|  5.4% |    3 MiB |       3 | `push`                           | `blib2to3/pgen2/parse.py:386`                          |
-|  3.6% |    2 MiB |       6 | `__init__`                       | `blib2to3/pytree.py:248`                               |
-|  3.6% |    2 MiB |       3 | `visit_default`                  | `black/linegen.py:134`                                 |
-|  3.6% |    2 MiB |       2 | `__init__`                       | `<string>:2`                                           |
-|  1.9% | 1.07 MiB |       7 | `transform_line`                 | `black/linegen.py:601`                                 |
-|  1.8% | 1.01 MiB |      11 | `<module>`                       | `/venv/lib/python3.11/site-packages/click/parser.py:1` |
-|  1.8% |    1 MiB |       3 | `_create_fn`                     | `/usr/lib/python3.11/dataclasses.py:413`               |
-|  1.8% |    1 MiB |       1 | `prefix`                         | `blib2to3/pytree.py:480`                               |
-|  1.8% |    1 MiB |       1 | `generate_comments`              | `black/comments.py:52`                                 |
-|  1.8% |    1 MiB |       1 | `debug`                          | `/usr/lib/python3.11/logging/__init__.py:1467`         |
-|  1.8% |    1 MiB |       1 | `_stringify_ast_with_new_parent` | `black/parsing.py:166`                                 |
-|  1.8% |    1 MiB |       1 | `generate_tokens`                | `blib2to3/pgen2/tokenize.py:565`                       |
-|  1.8% |    1 MiB |       1 | `__getitem__`                    | `/usr/lib/python3.11/re/_parser.py:162`                |
-|  1.0% |  560 KiB |     606 | `_compile_bytecode`              | `<frozen importlib._bootstrap_external>:727`           |
-|  0.1% | 75.7 KiB |      79 | `__new__`                        | `<frozen abc>:105`                                     |
+|     % |     Size | Allocations | Function                         | Location                                               |
+| ----: | -------: | ----------: | -------------------------------- | ------------------------------------------------------ |
+| 29.0% | 16.2 MiB |      20,788 | `mark`                           | `black/brackets.py:70`                                 |
+| 12.5% |    7 MiB |           7 | `__new__`                        | `blib2to3/pytree.py:81`                                |
+|  9.2% | 5.14 MiB |         200 | `update_sibling_maps`            | `blib2to3/pytree.py:369`                               |
+|  8.9% |    5 MiB |           5 | `changed`                        | `blib2to3/pytree.py:171`                               |
+|  5.4% | 3.01 MiB |           4 | `parse`                          | `/usr/lib/python3.11/ast.py:33`                        |
+|  5.4% |    3 MiB |           3 | `push`                           | `blib2to3/pgen2/parse.py:386`                          |
+|  3.6% |    2 MiB |           6 | `__init__`                       | `blib2to3/pytree.py:248`                               |
+|  3.6% |    2 MiB |           3 | `visit_default`                  | `black/linegen.py:134`                                 |
+|  3.6% |    2 MiB |           2 | `__init__`                       | `<string>:2`                                           |
+|  1.9% | 1.07 MiB |           7 | `transform_line`                 | `black/linegen.py:601`                                 |
+|  1.8% | 1.01 MiB |          11 | `<module>`                       | `/venv/lib/python3.11/site-packages/click/parser.py:1` |
+|  1.8% |    1 MiB |           3 | `_create_fn`                     | `/usr/lib/python3.11/dataclasses.py:413`               |
+|  1.8% |    1 MiB |           1 | `prefix`                         | `blib2to3/pytree.py:480`                               |
+|  1.8% |    1 MiB |           1 | `generate_comments`              | `black/comments.py:52`                                 |
+|  1.8% |    1 MiB |           1 | `debug`                          | `/usr/lib/python3.11/logging/__init__.py:1467`         |
+|  1.8% |    1 MiB |           1 | `_stringify_ast_with_new_parent` | `black/parsing.py:166`                                 |
+|  1.8% |    1 MiB |           1 | `generate_tokens`                | `blib2to3/pgen2/tokenize.py:565`                       |
+|  1.8% |    1 MiB |           1 | `__getitem__`                    | `/usr/lib/python3.11/re/_parser.py:162`                |
+|  1.0% |  560 KiB |         606 | `_compile_bytecode`              | `<frozen importlib._bootstrap_external>:727`           |
+|  0.1% | 75.7 KiB |          79 | `__new__`                        | `<frozen abc>:105`                                     |
 
 #### Categories
 
 ##### Ours
 
-|     % |     Size | Samples | Function                         | Location                         |
-| ----: | -------: | ------: | -------------------------------- | -------------------------------- |
-| 29.0% | 16.2 MiB |  20,788 | `mark`                           | `black/brackets.py:70`           |
-| 12.5% |    7 MiB |       7 | `__new__`                        | `blib2to3/pytree.py:81`          |
-|  9.2% | 5.14 MiB |     200 | `update_sibling_maps`            | `blib2to3/pytree.py:369`         |
-|  8.9% |    5 MiB |       5 | `changed`                        | `blib2to3/pytree.py:171`         |
-|  5.4% |    3 MiB |       3 | `push`                           | `blib2to3/pgen2/parse.py:386`    |
-|  3.6% |    2 MiB |       6 | `__init__`                       | `blib2to3/pytree.py:248`         |
-|  3.6% |    2 MiB |       3 | `visit_default`                  | `black/linegen.py:134`           |
-|  3.6% |    2 MiB |       2 | `__init__`                       | `<string>:2`                     |
-|  1.9% | 1.07 MiB |       7 | `transform_line`                 | `black/linegen.py:601`           |
-|  1.8% |    1 MiB |       1 | `prefix`                         | `blib2to3/pytree.py:480`         |
-|  1.8% |    1 MiB |       1 | `generate_comments`              | `black/comments.py:52`           |
-|  1.8% |    1 MiB |       1 | `_stringify_ast_with_new_parent` | `black/parsing.py:166`           |
-|  1.8% |    1 MiB |       1 | `generate_tokens`                | `blib2to3/pgen2/tokenize.py:565` |
-|  0.1% | 57.2 KiB |      65 | `normalize_string_prefix`        | `black/strings.py:143`           |
-|  0.1% | 41.5 KiB |      16 | `copy`                           | `blib2to3/pgen2/grammar.py:131`  |
-|  0.1% |   32 KiB |       1 | `classify`                       | `blib2to3/pgen2/parse.py:336`    |
-| <0.1% | 25.3 KiB |      40 | `make_first`                     | `blib2to3/pgen2/pgen.py:74`      |
-| <0.1% | 20.7 KiB |      14 | `<module>`                       | `blib2to3/pgen2/tokenize.py:1`   |
-| <0.1% | 18.6 KiB |       2 | `convert_one_fmt_off_pair`       | `black/comments.py:177`          |
-| <0.1% |   15 KiB |      18 | `<module>`                       | `blib2to3/pytree.py:1`           |
+|     % |     Size | Allocations | Function                         | Location                         |
+| ----: | -------: | ----------: | -------------------------------- | -------------------------------- |
+| 29.0% | 16.2 MiB |      20,788 | `mark`                           | `black/brackets.py:70`           |
+| 12.5% |    7 MiB |           7 | `__new__`                        | `blib2to3/pytree.py:81`          |
+|  9.2% | 5.14 MiB |         200 | `update_sibling_maps`            | `blib2to3/pytree.py:369`         |
+|  8.9% |    5 MiB |           5 | `changed`                        | `blib2to3/pytree.py:171`         |
+|  5.4% |    3 MiB |           3 | `push`                           | `blib2to3/pgen2/parse.py:386`    |
+|  3.6% |    2 MiB |           6 | `__init__`                       | `blib2to3/pytree.py:248`         |
+|  3.6% |    2 MiB |           3 | `visit_default`                  | `black/linegen.py:134`           |
+|  3.6% |    2 MiB |           2 | `__init__`                       | `<string>:2`                     |
+|  1.9% | 1.07 MiB |           7 | `transform_line`                 | `black/linegen.py:601`           |
+|  1.8% |    1 MiB |           1 | `prefix`                         | `blib2to3/pytree.py:480`         |
+|  1.8% |    1 MiB |           1 | `generate_comments`              | `black/comments.py:52`           |
+|  1.8% |    1 MiB |           1 | `_stringify_ast_with_new_parent` | `black/parsing.py:166`           |
+|  1.8% |    1 MiB |           1 | `generate_tokens`                | `blib2to3/pgen2/tokenize.py:565` |
+|  0.1% | 57.2 KiB |          65 | `normalize_string_prefix`        | `black/strings.py:143`           |
+|  0.1% | 41.5 KiB |          16 | `copy`                           | `blib2to3/pgen2/grammar.py:131`  |
+|  0.1% |   32 KiB |           1 | `classify`                       | `blib2to3/pgen2/parse.py:336`    |
+| <0.1% | 25.3 KiB |          40 | `make_first`                     | `blib2to3/pgen2/pgen.py:74`      |
+| <0.1% | 20.7 KiB |          14 | `<module>`                       | `blib2to3/pgen2/tokenize.py:1`   |
+| <0.1% | 18.6 KiB |           2 | `convert_one_fmt_off_pair`       | `black/comments.py:177`          |
+| <0.1% |   15 KiB |          18 | `<module>`                       | `blib2to3/pytree.py:1`           |
 
 ##### Standard library
 
-|     % |     Size | Samples | Function            | Location                                          |
-| ----: | -------: | ------: | ------------------- | ------------------------------------------------- |
-|  5.4% | 3.01 MiB |       4 | `parse`             | `/usr/lib/python3.11/ast.py:33`                   |
-|  1.8% |    1 MiB |       3 | `_create_fn`        | `/usr/lib/python3.11/dataclasses.py:413`          |
-|  1.8% |    1 MiB |       1 | `debug`             | `/usr/lib/python3.11/logging/__init__.py:1467`    |
-|  1.8% |    1 MiB |       1 | `__getitem__`       | `/usr/lib/python3.11/re/_parser.py:162`           |
-|  1.0% |  560 KiB |     606 | `_compile_bytecode` | `<frozen importlib._bootstrap_external>:727`      |
-|  0.1% | 75.7 KiB |      79 | `__new__`           | `<frozen abc>:105`                                |
-| <0.1% | 24.1 KiB |      27 | `__new__`           | `/usr/lib/python3.11/enum.py:488`                 |
-| <0.1% | 22.6 KiB |      12 | `compile`           | `/usr/lib/python3.11/re/_compiler.py:738`         |
-| <0.1% | 19.8 KiB |      12 | `<module>`          | `/usr/lib/python3.11/tomllib/_parser.py:1`        |
-| <0.1% | 17.4 KiB |      21 | `__new__`           | `/usr/lib/python3.11/typing.py:2891`              |
-| <0.1% |   12 KiB |       3 | `inner`             | `/usr/lib/python3.11/typing.py:338`               |
-| <0.1% |    8 KiB |       4 | `_fill_cache`       | `<frozen importlib._bootstrap_external>:1655`     |
-| <0.1% | 7.97 KiB |       1 | `_parse_sub`        | `/usr/lib/python3.11/re/_parser.py:447`           |
-| <0.1% | 6.73 KiB |       8 | `__setattr__`       | `/usr/lib/python3.11/enum.py:831`                 |
-| <0.1% | 5.63 KiB |       6 | `namedtuple`        | `/usr/lib/python3.11/collections/__init__.py:348` |
-| <0.1% | 5.61 KiB |       3 | `_parse`            | `/usr/lib/python3.11/re/_parser.py:507`           |
-| <0.1% | 5.32 KiB |       2 | `_code`             | `/usr/lib/python3.11/re/_compiler.py:571`         |
-| <0.1% | 4.73 KiB |       6 | `<module>`          | `/usr/lib/python3.11/pkgutil.py:1`                |
-| <0.1% | 2.85 KiB |       1 | `wrap`              | `/usr/lib/python3.11/dataclasses.py:1209`         |
-| <0.1% | 2.85 KiB |       4 | `_process_class`    | `/usr/lib/python3.11/dataclasses.py:884`          |
+|     % |     Size | Allocations | Function            | Location                                          |
+| ----: | -------: | ----------: | ------------------- | ------------------------------------------------- |
+|  5.4% | 3.01 MiB |           4 | `parse`             | `/usr/lib/python3.11/ast.py:33`                   |
+|  1.8% |    1 MiB |           3 | `_create_fn`        | `/usr/lib/python3.11/dataclasses.py:413`          |
+|  1.8% |    1 MiB |           1 | `debug`             | `/usr/lib/python3.11/logging/__init__.py:1467`    |
+|  1.8% |    1 MiB |           1 | `__getitem__`       | `/usr/lib/python3.11/re/_parser.py:162`           |
+|  1.0% |  560 KiB |         606 | `_compile_bytecode` | `<frozen importlib._bootstrap_external>:727`      |
+|  0.1% | 75.7 KiB |          79 | `__new__`           | `<frozen abc>:105`                                |
+| <0.1% | 24.1 KiB |          27 | `__new__`           | `/usr/lib/python3.11/enum.py:488`                 |
+| <0.1% | 22.6 KiB |          12 | `compile`           | `/usr/lib/python3.11/re/_compiler.py:738`         |
+| <0.1% | 19.8 KiB |          12 | `<module>`          | `/usr/lib/python3.11/tomllib/_parser.py:1`        |
+| <0.1% | 17.4 KiB |          21 | `__new__`           | `/usr/lib/python3.11/typing.py:2891`              |
+| <0.1% |   12 KiB |           3 | `inner`             | `/usr/lib/python3.11/typing.py:338`               |
+| <0.1% |    8 KiB |           4 | `_fill_cache`       | `<frozen importlib._bootstrap_external>:1655`     |
+| <0.1% | 7.97 KiB |           1 | `_parse_sub`        | `/usr/lib/python3.11/re/_parser.py:447`           |
+| <0.1% | 6.73 KiB |           8 | `__setattr__`       | `/usr/lib/python3.11/enum.py:831`                 |
+| <0.1% | 5.63 KiB |           6 | `namedtuple`        | `/usr/lib/python3.11/collections/__init__.py:348` |
+| <0.1% | 5.61 KiB |           3 | `_parse`            | `/usr/lib/python3.11/re/_parser.py:507`           |
+| <0.1% | 5.32 KiB |           2 | `_code`             | `/usr/lib/python3.11/re/_compiler.py:571`         |
+| <0.1% | 4.73 KiB |           6 | `<module>`          | `/usr/lib/python3.11/pkgutil.py:1`                |
+| <0.1% | 2.85 KiB |           1 | `wrap`              | `/usr/lib/python3.11/dataclasses.py:1209`         |
+| <0.1% | 2.85 KiB |           4 | `_process_class`    | `/usr/lib/python3.11/dataclasses.py:884`          |
 
 ##### Third-party
 
-|     % |     Size | Samples | Function              | Location                                                                   |
-| ----: | -------: | ------: | --------------------- | -------------------------------------------------------------------------- |
-|  1.8% | 1.01 MiB |      11 | `<module>`            | `/venv/lib/python3.11/site-packages/click/parser.py:1`                     |
-|  0.1% | 44.3 KiB |      31 | `__init__`            | `/venv/lib/python3.11/site-packages/click/core.py:2883`                    |
-| <0.1% |   25 KiB |      22 | `<module>`            | `/venv/lib/python3.11/site-packages/click/core.py:1`                       |
-| <0.1% |   15 KiB |      18 | `<module>`            | `/venv/lib/python3.11/site-packages/mypy_extensions.py:1`                  |
-| <0.1% | 13.4 KiB |      15 | `<module>`            | `/venv/lib/python3.11/site-packages/click/exceptions.py:1`                 |
-| <0.1% | 9.61 KiB |       9 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/version.py:1`                |
-| <0.1% | 7.08 KiB |       8 | `<module>`            | `/venv/lib/python3.11/site-packages/click/utils.py:1`                      |
-| <0.1% | 6.48 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/util.py:1`                    |
-| <0.1% | 6.24 KiB |       5 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                |
-| <0.1% | 5.97 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                   |
-| <0.1% |  5.8 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/click/_compat.py:1`                    |
-| <0.1% | 3.82 KiB |       1 | `Specifier`           | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`           |
-| <0.1% | 3.72 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`                 |
-| <0.1% | 3.56 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                  |
-| <0.1% | 3.37 KiB |       5 | `handle_parse_result` | `/venv/lib/python3.11/site-packages/click/core.py:2663`                    |
-| <0.1% | 3.19 KiB |       1 | `<module>`            | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                   |
-| <0.1% | 3.19 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`                |
-| <0.1% | 3.04 KiB |       2 | `new_func`            | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                |
-| <0.1% | 2.81 KiB |       3 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1` |
-| <0.1% | 2.76 KiB |       2 | `<module>`            | `/venv/lib/python3.11/site-packages/click/types.py:1`                      |
+|     % |     Size | Allocations | Function              | Location                                                                   |
+| ----: | -------: | ----------: | --------------------- | -------------------------------------------------------------------------- |
+|  1.8% | 1.01 MiB |          11 | `<module>`            | `/venv/lib/python3.11/site-packages/click/parser.py:1`                     |
+|  0.1% | 44.3 KiB |          31 | `__init__`            | `/venv/lib/python3.11/site-packages/click/core.py:2883`                    |
+| <0.1% |   25 KiB |          22 | `<module>`            | `/venv/lib/python3.11/site-packages/click/core.py:1`                       |
+| <0.1% |   15 KiB |          18 | `<module>`            | `/venv/lib/python3.11/site-packages/mypy_extensions.py:1`                  |
+| <0.1% | 13.4 KiB |          15 | `<module>`            | `/venv/lib/python3.11/site-packages/click/exceptions.py:1`                 |
+| <0.1% | 9.61 KiB |           9 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/version.py:1`                |
+| <0.1% | 7.08 KiB |           8 | `<module>`            | `/venv/lib/python3.11/site-packages/click/utils.py:1`                      |
+| <0.1% | 6.48 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/util.py:1`                    |
+| <0.1% | 6.24 KiB |           5 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                |
+| <0.1% | 5.97 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                   |
+| <0.1% |  5.8 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/click/_compat.py:1`                    |
+| <0.1% | 3.82 KiB |           1 | `Specifier`           | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`           |
+| <0.1% | 3.72 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`                 |
+| <0.1% | 3.56 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                  |
+| <0.1% | 3.37 KiB |           5 | `handle_parse_result` | `/venv/lib/python3.11/site-packages/click/core.py:2663`                    |
+| <0.1% | 3.19 KiB |           1 | `<module>`            | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                   |
+| <0.1% | 3.19 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`                |
+| <0.1% | 3.04 KiB |           2 | `new_func`            | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                |
+| <0.1% | 2.81 KiB |           3 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1` |
+| <0.1% | 2.76 KiB |           2 | `<module>`            | `/venv/lib/python3.11/site-packages/click/types.py:1`                      |
 
 #### Lines
 
@@ -1589,446 +1589,446 @@ Lines ranked by contribution to each function's self size.
 
 ##### `mark` (`black/brackets.py:70`)
 
-|      % |     Size | Samples | Location                |
-| -----: | -------: | ------: | ----------------------- |
-| 100.0% | 16.2 MiB |  20,787 | `black/brackets.py:112` |
-|  <0.1% | 1.49 KiB |       1 | `black/brackets.py:114` |
+|      % |     Size | Allocations | Location                |
+| -----: | -------: | ----------: | ----------------------- |
+| 100.0% | 16.2 MiB |      20,787 | `black/brackets.py:112` |
+|  <0.1% | 1.49 KiB |           1 | `black/brackets.py:114` |
 
 ##### `__new__` (`blib2to3/pytree.py:81`)
 
-|      % |  Size | Samples | Location                |
-| -----: | ----: | ------: | ----------------------- |
-| 100.0% | 7 MiB |       7 | `blib2to3/pytree.py:84` |
+|      % |  Size | Allocations | Location                |
+| -----: | ----: | ----------: | ----------------------- |
+| 100.0% | 7 MiB |           7 | `blib2to3/pytree.py:84` |
 
 ##### `update_sibling_maps` (`blib2to3/pytree.py:369`)
 
-|     % |     Size | Samples | Location                 |
-| ----: | -------: | ------: | ------------------------ |
-| 98.6% | 5.07 MiB |      98 | `blib2to3/pytree.py:377` |
-|  1.3% | 70.3 KiB |      93 | `blib2to3/pytree.py:376` |
-|  0.1% | 4.99 KiB |       9 | `blib2to3/pytree.py:379` |
+|     % |     Size | Allocations | Location                 |
+| ----: | -------: | ----------: | ------------------------ |
+| 98.6% | 5.07 MiB |          98 | `blib2to3/pytree.py:377` |
+|  1.3% | 70.3 KiB |          93 | `blib2to3/pytree.py:376` |
+|  0.1% | 4.99 KiB |           9 | `blib2to3/pytree.py:379` |
 
 ##### `changed` (`blib2to3/pytree.py:171`)
 
-|      % |  Size | Samples | Location                 |
-| -----: | ----: | ------: | ------------------------ |
-| 100.0% | 5 MiB |       5 | `blib2to3/pytree.py:175` |
+|      % |  Size | Allocations | Location                 |
+| -----: | ----: | ----------: | ------------------------ |
+| 100.0% | 5 MiB |           5 | `blib2to3/pytree.py:175` |
 
 ##### `parse` (`/usr/lib/python3.11/ast.py:33`)
 
-|      % |     Size | Samples | Location                        |
-| -----: | -------: | ------: | ------------------------------- |
-| 100.0% | 3.01 MiB |       4 | `/usr/lib/python3.11/ast.py:50` |
+|      % |     Size | Allocations | Location                        |
+| -----: | -------: | ----------: | ------------------------------- |
+| 100.0% | 3.01 MiB |           4 | `/usr/lib/python3.11/ast.py:50` |
 
 ##### `push` (`blib2to3/pgen2/parse.py:386`)
 
-|      % |  Size | Samples | Location                      |
-| -----: | ----: | ------: | ----------------------------- |
-| 100.0% | 3 MiB |       3 | `blib2to3/pgen2/parse.py:394` |
+|      % |  Size | Allocations | Location                      |
+| -----: | ----: | ----------: | ----------------------------- |
+| 100.0% | 3 MiB |           3 | `blib2to3/pgen2/parse.py:394` |
 
 ##### `__init__` (`blib2to3/pytree.py:248`)
 
-|      % |  Size | Samples | Location                 |
-| -----: | ----: | ------: | ------------------------ |
-| 100.0% | 2 MiB |       6 | `blib2to3/pytree.py:266` |
+|      % |  Size | Allocations | Location                 |
+| -----: | ----: | ----------: | ------------------------ |
+| 100.0% | 2 MiB |           6 | `blib2to3/pytree.py:266` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|      % |  Size | Samples | Location               |
-| -----: | ----: | ------: | ---------------------- |
-| 100.0% | 2 MiB |       2 | `black/linegen.py:158` |
-|  <0.1% | 702 B |       1 | `black/linegen.py:144` |
+|      % |  Size | Allocations | Location               |
+| -----: | ----: | ----------: | ---------------------- |
+| 100.0% | 2 MiB |           2 | `black/linegen.py:158` |
+|  <0.1% | 702 B |           1 | `black/linegen.py:144` |
 
 ##### `__init__` (`<string>:2`)
 
-|     % |  Size | Samples | Location     |
-| ----: | ----: | ------: | ------------ |
-| 50.0% | 1 MiB |       1 | `<string>:5` |
-| 50.0% | 1 MiB |       1 | `<string>:7` |
+|     % |  Size | Allocations | Location     |
+| ----: | ----: | ----------: | ------------ |
+| 50.0% | 1 MiB |           1 | `<string>:5` |
+| 50.0% | 1 MiB |           1 | `<string>:7` |
 
 ##### `transform_line` (`black/linegen.py:601`)
 
-|     % |     Size | Samples | Location               |
-| ----: | -------: | ------: | ---------------------- |
-| 93.0% |    1 MiB |       1 | `black/linegen.py:707` |
-|  6.7% | 73.7 KiB |       3 | `black/linegen.py:679` |
-|  0.1% | 1.39 KiB |       1 | `black/linegen.py:635` |
-|  0.1% |    910 B |       1 | `black/linegen.py:714` |
-| <0.1% |    518 B |       1 | `black/linegen.py:631` |
+|     % |     Size | Allocations | Location               |
+| ----: | -------: | ----------: | ---------------------- |
+| 93.0% |    1 MiB |           1 | `black/linegen.py:707` |
+|  6.7% | 73.7 KiB |           3 | `black/linegen.py:679` |
+|  0.1% | 1.39 KiB |           1 | `black/linegen.py:635` |
+|  0.1% |    910 B |           1 | `black/linegen.py:714` |
+| <0.1% |    518 B |           1 | `black/linegen.py:631` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`)
 
-|     % |     Size | Samples | Location                                                 |
-| ----: | -------: | ------: | -------------------------------------------------------- |
-| 99.4% |    1 MiB |       3 | `/venv/lib/python3.11/site-packages/click/parser.py:185` |
-|  0.2% | 2.29 KiB |       3 | `/venv/lib/python3.11/site-packages/click/parser.py:224` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:127` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:216` |
-|  0.1% |    768 B |       1 | `/venv/lib/python3.11/site-packages/click/parser.py:51`  |
+|     % |     Size | Allocations | Location                                                 |
+| ----: | -------: | ----------: | -------------------------------------------------------- |
+| 99.4% |    1 MiB |           3 | `/venv/lib/python3.11/site-packages/click/parser.py:185` |
+|  0.2% | 2.29 KiB |           3 | `/venv/lib/python3.11/site-packages/click/parser.py:224` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:127` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:216` |
+|  0.1% |    768 B |           1 | `/venv/lib/python3.11/site-packages/click/parser.py:51`  |
 
 ##### `_create_fn` (`/usr/lib/python3.11/dataclasses.py:413`)
 
-|      % |  Size | Samples | Location                                 |
-| -----: | ----: | ------: | ---------------------------------------- |
-| 100.0% | 1 MiB |       3 | `/usr/lib/python3.11/dataclasses.py:433` |
+|      % |  Size | Allocations | Location                                 |
+| -----: | ----: | ----------: | ---------------------------------------- |
+| 100.0% | 1 MiB |           3 | `/usr/lib/python3.11/dataclasses.py:433` |
 
 ##### `prefix` (`blib2to3/pytree.py:480`)
 
-|      % |  Size | Samples | Location                 |
-| -----: | ----: | ------: | ------------------------ |
-| 100.0% | 1 MiB |       1 | `blib2to3/pytree.py:482` |
+|      % |  Size | Allocations | Location                 |
+| -----: | ----: | ----------: | ------------------------ |
+| 100.0% | 1 MiB |           1 | `blib2to3/pytree.py:482` |
 
 ##### `generate_comments` (`black/comments.py:52`)
 
-|      % |  Size | Samples | Location               |
-| -----: | ----: | ------: | ---------------------- |
-| 100.0% | 1 MiB |       1 | `black/comments.py:76` |
+|      % |  Size | Allocations | Location               |
+| -----: | ----: | ----------: | ---------------------- |
+| 100.0% | 1 MiB |           1 | `black/comments.py:76` |
 
 ##### `debug` (`/usr/lib/python3.11/logging/__init__.py:1467`)
 
-|      % |  Size | Samples | Location                                       |
-| -----: | ----: | ------: | ---------------------------------------------- |
-| 100.0% | 1 MiB |       1 | `/usr/lib/python3.11/logging/__init__.py:1476` |
+|      % |  Size | Allocations | Location                                       |
+| -----: | ----: | ----------: | ---------------------------------------------- |
+| 100.0% | 1 MiB |           1 | `/usr/lib/python3.11/logging/__init__.py:1476` |
 
 ##### `_stringify_ast_with_new_parent` (`black/parsing.py:166`)
 
-|      % |  Size | Samples | Location               |
-| -----: | ----: | ------: | ---------------------- |
-| 100.0% | 1 MiB |       1 | `black/parsing.py:170` |
+|      % |  Size | Allocations | Location               |
+| -----: | ----: | ----------: | ---------------------- |
+| 100.0% | 1 MiB |           1 | `black/parsing.py:170` |
 
 ##### `generate_tokens` (`blib2to3/pgen2/tokenize.py:565`)
 
-|      % |  Size | Samples | Location                         |
-| -----: | ----: | ------: | -------------------------------- |
-| 100.0% | 1 MiB |       1 | `blib2to3/pgen2/tokenize.py:972` |
+|      % |  Size | Allocations | Location                         |
+| -----: | ----: | ----------: | -------------------------------- |
+| 100.0% | 1 MiB |           1 | `blib2to3/pgen2/tokenize.py:972` |
 
 ##### `__getitem__` (`/usr/lib/python3.11/re/_parser.py:162`)
 
-|      % |  Size | Samples | Location                                |
-| -----: | ----: | ------: | --------------------------------------- |
-| 100.0% | 1 MiB |       1 | `/usr/lib/python3.11/re/_parser.py:164` |
+|      % |  Size | Allocations | Location                                |
+| -----: | ----: | ----------: | --------------------------------------- |
+| 100.0% | 1 MiB |           1 | `/usr/lib/python3.11/re/_parser.py:164` |
 
 ##### `_compile_bytecode` (`<frozen importlib._bootstrap_external>:727`)
 
-|      % |    Size | Samples | Location                                     |
-| -----: | ------: | ------: | -------------------------------------------- |
-| 100.0% | 560 KiB |     606 | `<frozen importlib._bootstrap_external>:729` |
+|      % |    Size | Allocations | Location                                     |
+| -----: | ------: | ----------: | -------------------------------------------- |
+| 100.0% | 560 KiB |         606 | `<frozen importlib._bootstrap_external>:729` |
 
 ##### `__new__` (`<frozen abc>:105`)
 
-|      % |     Size | Samples | Location           |
-| -----: | -------: | ------: | ------------------ |
-| 100.0% | 75.7 KiB |      79 | `<frozen abc>:106` |
+|      % |     Size | Allocations | Location           |
+| -----: | -------: | ----------: | ------------------ |
+| 100.0% | 75.7 KiB |          79 | `<frozen abc>:106` |
 
 ##### `normalize_string_prefix` (`black/strings.py:143`)
 
-|      % |     Size | Samples | Location               |
-| -----: | -------: | ------: | ---------------------- |
-| 100.0% | 57.2 KiB |      65 | `black/strings.py:158` |
+|      % |     Size | Allocations | Location               |
+| -----: | -------: | ----------: | ---------------------- |
+| 100.0% | 57.2 KiB |          65 | `black/strings.py:158` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|     % |   Size | Samples | Location                                                |
-| ----: | -----: | ------: | ------------------------------------------------------- |
-| 97.1% | 43 KiB |      29 | `/venv/lib/python3.11/site-packages/click/core.py:3023` |
-|  1.6% |  704 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2905` |
-|  1.4% |  614 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2907` |
+|     % |   Size | Allocations | Location                                                |
+| ----: | -----: | ----------: | ------------------------------------------------------- |
+| 97.1% | 43 KiB |          29 | `/venv/lib/python3.11/site-packages/click/core.py:3023` |
+|  1.6% |  704 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2905` |
+|  1.4% |  614 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2907` |
 
 ##### `copy` (`blib2to3/pgen2/grammar.py:131`)
 
-|     % |     Size | Samples | Location                        |
-| ----: | -------: | ------: | ------------------------------- |
-| 88.2% | 36.6 KiB |      12 | `blib2to3/pgen2/grammar.py:145` |
-|  7.6% | 3.16 KiB |       2 | `blib2to3/pgen2/grammar.py:146` |
-|  4.2% | 1.75 KiB |       2 | `blib2to3/pgen2/grammar.py:147` |
+|     % |     Size | Allocations | Location                        |
+| ----: | -------: | ----------: | ------------------------------- |
+| 88.2% | 36.6 KiB |          12 | `blib2to3/pgen2/grammar.py:145` |
+|  7.6% | 3.16 KiB |           2 | `blib2to3/pgen2/grammar.py:146` |
+|  4.2% | 1.75 KiB |           2 | `blib2to3/pgen2/grammar.py:147` |
 
 ##### `classify` (`blib2to3/pgen2/parse.py:336`)
 
-|      % |   Size | Samples | Location                      |
-| -----: | -----: | ------: | ----------------------------- |
-| 100.0% | 32 KiB |       1 | `blib2to3/pgen2/parse.py:343` |
+|      % |   Size | Allocations | Location                      |
+| -----: | -----: | ----------: | ----------------------------- |
+| 100.0% | 32 KiB |           1 | `blib2to3/pgen2/parse.py:343` |
 
 ##### `make_first` (`blib2to3/pgen2/pgen.py:74`)
 
-|      % |     Size | Samples | Location                    |
-| -----: | -------: | ------: | --------------------------- |
-| 100.0% | 25.3 KiB |      40 | `blib2to3/pgen2/pgen.py:81` |
+|      % |     Size | Allocations | Location                    |
+| -----: | -------: | ----------: | --------------------------- |
+| 100.0% | 25.3 KiB |          40 | `blib2to3/pgen2/pgen.py:81` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 30.4% |  7.6 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:204`  |
-| 19.2% | 4.79 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:956`  |
-| 15.7% | 3.92 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:1587` |
-|  9.5% | 2.37 KiB |       3 | `/venv/lib/python3.11/site-packages/click/core.py:2057` |
-|  6.8% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/core.py:2050` |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 30.4% |  7.6 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:204`  |
+| 19.2% | 4.79 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:956`  |
+| 15.7% | 3.92 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:1587` |
+|  9.5% | 2.37 KiB |           3 | `/venv/lib/python3.11/site-packages/click/core.py:2057` |
+|  6.8% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/core.py:2050` |
 
 ##### `__new__` (`/usr/lib/python3.11/enum.py:488`)
 
-|      % |     Size | Samples | Location                          |
-| -----: | -------: | ------: | --------------------------------- |
-| 100.0% | 24.1 KiB |      27 | `/usr/lib/python3.11/enum.py:554` |
+|      % |     Size | Allocations | Location                          |
+| -----: | -------: | ----------: | --------------------------------- |
+| 100.0% | 24.1 KiB |          27 | `/usr/lib/python3.11/enum.py:554` |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|      % |     Size | Samples | Location                                  |
-| -----: | -------: | ------: | ----------------------------------------- |
-| 100.0% | 22.6 KiB |      12 | `/usr/lib/python3.11/re/_compiler.py:759` |
+|      % |     Size | Allocations | Location                                  |
+| -----: | -------: | ----------: | ----------------------------------------- |
+| 100.0% | 22.6 KiB |          12 | `/usr/lib/python3.11/re/_compiler.py:759` |
 
 ##### `<module>` (`blib2to3/pgen2/tokenize.py:1`)
 
-|     % |     Size | Samples | Location                         |
-| ----: | -------: | ------: | -------------------------------- |
-| 15.4% | 3.19 KiB |       1 | `blib2to3/pgen2/tokenize.py:170` |
-| 15.4% | 3.19 KiB |       1 | `blib2to3/pgen2/tokenize.py:208` |
-| 14.7% | 3.04 KiB |       3 | `blib2to3/pgen2/tokenize.py:490` |
-|  9.7% |    2 KiB |       1 | `blib2to3/pgen2/tokenize.py:224` |
-|  9.7% |    2 KiB |       1 | `blib2to3/pgen2/tokenize.py:229` |
+|     % |     Size | Allocations | Location                         |
+| ----: | -------: | ----------: | -------------------------------- |
+| 15.4% | 3.19 KiB |           1 | `blib2to3/pgen2/tokenize.py:170` |
+| 15.4% | 3.19 KiB |           1 | `blib2to3/pgen2/tokenize.py:208` |
+| 14.7% | 3.04 KiB |           3 | `blib2to3/pgen2/tokenize.py:490` |
+|  9.7% |    2 KiB |           1 | `blib2to3/pgen2/tokenize.py:224` |
+|  9.7% |    2 KiB |           1 | `blib2to3/pgen2/tokenize.py:229` |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/_parser.py:1`)
 
-|     % |  Size | Samples | Location                                    |
-| ----: | ----: | ------: | ------------------------------------------- |
-| 20.2% | 4 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:37` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:38` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:27` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:22` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:26` |
+|     % |  Size | Allocations | Location                                    |
+| ----: | ----: | ----------: | ------------------------------------------- |
+| 20.2% | 4 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:37` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:38` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:27` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:22` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:26` |
 
 ##### `convert_one_fmt_off_pair` (`black/comments.py:177`)
 
-|      % |     Size | Samples | Location                |
-| -----: | -------: | ------: | ----------------------- |
-| 100.0% | 18.6 KiB |       2 | `black/comments.py:186` |
+|      % |     Size | Allocations | Location                |
+| -----: | -------: | ----------: | ----------------------- |
+| 100.0% | 18.6 KiB |           2 | `black/comments.py:186` |
 
 ##### `__new__` (`/usr/lib/python3.11/typing.py:2891`)
 
-|      % |     Size | Samples | Location                             |
-| -----: | -------: | ------: | ------------------------------------ |
-| 100.0% | 17.4 KiB |      21 | `/usr/lib/python3.11/typing.py:2909` |
+|      % |     Size | Allocations | Location                             |
+| -----: | -------: | ----------: | ------------------------------------ |
+| 100.0% | 17.4 KiB |          21 | `/usr/lib/python3.11/typing.py:2909` |
 
 ##### `<module>` (`blib2to3/pytree.py:1`)
 
-|     % |     Size | Samples | Location                 |
-| ----: | -------: | ------: | ------------------------ |
-| 16.3% | 2.44 KiB |       3 | `blib2to3/pytree.py:64`  |
-| 11.3% | 1.69 KiB |       2 | `blib2to3/pytree.py:382` |
-| 11.3% | 1.69 KiB |       2 | `blib2to3/pytree.py:242` |
-| 11.3% | 1.69 KiB |       2 | `blib2to3/pytree.py:509` |
-| 11.3% | 1.69 KiB |       2 | `blib2to3/pytree.py:600` |
+|     % |     Size | Allocations | Location                 |
+| ----: | -------: | ----------: | ------------------------ |
+| 16.3% | 2.44 KiB |           3 | `blib2to3/pytree.py:64`  |
+| 11.3% | 1.69 KiB |           2 | `blib2to3/pytree.py:382` |
+| 11.3% | 1.69 KiB |           2 | `blib2to3/pytree.py:242` |
+| 11.3% | 1.69 KiB |           2 | `blib2to3/pytree.py:509` |
+| 11.3% | 1.69 KiB |           2 | `blib2to3/pytree.py:600` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/mypy_extensions.py:1`)
 
-|     % |     Size | Samples | Location                                                    |
-| ----: | -------: | ------: | ----------------------------------------------------------- |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:205` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:198` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:167` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:154` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:175` |
+|     % |     Size | Allocations | Location                                                    |
+| ----: | -------: | ----------: | ----------------------------------------------------------- |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:205` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:198` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:167` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:154` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:175` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/exceptions.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 18.4% | 2.45 KiB |       3 | `/venv/lib/python3.11/site-packages/click/exceptions.py:114` |
-| 11.5% | 1.53 KiB |       2 | `/venv/lib/python3.11/site-packages/click/exceptions.py:366` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:68`  |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:362` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:342` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 18.4% | 2.45 KiB |           3 | `/venv/lib/python3.11/site-packages/click/exceptions.py:114` |
+| 11.5% | 1.53 KiB |           2 | `/venv/lib/python3.11/site-packages/click/exceptions.py:366` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:68`  |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:362` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:342` |
 
 ##### `inner` (`/usr/lib/python3.11/typing.py:338`)
 
-|      % |   Size | Samples | Location                            |
-| -----: | -----: | ------: | ----------------------------------- |
-| 100.0% | 12 KiB |       3 | `/usr/lib/python3.11/typing.py:341` |
+|      % |   Size | Allocations | Location                            |
+| -----: | -----: | ----------: | ----------------------------------- |
+| 100.0% | 12 KiB |           3 | `/usr/lib/python3.11/typing.py:341` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/version.py:1`)
 
-|     % |     Size | Samples | Location                                                      |
-| ----: | -------: | ------: | ------------------------------------------------------------- |
-| 38.2% | 3.68 KiB |       3 | `/venv/lib/python3.11/site-packages/packaging/version.py:340` |
-| 15.5% | 1.49 KiB |       2 | `/venv/lib/python3.11/site-packages/packaging/version.py:124` |
-| 15.4% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:285` |
-| 11.3% | 1.09 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:228` |
-|  9.8% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:134` |
+|     % |     Size | Allocations | Location                                                      |
+| ----: | -------: | ----------: | ------------------------------------------------------------- |
+| 38.2% | 3.68 KiB |           3 | `/venv/lib/python3.11/site-packages/packaging/version.py:340` |
+| 15.5% | 1.49 KiB |           2 | `/venv/lib/python3.11/site-packages/packaging/version.py:124` |
+| 15.4% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:285` |
+| 11.3% | 1.09 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:228` |
+|  9.8% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:134` |
 
 ##### `_fill_cache` (`<frozen importlib._bootstrap_external>:1655`)
 
-|      % |  Size | Samples | Location                                      |
-| -----: | ----: | ------: | --------------------------------------------- |
-| 100.0% | 8 KiB |       4 | `<frozen importlib._bootstrap_external>:1667` |
+|      % |  Size | Allocations | Location                                      |
+| -----: | ----: | ----------: | --------------------------------------------- |
+| 100.0% | 8 KiB |           4 | `<frozen importlib._bootstrap_external>:1667` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|      % |     Size | Samples | Location                                |
-| -----: | -------: | ------: | --------------------------------------- |
-| 100.0% | 7.97 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:455` |
+|      % |     Size | Allocations | Location                                |
+| -----: | -------: | ----------: | --------------------------------------- |
+| 100.0% | 7.97 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:455` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/utils.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 44.8% | 3.17 KiB |       3 | `/venv/lib/python3.11/site-packages/click/utils.py:522` |
-| 31.4% | 2.22 KiB |       3 | `/venv/lib/python3.11/site-packages/click/utils.py:207` |
-| 23.8% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/utils.py:113` |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 44.8% | 3.17 KiB |           3 | `/venv/lib/python3.11/site-packages/click/utils.py:522` |
+| 31.4% | 2.22 KiB |           3 | `/venv/lib/python3.11/site-packages/click/utils.py:207` |
+| 23.8% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/utils.py:113` |
 
 ##### `__setattr__` (`/usr/lib/python3.11/enum.py:831`)
 
-|      % |     Size | Samples | Location                          |
-| -----: | -------: | ------: | --------------------------------- |
-| 100.0% | 6.73 KiB |       8 | `/usr/lib/python3.11/enum.py:842` |
+|      % |     Size | Allocations | Location                          |
+| -----: | -------: | ----------: | --------------------------------- |
+| 100.0% | 6.73 KiB |           8 | `/usr/lib/python3.11/enum.py:842` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/util.py:1`)
 
-|     % |     Size | Samples | Location                                                  |
-| ----: | -------: | ------: | --------------------------------------------------------- |
-| 22.9% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:254` |
-| 16.9% | 1.09 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:765` |
-| 16.3% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:710` |
-| 15.1% |   1000 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:741` |
-| 14.5% |    960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:604` |
+|     % |     Size | Allocations | Location                                                  |
+| ----: | -------: | ----------: | --------------------------------------------------------- |
+| 22.9% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:254` |
+| 16.9% | 1.09 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:765` |
+| 16.3% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:710` |
+| 15.1% |   1000 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:741` |
+| 14.5% |    960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:604` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|     % |     Size | Samples | Location                                                      |
-| ----: | -------: | ------: | ------------------------------------------------------------- |
-| 23.8% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:681` |
-| 23.0% | 1.43 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:44`  |
-| 19.4% | 1.21 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:63`  |
-| 16.9% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:179` |
-| 16.9% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:236` |
+|     % |     Size | Allocations | Location                                                      |
+| ----: | -------: | ----------: | ------------------------------------------------------------- |
+| 23.8% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:681` |
+| 23.0% | 1.43 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:44`  |
+| 19.4% | 1.21 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:63`  |
+| 16.9% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:179` |
+| 16.9% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:236` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|     % |     Size | Samples | Location                                                   |
-| ----: | -------: | ------: | ---------------------------------------------------------- |
-| 28.0% | 1.67 KiB |       2 | `/venv/lib/python3.11/site-packages/packaging/tags.py:118` |
-| 24.9% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:322` |
-| 15.7% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:101` |
-| 15.7% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:110` |
-| 15.7% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:93`  |
+|     % |     Size | Allocations | Location                                                   |
+| ----: | -------: | ----------: | ---------------------------------------------------------- |
+| 28.0% | 1.67 KiB |           2 | `/venv/lib/python3.11/site-packages/packaging/tags.py:118` |
+| 24.9% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:322` |
+| 15.7% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:101` |
+| 15.7% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:110` |
+| 15.7% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:93`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/_compat.py:1`)
 
-|     % |     Size | Samples | Location                                                  |
-| ----: | -------: | ------: | --------------------------------------------------------- |
-| 29.1% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/_compat.py:82`  |
-| 29.1% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/_compat.py:452` |
-| 25.6% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/click/_compat.py:344` |
-| 16.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/_compat.py:56`  |
+|     % |     Size | Allocations | Location                                                  |
+| ----: | -------: | ----------: | --------------------------------------------------------- |
+| 29.1% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/_compat.py:82`  |
+| 29.1% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/_compat.py:452` |
+| 25.6% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/click/_compat.py:344` |
+| 16.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/_compat.py:56`  |
 
 ##### `namedtuple` (`/usr/lib/python3.11/collections/__init__.py:348`)
 
-|      % |     Size | Samples | Location                                          |
-| -----: | -------: | ------: | ------------------------------------------------- |
-| 100.0% | 5.63 KiB |       6 | `/usr/lib/python3.11/collections/__init__.py:501` |
+|      % |     Size | Allocations | Location                                          |
+| -----: | -------: | ----------: | ------------------------------------------------- |
+| 100.0% | 5.63 KiB |           6 | `/usr/lib/python3.11/collections/__init__.py:501` |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|     % |     Size | Samples | Location                                |
-| ----: | -------: | ------: | --------------------------------------- |
-| 43.4% | 2.43 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:539` |
-| 33.9% |  1.9 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:568` |
-| 22.7% | 1.28 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:838` |
+|     % |     Size | Allocations | Location                                |
+| ----: | -------: | ----------: | --------------------------------------- |
+| 43.4% | 2.43 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:539` |
+| 33.9% |  1.9 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:568` |
+| 22.7% | 1.28 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:838` |
 
 ##### `_code` (`/usr/lib/python3.11/re/_compiler.py:571`)
 
-|     % |     Size | Samples | Location                                  |
-| ----: | -------: | ------: | ----------------------------------------- |
-| 81.6% | 4.34 KiB |       1 | `/usr/lib/python3.11/re/_compiler.py:580` |
-| 18.4% |   1002 B |       1 | `/usr/lib/python3.11/re/_compiler.py:577` |
+|     % |     Size | Allocations | Location                                  |
+| ----: | -------: | ----------: | ----------------------------------------- |
+| 81.6% | 4.34 KiB |           1 | `/usr/lib/python3.11/re/_compiler.py:580` |
+| 18.4% |   1002 B |           1 | `/usr/lib/python3.11/re/_compiler.py:577` |
 
 ##### `<module>` (`/usr/lib/python3.11/pkgutil.py:1`)
 
-|     % |     Size | Samples | Location                             |
-| ----: | -------: | ------: | ------------------------------------ |
-| 35.7% | 1.69 KiB |       2 | `/usr/lib/python3.11/pkgutil.py:194` |
-| 35.7% | 1.69 KiB |       2 | `/usr/lib/python3.11/pkgutil.py:269` |
-| 15.9% |    768 B |       1 | `/usr/lib/python3.11/pkgutil.py:137` |
-| 12.8% |    620 B |       1 | `/usr/lib/python3.11/pkgutil.py:184` |
+|     % |     Size | Allocations | Location                             |
+| ----: | -------: | ----------: | ------------------------------------ |
+| 35.7% | 1.69 KiB |           2 | `/usr/lib/python3.11/pkgutil.py:194` |
+| 35.7% | 1.69 KiB |           2 | `/usr/lib/python3.11/pkgutil.py:269` |
+| 15.9% |    768 B |           1 | `/usr/lib/python3.11/pkgutil.py:137` |
+| 12.8% |    620 B |           1 | `/usr/lib/python3.11/pkgutil.py:184` |
 
 ##### `Specifier` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`)
 
-|      % |     Size | Samples | Location                                                         |
-| -----: | -------: | ------: | ---------------------------------------------------------------- |
-| 100.0% | 3.82 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:340` |
+|      % |     Size | Allocations | Location                                                         |
+| -----: | -------: | ----------: | ---------------------------------------------------------------- |
+| 100.0% | 3.82 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:340` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 46.4% | 1.73 KiB |       2 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:29`  |
-| 27.3% | 1.02 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:90`  |
-| 26.3% |   1000 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:245` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 46.4% | 1.73 KiB |           2 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:29`  |
+| 27.3% | 1.02 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:90`  |
+| 26.3% |   1000 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:245` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|     % |  Size | Samples | Location                                                   |
-| ----: | ----: | ------: | ---------------------------------------------------------- |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:62` |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:46` |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:54` |
-| 21.1% | 768 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:27` |
+|     % |  Size | Allocations | Location                                                   |
+| ----: | ----: | ----------: | ---------------------------------------------------------- |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:62` |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:46` |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:54` |
+| 21.1% | 768 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:27` |
 
 ##### `handle_parse_result` (`/venv/lib/python3.11/site-packages/click/core.py:2663`)
 
-|     % |    Size | Samples | Location                                                |
-| ----: | ------: | ------: | ------------------------------------------------------- |
-| 38.5% | 1.3 KiB |       2 | `/venv/lib/python3.11/site-packages/click/core.py:2686` |
-| 22.3% |   768 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2740` |
-| 22.3% |   768 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2739` |
-| 17.0% |   586 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2711` |
+|     % |    Size | Allocations | Location                                                |
+| ----: | ------: | ----------: | ------------------------------------------------------- |
+| 38.5% | 1.3 KiB |           2 | `/venv/lib/python3.11/site-packages/click/core.py:2686` |
+| 22.3% |   768 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2740` |
+| 22.3% |   768 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2739` |
+| 17.0% |   586 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2711` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|      % |     Size | Samples | Location                                                  |
-| -----: | -------: | ------: | --------------------------------------------------------- |
-| 100.0% | 3.19 KiB |       1 | `/venv/lib/python3.11/site-packages/click/__init__.py:74` |
+|      % |     Size | Allocations | Location                                                  |
+| -----: | -------: | ----------: | --------------------------------------------------------- |
+| 100.0% | 3.19 KiB |           1 | `/venv/lib/python3.11/site-packages/click/__init__.py:74` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 76.5% | 2.44 KiB |       3 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:55` |
-| 23.5% |    768 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:14` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 76.5% | 2.44 KiB |           3 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:55` |
+| 23.5% |    768 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:14` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Location                                                    |
-| -----: | -------: | ------: | ----------------------------------------------------------- |
-| 100.0% | 3.04 KiB |       2 | `/venv/lib/python3.11/site-packages/click/decorators.py:34` |
+|      % |     Size | Allocations | Location                                                    |
+| -----: | -------: | ----------: | ----------------------------------------------------------- |
+| 100.0% | 3.04 KiB |           2 | `/venv/lib/python3.11/site-packages/click/decorators.py:34` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|      % |     Size | Samples | Location                                  |
-| -----: | -------: | ------: | ----------------------------------------- |
-| 100.0% | 2.85 KiB |       1 | `/usr/lib/python3.11/dataclasses.py:1210` |
+|      % |     Size | Allocations | Location                                  |
+| -----: | -------: | ----------: | ----------------------------------------- |
+| 100.0% | 2.85 KiB |           1 | `/usr/lib/python3.11/dataclasses.py:1210` |
 
 ##### `_process_class` (`/usr/lib/python3.11/dataclasses.py:884`)
 
-|     % |     Size | Samples | Location                                  |
-| ----: | -------: | ------: | ----------------------------------------- |
-| 41.3% | 1.18 KiB |       1 | `/usr/lib/python3.11/dataclasses.py:958`  |
-| 21.0% |    612 B |       1 | `/usr/lib/python3.11/dataclasses.py:1027` |
-| 19.9% |    580 B |       1 | `/usr/lib/python3.11/dataclasses.py:1096` |
-| 17.8% |    518 B |       1 | `/usr/lib/python3.11/dataclasses.py:947`  |
+|     % |     Size | Allocations | Location                                  |
+| ----: | -------: | ----------: | ----------------------------------------- |
+| 41.3% | 1.18 KiB |           1 | `/usr/lib/python3.11/dataclasses.py:958`  |
+| 21.0% |    612 B |           1 | `/usr/lib/python3.11/dataclasses.py:1027` |
+| 19.9% |    580 B |           1 | `/usr/lib/python3.11/dataclasses.py:1096` |
+| 17.8% |    518 B |           1 | `/usr/lib/python3.11/dataclasses.py:947`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1`)
 
-|     % |  Size | Samples | Location                                                                     |
-| ----: | ----: | ------: | ---------------------------------------------------------------------------- |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:22`  |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:205` |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:197` |
+|     % |  Size | Allocations | Location                                                                     |
+| ----: | ----: | ----------: | ---------------------------------------------------------------------------- |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:22`  |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:205` |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:197` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 53.7% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/click/types.py:464` |
-| 46.3% | 1.28 KiB |       1 | `/venv/lib/python3.11/site-packages/click/types.py:37`  |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 53.7% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/click/types.py:464` |
+| 46.3% | 1.28 KiB |           1 | `/venv/lib/python3.11/site-packages/click/types.py:37`  |
 
 #### Callers
 
@@ -2036,487 +2036,487 @@ Callers ranked by contribution to each function's self size. Inlining can make c
 
 ##### `mark` (`black/brackets.py:70`)
 
-|      % |     Size | Samples | Caller   | Location            |
-| -----: | -------: | ------: | -------- | ------------------- |
-| 100.0% | 16.2 MiB |  20,788 | `append` | `black/lines.py:63` |
+|      % |     Size | Allocations | Caller   | Location            |
+| -----: | -------: | ----------: | -------- | ------------------- |
+| 100.0% | 16.2 MiB |      20,788 | `append` | `black/lines.py:63` |
 
 ##### `__new__` (`blib2to3/pytree.py:81`)
 
-|     % |  Size | Samples | Caller    | Location                 |
-| ----: | ----: | ------: | --------- | ------------------------ |
-| 85.7% | 6 MiB |       6 | `convert` | `blib2to3/pytree.py:486` |
-| 14.3% | 1 MiB |       1 | `clone`   | `blib2to3/pytree.py:452` |
+|     % |  Size | Allocations | Caller    | Location                 |
+| ----: | ----: | ----------: | --------- | ------------------------ |
+| 85.7% | 6 MiB |           6 | `convert` | `blib2to3/pytree.py:486` |
+| 14.3% | 1 MiB |           1 | `clone`   | `blib2to3/pytree.py:452` |
 
 ##### `update_sibling_maps` (`blib2to3/pytree.py:369`)
 
-|     % |     Size | Samples | Caller         | Location                 |
-| ----: | -------: | ------: | -------------- | ------------------------ |
-| 80.6% | 4.14 MiB |     199 | `prev_sibling` | `blib2to3/pytree.py:207` |
-| 19.4% |    1 MiB |       1 | `next_sibling` | `blib2to3/pytree.py:193` |
+|     % |     Size | Allocations | Caller         | Location                 |
+| ----: | -------: | ----------: | -------------- | ------------------------ |
+| 80.6% | 4.14 MiB |         199 | `prev_sibling` | `blib2to3/pytree.py:207` |
+| 19.4% |    1 MiB |           1 | `next_sibling` | `blib2to3/pytree.py:193` |
 
 ##### `changed` (`blib2to3/pytree.py:171`)
 
-|     % |  Size | Samples | Caller    | Location                 |
-| ----: | ----: | ------: | --------- | ------------------------ |
-| 80.0% | 4 MiB |       4 | `changed` | `blib2to3/pytree.py:171` |
-| 20.0% | 1 MiB |       1 | `prefix`  | `blib2to3/pytree.py:480` |
+|     % |  Size | Allocations | Caller    | Location                 |
+| ----: | ----: | ----------: | --------- | ------------------------ |
+| 80.0% | 4 MiB |           4 | `changed` | `blib2to3/pytree.py:171` |
+| 20.0% | 1 MiB |           1 | `prefix`  | `blib2to3/pytree.py:480` |
 
 ##### `parse` (`/usr/lib/python3.11/ast.py:33`)
 
-|      % |     Size | Samples | Caller                  | Location               |
-| -----: | -------: | ------: | ----------------------- | ---------------------- |
-| 100.0% | 3.01 MiB |       4 | `_parse_single_version` | `black/parsing.py:117` |
+|      % |     Size | Allocations | Caller                  | Location               |
+| -----: | -------: | ----------: | ----------------------- | ---------------------- |
+| 100.0% | 3.01 MiB |           4 | `_parse_single_version` | `black/parsing.py:117` |
 
 ##### `push` (`blib2to3/pgen2/parse.py:386`)
 
-|      % |  Size | Samples | Caller      | Location                      |
-| -----: | ----: | ------: | ----------- | ----------------------------- |
-| 100.0% | 3 MiB |       3 | `_addtoken` | `blib2to3/pgen2/parse.py:290` |
+|      % |  Size | Allocations | Caller      | Location                      |
+| -----: | ----: | ----------: | ----------- | ----------------------------- |
+| 100.0% | 3 MiB |           3 | `_addtoken` | `blib2to3/pgen2/parse.py:290` |
 
 ##### `__init__` (`blib2to3/pytree.py:248`)
 
-|     % |  Size | Samples | Caller                | Location                 |
-| ----: | ----: | ------: | --------------------- | ------------------------ |
-| 50.1% | 1 MiB |       5 | `convert`             | `blib2to3/pytree.py:486` |
-| 49.9% | 1 MiB |       1 | `wrap_in_parentheses` | `black/nodes.py:935`     |
+|     % |  Size | Allocations | Caller                | Location                 |
+| ----: | ----: | ----------: | --------------------- | ------------------------ |
+| 50.1% | 1 MiB |           5 | `convert`             | `blib2to3/pytree.py:486` |
+| 49.9% | 1 MiB |           1 | `wrap_in_parentheses` | `black/nodes.py:935`     |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|      % |  Size | Samples | Caller         | Location               |
-| -----: | ----: | ------: | -------------- | ---------------------- |
-| 100.0% | 2 MiB |       2 | `visit`        | `black/nodes.py:163`   |
-|  <0.1% | 702 B |       1 | `visit_STRING` | `black/linegen.py:413` |
+|      % |  Size | Allocations | Caller         | Location               |
+| -----: | ----: | ----------: | -------------- | ---------------------- |
+| 100.0% | 2 MiB |           2 | `visit`        | `black/nodes.py:163`   |
+|  <0.1% | 702 B |           1 | `visit_STRING` | `black/linegen.py:413` |
 
 ##### `__init__` (`<string>:2`)
 
-|     % |  Size | Samples | Caller            | Location                |
-| ----: | ----: | ------: | ----------------- | ----------------------- |
-| 50.0% | 1 MiB |       1 | `line`            | `black/linegen.py:109`  |
-| 50.0% | 1 MiB |       1 | `delimiter_split` | `black/linegen.py:1203` |
+|     % |  Size | Allocations | Caller            | Location                |
+| ----: | ----: | ----------: | ----------------- | ----------------------- |
+| 50.0% | 1 MiB |           1 | `line`            | `black/linegen.py:109`  |
+| 50.0% | 1 MiB |           1 | `delimiter_split` | `black/linegen.py:1203` |
 
 ##### `transform_line` (`black/linegen.py:601`)
 
-|      % |     Size | Samples | Caller             | Location                 |
-| -----: | -------: | ------: | ------------------ | ------------------------ |
-| 100.0% | 1.07 MiB |       7 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |     Size | Allocations | Caller             | Location                 |
+| -----: | -------: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 1.07 MiB |           7 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 1.01 MiB |      11 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 1.01 MiB |          11 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `_create_fn` (`/usr/lib/python3.11/dataclasses.py:413`)
 
-|     % |  Size | Samples | Caller     | Location                                 |
-| ----: | ----: | ------: | ---------- | ---------------------------------------- |
-| 99.9% | 1 MiB |       1 | `_init_fn` | `/usr/lib/python3.11/dataclasses.py:528` |
-| <0.1% | 341 B |       1 | `_cmp_fn`  | `/usr/lib/python3.11/dataclasses.py:624` |
-| <0.1% | 336 B |       1 | `_repr_fn` | `/usr/lib/python3.11/dataclasses.py:588` |
+|     % |  Size | Allocations | Caller     | Location                                 |
+| ----: | ----: | ----------: | ---------- | ---------------------------------------- |
+| 99.9% | 1 MiB |           1 | `_init_fn` | `/usr/lib/python3.11/dataclasses.py:528` |
+| <0.1% | 341 B |           1 | `_cmp_fn`  | `/usr/lib/python3.11/dataclasses.py:624` |
+| <0.1% | 336 B |           1 | `_repr_fn` | `/usr/lib/python3.11/dataclasses.py:588` |
 
 ##### `prefix` (`blib2to3/pytree.py:480`)
 
-|      % |  Size | Samples | Caller   | Location            |
-| -----: | ----: | ------: | -------- | ------------------- |
-| 100.0% | 1 MiB |       1 | `append` | `black/lines.py:63` |
+|      % |  Size | Allocations | Caller   | Location            |
+| -----: | ----: | ----------: | -------- | ------------------- |
+| 100.0% | 1 MiB |           1 | `append` | `black/lines.py:63` |
 
 ##### `generate_comments` (`black/comments.py:52`)
 
-|      % |  Size | Samples | Caller          | Location               |
-| -----: | ----: | ------: | --------------- | ---------------------- |
-| 100.0% | 1 MiB |       1 | `visit_default` | `black/linegen.py:134` |
+|      % |  Size | Allocations | Caller          | Location               |
+| -----: | ----: | ----------: | --------------- | ---------------------- |
+| 100.0% | 1 MiB |           1 | `visit_default` | `black/linegen.py:134` |
 
 ##### `debug` (`/usr/lib/python3.11/logging/__init__.py:1467`)
 
-|      % |  Size | Samples | Caller         | Location                       |
-| -----: | ----: | ------: | -------------- | ------------------------------ |
-| 100.0% | 1 MiB |       1 | `parse_tokens` | `blib2to3/pgen2/driver.py:114` |
+|      % |  Size | Allocations | Caller         | Location                       |
+| -----: | ----: | ----------: | -------------- | ------------------------------ |
+| 100.0% | 1 MiB |           1 | `parse_tokens` | `blib2to3/pgen2/driver.py:114` |
 
 ##### `_stringify_ast_with_new_parent` (`black/parsing.py:166`)
 
-|      % |  Size | Samples | Caller           | Location               |
-| -----: | ----: | ------: | ---------------- | ---------------------- |
-| 100.0% | 1 MiB |       1 | `_stringify_ast` | `black/parsing.py:174` |
+|      % |  Size | Allocations | Caller           | Location               |
+| -----: | ----: | ----------: | ---------------- | ---------------------- |
+| 100.0% | 1 MiB |           1 | `_stringify_ast` | `black/parsing.py:174` |
 
 ##### `generate_tokens` (`blib2to3/pgen2/tokenize.py:565`)
 
-|      % |  Size | Samples | Caller     | Location                      |
-| -----: | ----: | ------: | ---------- | ----------------------------- |
-| 100.0% | 1 MiB |       1 | `__next__` | `blib2to3/pgen2/driver.py:80` |
+|      % |  Size | Allocations | Caller     | Location                      |
+| -----: | ----: | ----------: | ---------- | ----------------------------- |
+| 100.0% | 1 MiB |           1 | `__next__` | `blib2to3/pgen2/driver.py:80` |
 
 ##### `__getitem__` (`/usr/lib/python3.11/re/_parser.py:162`)
 
-|      % |  Size | Samples | Caller   | Location                                |
-| -----: | ----: | ------: | -------- | --------------------------------------- |
-| 100.0% | 1 MiB |       1 | `_parse` | `/usr/lib/python3.11/re/_parser.py:507` |
+|      % |  Size | Allocations | Caller   | Location                                |
+| -----: | ----: | ----------: | -------- | --------------------------------------- |
+| 100.0% | 1 MiB |           1 | `_parse` | `/usr/lib/python3.11/re/_parser.py:507` |
 
 ##### `_compile_bytecode` (`<frozen importlib._bootstrap_external>:727`)
 
-|      % |    Size | Samples | Caller     | Location                                      |
-| -----: | ------: | ------: | ---------- | --------------------------------------------- |
-| 100.0% | 560 KiB |     606 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
+|      % |    Size | Allocations | Caller     | Location                                      |
+| -----: | ------: | ----------: | ---------- | --------------------------------------------- |
+| 100.0% | 560 KiB |         606 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `__new__` (`<frozen abc>:105`)
 
-|     % |     Size | Samples | Caller     | Location                                                       |
-| ----: | -------: | ------: | ---------- | -------------------------------------------------------------- |
-| 50.5% | 38.2 KiB |      45 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`          |
-| 23.1% | 17.5 KiB |      18 | `<module>` | `black/trans.py:1`                                             |
-| 18.3% | 13.9 KiB |       9 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`           |
-|  8.0% | 6.07 KiB |       7 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
+|     % |     Size | Allocations | Caller     | Location                                                       |
+| ----: | -------: | ----------: | ---------- | -------------------------------------------------------------- |
+| 50.5% | 38.2 KiB |          45 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`          |
+| 23.1% | 17.5 KiB |          18 | `<module>` | `black/trans.py:1`                                             |
+| 18.3% | 13.9 KiB |           9 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`           |
+|  8.0% | 6.07 KiB |           7 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
 
 ##### `normalize_string_prefix` (`black/strings.py:143`)
 
-|      % |     Size | Samples | Caller         | Location               |
-| -----: | -------: | ------: | -------------- | ---------------------- |
-| 100.0% | 57.2 KiB |      65 | `visit_STRING` | `black/linegen.py:413` |
+|      % |     Size | Allocations | Caller         | Location               |
+| -----: | -------: | ----------: | -------------- | ---------------------- |
+| 100.0% | 57.2 KiB |          65 | `visit_STRING` | `black/linegen.py:413` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|      % |     Size | Samples | Caller      | Location                                                     |
-| -----: | -------: | ------: | ----------- | ------------------------------------------------------------ |
-| 100.0% | 44.3 KiB |      31 | `decorator` | `/venv/lib/python3.11/site-packages/click/decorators.py:373` |
+|      % |     Size | Allocations | Caller      | Location                                                     |
+| -----: | -------: | ----------: | ----------- | ------------------------------------------------------------ |
+| 100.0% | 44.3 KiB |          31 | `decorator` | `/venv/lib/python3.11/site-packages/click/decorators.py:373` |
 
 ##### `copy` (`blib2to3/pgen2/grammar.py:131`)
 
-|      % |     Size | Samples | Caller       | Location                 |
-| -----: | -------: | ------: | ------------ | ------------------------ |
-| 100.0% | 41.5 KiB |      16 | `initialize` | `blib2to3/pygram.py:165` |
+|      % |     Size | Allocations | Caller       | Location                 |
+| -----: | -------: | ----------: | ------------ | ------------------------ |
+| 100.0% | 41.5 KiB |          16 | `initialize` | `blib2to3/pygram.py:165` |
 
 ##### `classify` (`blib2to3/pgen2/parse.py:336`)
 
-|      % |   Size | Samples | Caller     | Location                      |
-| -----: | -----: | ------: | ---------- | ----------------------------- |
-| 100.0% | 32 KiB |       1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
+|      % |   Size | Allocations | Caller     | Location                      |
+| -----: | -----: | ----------: | ---------- | ----------------------------- |
+| 100.0% | 32 KiB |           1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
 
 ##### `make_first` (`blib2to3/pgen2/pgen.py:74`)
 
-|      % |     Size | Samples | Caller         | Location                    |
-| -----: | -------: | ------: | -------------- | --------------------------- |
-| 100.0% | 25.3 KiB |      40 | `make_grammar` | `blib2to3/pgen2/pgen.py:49` |
+|      % |     Size | Allocations | Caller         | Location                    |
+| -----: | -------: | ----------: | -------------- | --------------------------- |
+| 100.0% | 25.3 KiB |          40 | `make_grammar` | `blib2to3/pgen2/pgen.py:49` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 25 KiB |      22 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 25 KiB |          22 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__new__` (`/usr/lib/python3.11/enum.py:488`)
 
-|     % |     Size | Samples | Caller     | Location                                                     |
-| ----: | -------: | ------: | ---------- | ------------------------------------------------------------ |
-| 31.7% | 7.64 KiB |       9 | `<module>` | `black/mode.py:1`                                            |
-| 16.2% | 3.89 KiB |       4 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/_elffile.py:1` |
-| 13.7% |  3.3 KiB |       3 | `<module>` | `/venv/lib/python3.11/site-packages/click/_utils.py:1`       |
-| 10.1% | 2.44 KiB |       3 | `<module>` | `black/__init__.py:1`                                        |
-|  7.2% | 1.74 KiB |       2 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`         |
+|     % |     Size | Allocations | Caller     | Location                                                     |
+| ----: | -------: | ----------: | ---------- | ------------------------------------------------------------ |
+| 31.7% | 7.64 KiB |           9 | `<module>` | `black/mode.py:1`                                            |
+| 16.2% | 3.89 KiB |           4 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/_elffile.py:1` |
+| 13.7% |  3.3 KiB |           3 | `<module>` | `/venv/lib/python3.11/site-packages/click/_utils.py:1`       |
+| 10.1% | 2.44 KiB |           3 | `<module>` | `black/__init__.py:1`                                        |
+|  7.2% | 1.74 KiB |           2 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`         |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|      % |     Size | Samples | Caller     | Location                                 |
-| -----: | -------: | ------: | ---------- | ---------------------------------------- |
-| 100.0% | 22.6 KiB |      12 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
+|      % |     Size | Allocations | Caller     | Location                                 |
+| -----: | -------: | ----------: | ---------- | ---------------------------------------- |
+| 100.0% | 22.6 KiB |          12 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
 
 ##### `<module>` (`blib2to3/pgen2/tokenize.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 20.7 KiB |      14 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 20.7 KiB |          14 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/_parser.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 19.8 KiB |      12 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 19.8 KiB |          12 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `convert_one_fmt_off_pair` (`black/comments.py:177`)
 
-|      % |     Size | Samples | Caller              | Location                |
-| -----: | -------: | ------: | ------------------- | ----------------------- |
-| 100.0% | 18.6 KiB |       2 | `normalize_fmt_off` | `black/comments.py:168` |
+|      % |     Size | Allocations | Caller              | Location                |
+| -----: | -------: | ----------: | ------------------- | ----------------------- |
+| 100.0% | 18.6 KiB |           2 | `normalize_fmt_off` | `black/comments.py:168` |
 
 ##### `__new__` (`/usr/lib/python3.11/typing.py:2891`)
 
-|     % |     Size | Samples | Caller     | Location                                                    |
-| ----: | -------: | ------: | ---------- | ----------------------------------------------------------- |
-| 90.3% | 15.7 KiB |      19 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`       |
-|  9.7% | 1.69 KiB |       2 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/version.py:1` |
+|     % |     Size | Allocations | Caller     | Location                                                    |
+| ----: | -------: | ----------: | ---------- | ----------------------------------------------------------- |
+| 90.3% | 15.7 KiB |          19 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`       |
+|  9.7% | 1.69 KiB |           2 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/version.py:1` |
 
 ##### `<module>` (`blib2to3/pytree.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 15 KiB |      18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 15 KiB |          18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/mypy_extensions.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 15 KiB |      18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 15 KiB |          18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/exceptions.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 13.4 KiB |      15 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 13.4 KiB |          15 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `inner` (`/usr/lib/python3.11/typing.py:338`)
 
-|     % |     Size | Samples | Caller        | Location                                              |
-| ----: | -------: | ------: | ------------- | ----------------------------------------------------- |
-| 75.3% | 9.02 KiB |       1 | `Line`        | `black/lines.py:49`                                   |
-| 17.9% | 2.15 KiB |       1 | `__getitem__` | `/usr/lib/python3.11/typing.py:467`                   |
-|  6.7% |    826 B |       1 | `<module>`    | `/venv/lib/python3.11/site-packages/click/types.py:1` |
+|     % |     Size | Allocations | Caller        | Location                                              |
+| ----: | -------: | ----------: | ------------- | ----------------------------------------------------- |
+| 75.3% | 9.02 KiB |           1 | `Line`        | `black/lines.py:49`                                   |
+| 17.9% | 2.15 KiB |           1 | `__getitem__` | `/usr/lib/python3.11/typing.py:467`                   |
+|  6.7% |    826 B |           1 | `<module>`    | `/venv/lib/python3.11/site-packages/click/types.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/version.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 9.61 KiB |       9 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 9.61 KiB |           9 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `_fill_cache` (`<frozen importlib._bootstrap_external>:1655`)
 
-|      % |  Size | Samples | Caller      | Location                                      |
-| -----: | ----: | ------: | ----------- | --------------------------------------------- |
-| 100.0% | 8 KiB |       4 | `find_spec` | `<frozen importlib._bootstrap_external>:1604` |
+|      % |  Size | Allocations | Caller      | Location                                      |
+| -----: | ----: | ----------: | ----------- | --------------------------------------------- |
+| 100.0% | 8 KiB |           4 | `find_spec` | `<frozen importlib._bootstrap_external>:1604` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|      % |     Size | Samples | Caller  | Location                                |
-| -----: | -------: | ------: | ------- | --------------------------------------- |
-| 100.0% | 7.97 KiB |       1 | `parse` | `/usr/lib/python3.11/re/_parser.py:970` |
+|      % |     Size | Allocations | Caller  | Location                                |
+| -----: | -------: | ----------: | ------- | --------------------------------------- |
+| 100.0% | 7.97 KiB |           1 | `parse` | `/usr/lib/python3.11/re/_parser.py:970` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/utils.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 7.08 KiB |       8 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 7.08 KiB |           8 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__setattr__` (`/usr/lib/python3.11/enum.py:831`)
 
-|     % |     Size | Samples | Caller         | Location                          |
-| ----: | -------: | ------: | -------------- | --------------------------------- |
-| 66.6% | 4.48 KiB |       5 | `__set_name__` | `/usr/lib/python3.11/enum.py:237` |
-| 33.4% | 2.25 KiB |       3 | `__new__`      | `/usr/lib/python3.11/enum.py:488` |
+|     % |     Size | Allocations | Caller         | Location                          |
+| ----: | -------: | ----------: | -------------- | --------------------------------- |
+| 66.6% | 4.48 KiB |           5 | `__set_name__` | `/usr/lib/python3.11/enum.py:237` |
+| 33.4% | 2.25 KiB |           3 | `__new__`      | `/usr/lib/python3.11/enum.py:488` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/util.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 6.48 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 6.48 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 6.24 KiB |       5 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 6.24 KiB |           5 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 5.97 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 5.97 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/_compat.py:1`)
 
-|      % |    Size | Samples | Caller                      | Location                            |
-| -----: | ------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 5.8 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |    Size | Allocations | Caller                      | Location                            |
+| -----: | ------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 5.8 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `namedtuple` (`/usr/lib/python3.11/collections/__init__.py:348`)
 
-|     % |     Size | Samples | Caller          | Location                             |
-| ----: | -------: | ------: | --------------- | ------------------------------------ |
-| 83.3% | 4.69 KiB |       5 | `_make_nmtuple` | `/usr/lib/python3.11/typing.py:2795` |
-| 16.7% |    960 B |       1 | `<module>`      | `/usr/lib/python3.11/pkgutil.py:1`   |
+|     % |     Size | Allocations | Caller          | Location                             |
+| ----: | -------: | ----------: | --------------- | ------------------------------------ |
+| 83.3% | 4.69 KiB |           5 | `_make_nmtuple` | `/usr/lib/python3.11/typing.py:2795` |
+| 16.7% |    960 B |           1 | `<module>`      | `/usr/lib/python3.11/pkgutil.py:1`   |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|      % |     Size | Samples | Caller       | Location                                |
-| -----: | -------: | ------: | ------------ | --------------------------------------- |
-| 100.0% | 5.61 KiB |       3 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
+|      % |     Size | Allocations | Caller       | Location                                |
+| -----: | -------: | ----------: | ------------ | --------------------------------------- |
+| 100.0% | 5.61 KiB |           3 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
 
 ##### `_code` (`/usr/lib/python3.11/re/_compiler.py:571`)
 
-|      % |     Size | Samples | Caller    | Location                                  |
-| -----: | -------: | ------: | --------- | ----------------------------------------- |
-| 100.0% | 5.32 KiB |       2 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
+|      % |     Size | Allocations | Caller    | Location                                  |
+| -----: | -------: | ----------: | --------- | ----------------------------------------- |
+| 100.0% | 5.32 KiB |           2 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
 
 ##### `<module>` (`/usr/lib/python3.11/pkgutil.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 4.73 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 4.73 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `Specifier` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`)
 
-|      % |     Size | Samples | Caller     | Location                                                       |
-| -----: | -------: | ------: | ---------- | -------------------------------------------------------------- |
-| 100.0% | 3.82 KiB |       1 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
+|      % |     Size | Allocations | Caller     | Location                                                       |
+| -----: | -------: | ----------: | ---------- | -------------------------------------------------------------- |
+| 100.0% | 3.82 KiB |           1 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.72 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.72 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.56 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.56 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `handle_parse_result` (`/venv/lib/python3.11/site-packages/click/core.py:2663`)
 
-|      % |     Size | Samples | Caller       | Location                                                |
-| -----: | -------: | ------: | ------------ | ------------------------------------------------------- |
-| 100.0% | 3.37 KiB |       5 | `parse_args` | `/venv/lib/python3.11/site-packages/click/core.py:1303` |
+|      % |     Size | Allocations | Caller       | Location                                                |
+| -----: | -------: | ----------: | ------------ | ------------------------------------------------------- |
+| 100.0% | 3.37 KiB |           5 | `parse_args` | `/venv/lib/python3.11/site-packages/click/core.py:1303` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.19 KiB |       1 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.19 KiB |           1 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.19 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.19 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Caller   | Location                                               |
-| -----: | -------: | ------: | -------- | ------------------------------------------------------ |
-| 100.0% | 3.04 KiB |       2 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
+|      % |     Size | Allocations | Caller   | Location                                               |
+| -----: | -------: | ----------: | -------- | ------------------------------------------------------ |
+| 100.0% | 3.04 KiB |           2 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|      % |     Size | Samples | Caller     | Location                                                   |
-| -----: | -------: | ------: | ---------- | ---------------------------------------------------------- |
-| 100.0% | 2.85 KiB |       1 | `<module>` | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1` |
+|      % |     Size | Allocations | Caller     | Location                                                   |
+| -----: | -------: | ----------: | ---------- | ---------------------------------------------------------- |
+| 100.0% | 2.85 KiB |           1 | `<module>` | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1` |
 
 ##### `_process_class` (`/usr/lib/python3.11/dataclasses.py:884`)
 
-|      % |     Size | Samples | Caller | Location                                  |
-| -----: | -------: | ------: | ------ | ----------------------------------------- |
-| 100.0% | 2.85 KiB |       4 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
+|      % |     Size | Allocations | Caller | Location                                  |
+| -----: | -------: | ----------: | ------ | ----------------------------------------- |
+| 100.0% | 2.85 KiB |           4 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.81 KiB |       3 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.81 KiB |           3 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.76 KiB |       2 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.76 KiB |           2 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ### Total size
 
 Functions ranked by total bytes never freed in the function and all its callees.
 
-|      % |     Size | Samples | Function               | Location                                                       |
-| -----: | -------: | ------: | ---------------------- | -------------------------------------------------------------- |
-| 100.0% | 55.9 MiB |  22,489 | `_run_tracker`         | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
-| 100.0% | 55.9 MiB |  22,488 | `run_module`           | `<frozen runpy>:201`                                           |
-|  92.3% | 51.6 MiB |  21,189 | `__call__`             | `/venv/lib/python3.11/site-packages/click/core.py:1567`        |
-|  92.3% | 51.6 MiB |  21,189 | `patched_main`         | `black/__init__.py:1594`                                       |
-|  92.3% | 51.6 MiB |  21,189 | `<module>`             | `black/__main__.py:1`                                          |
-|  92.3% | 51.6 MiB |  21,189 | `_run_code`            | `<frozen runpy>:65`                                            |
-|  92.3% | 51.6 MiB |  21,189 | `_run_module_code`     | `<frozen runpy>:91`                                            |
-|  92.3% | 51.6 MiB |  21,188 | `main`                 | `/venv/lib/python3.11/site-packages/click/core.py:1422`        |
-|  92.3% | 51.6 MiB |  21,169 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:1339`        |
-|  92.3% | 51.6 MiB |  21,167 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:853`         |
-|  92.3% | 51.6 MiB |  21,166 | `new_func`             | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
-|  92.3% | 51.6 MiB |  21,164 | `main`                 | `black/__init__.py:244`                                        |
-|  92.3% | 51.6 MiB |  21,159 | `reformat_one`         | `black/__init__.py:860`                                        |
-|  92.3% | 51.6 MiB |  21,152 | `format_file_in_place` | `black/__init__.py:917`                                        |
-|  92.3% | 51.6 MiB |  21,151 | `format_file_contents` | `black/__init__.py:1054`                                       |
-|  85.1% | 47.6 MiB |  21,143 | `_format_str_once`     | `black/__init__.py:1236`                                       |
-|  58.0% | 32.4 MiB |  21,083 | `visit`                | `black/nodes.py:163`                                           |
-|  58.0% | 32.4 MiB |  21,081 | `visit_default`        | `black/linegen.py:134`                                         |
-|  58.0% | 32.4 MiB |  21,081 | `visit_default`        | `black/nodes.py:187`                                           |
-|  57.5% | 32.2 MiB |  20,710 | `visit_stmt`           | `black/linegen.py:199`                                         |
+|      % |     Size | Allocations | Function               | Location                                                       |
+| -----: | -------: | ----------: | ---------------------- | -------------------------------------------------------------- |
+| 100.0% | 55.9 MiB |      22,489 | `_run_tracker`         | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
+| 100.0% | 55.9 MiB |      22,488 | `run_module`           | `<frozen runpy>:201`                                           |
+|  92.3% | 51.6 MiB |      21,189 | `__call__`             | `/venv/lib/python3.11/site-packages/click/core.py:1567`        |
+|  92.3% | 51.6 MiB |      21,189 | `patched_main`         | `black/__init__.py:1594`                                       |
+|  92.3% | 51.6 MiB |      21,189 | `<module>`             | `black/__main__.py:1`                                          |
+|  92.3% | 51.6 MiB |      21,189 | `_run_code`            | `<frozen runpy>:65`                                            |
+|  92.3% | 51.6 MiB |      21,189 | `_run_module_code`     | `<frozen runpy>:91`                                            |
+|  92.3% | 51.6 MiB |      21,188 | `main`                 | `/venv/lib/python3.11/site-packages/click/core.py:1422`        |
+|  92.3% | 51.6 MiB |      21,169 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:1339`        |
+|  92.3% | 51.6 MiB |      21,167 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:853`         |
+|  92.3% | 51.6 MiB |      21,166 | `new_func`             | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
+|  92.3% | 51.6 MiB |      21,164 | `main`                 | `black/__init__.py:244`                                        |
+|  92.3% | 51.6 MiB |      21,159 | `reformat_one`         | `black/__init__.py:860`                                        |
+|  92.3% | 51.6 MiB |      21,152 | `format_file_in_place` | `black/__init__.py:917`                                        |
+|  92.3% | 51.6 MiB |      21,151 | `format_file_contents` | `black/__init__.py:1054`                                       |
+|  85.1% | 47.6 MiB |      21,143 | `_format_str_once`     | `black/__init__.py:1236`                                       |
+|  58.0% | 32.4 MiB |      21,083 | `visit`                | `black/nodes.py:163`                                           |
+|  58.0% | 32.4 MiB |      21,081 | `visit_default`        | `black/linegen.py:134`                                         |
+|  58.0% | 32.4 MiB |      21,081 | `visit_default`        | `black/nodes.py:187`                                           |
+|  57.5% | 32.2 MiB |      20,710 | `visit_stmt`           | `black/linegen.py:199`                                         |
 
 #### Categories
 
 ##### Ours
 
-|     % |     Size | Samples | Function                          | Location                 |
-| ----: | -------: | ------: | --------------------------------- | ------------------------ |
-| 92.3% | 51.6 MiB |  21,189 | `patched_main`                    | `black/__init__.py:1594` |
-| 92.3% | 51.6 MiB |  21,189 | `<module>`                        | `black/__main__.py:1`    |
-| 92.3% | 51.6 MiB |  21,164 | `main`                            | `black/__init__.py:244`  |
-| 92.3% | 51.6 MiB |  21,159 | `reformat_one`                    | `black/__init__.py:860`  |
-| 92.3% | 51.6 MiB |  21,152 | `format_file_in_place`            | `black/__init__.py:917`  |
-| 92.3% | 51.6 MiB |  21,151 | `format_file_contents`            | `black/__init__.py:1054` |
-| 85.1% | 47.6 MiB |  21,143 | `_format_str_once`                | `black/__init__.py:1236` |
-| 58.0% | 32.4 MiB |  21,083 | `visit`                           | `black/nodes.py:163`     |
-| 58.0% | 32.4 MiB |  21,081 | `visit_default`                   | `black/linegen.py:134`   |
-| 58.0% | 32.4 MiB |  21,081 | `visit_default`                   | `black/nodes.py:187`     |
-| 57.5% | 32.2 MiB |  20,710 | `visit_stmt`                      | `black/linegen.py:199`   |
-| 56.9% | 31.8 MiB |  20,269 | `visit_funcdef`                   | `black/linegen.py:254`   |
-| 56.7% | 31.7 MiB |  20,143 | `visit_suite`                     | `black/linegen.py:288`   |
-| 48.4% | 27.1 MiB |      85 | `format_str`                      | `black/__init__.py:1189` |
-| 43.9% | 24.5 MiB |  21,066 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
-| 38.1% | 21.3 MiB |  20,886 | `append`                          | `black/lines.py:63`      |
-| 37.2% | 20.8 MiB |  13,399 | `visit_simple_stmt`               | `black/linegen.py:295`   |
-| 36.7% | 20.5 MiB |  21,059 | `assert_stable`                   | `black/__init__.py:1557` |
-| 29.0% | 16.2 MiB |  20,788 | `mark`                            | `black/brackets.py:70`   |
-| 24.9% | 13.9 MiB |  10,805 | `visit_power`                     | `black/linegen.py:341`   |
+|     % |     Size | Allocations | Function                          | Location                 |
+| ----: | -------: | ----------: | --------------------------------- | ------------------------ |
+| 92.3% | 51.6 MiB |      21,189 | `patched_main`                    | `black/__init__.py:1594` |
+| 92.3% | 51.6 MiB |      21,189 | `<module>`                        | `black/__main__.py:1`    |
+| 92.3% | 51.6 MiB |      21,164 | `main`                            | `black/__init__.py:244`  |
+| 92.3% | 51.6 MiB |      21,159 | `reformat_one`                    | `black/__init__.py:860`  |
+| 92.3% | 51.6 MiB |      21,152 | `format_file_in_place`            | `black/__init__.py:917`  |
+| 92.3% | 51.6 MiB |      21,151 | `format_file_contents`            | `black/__init__.py:1054` |
+| 85.1% | 47.6 MiB |      21,143 | `_format_str_once`                | `black/__init__.py:1236` |
+| 58.0% | 32.4 MiB |      21,083 | `visit`                           | `black/nodes.py:163`     |
+| 58.0% | 32.4 MiB |      21,081 | `visit_default`                   | `black/linegen.py:134`   |
+| 58.0% | 32.4 MiB |      21,081 | `visit_default`                   | `black/nodes.py:187`     |
+| 57.5% | 32.2 MiB |      20,710 | `visit_stmt`                      | `black/linegen.py:199`   |
+| 56.9% | 31.8 MiB |      20,269 | `visit_funcdef`                   | `black/linegen.py:254`   |
+| 56.7% | 31.7 MiB |      20,143 | `visit_suite`                     | `black/linegen.py:288`   |
+| 48.4% | 27.1 MiB |          85 | `format_str`                      | `black/__init__.py:1189` |
+| 43.9% | 24.5 MiB |      21,066 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+| 38.1% | 21.3 MiB |      20,886 | `append`                          | `black/lines.py:63`      |
+| 37.2% | 20.8 MiB |      13,399 | `visit_simple_stmt`               | `black/linegen.py:295`   |
+| 36.7% | 20.5 MiB |      21,059 | `assert_stable`                   | `black/__init__.py:1557` |
+| 29.0% | 16.2 MiB |      20,788 | `mark`                            | `black/brackets.py:70`   |
+| 24.9% | 13.9 MiB |      10,805 | `visit_power`                     | `black/linegen.py:341`   |
 
 ##### Standard library
 
-|      % |     Size | Samples | Function                    | Location                                     |
-| -----: | -------: | ------: | --------------------------- | -------------------------------------------- |
-| 100.0% | 55.9 MiB |  22,488 | `run_module`                | `<frozen runpy>:201`                         |
-|  92.3% | 51.6 MiB |  21,189 | `_run_code`                 | `<frozen runpy>:65`                          |
-|  92.3% | 51.6 MiB |  21,189 | `_run_module_code`          | `<frozen runpy>:91`                          |
-|   7.7% | 4.28 MiB |   1,298 | `_get_module_details`       | `<frozen runpy>:105`                         |
-|   7.6% | 4.28 MiB |   1,291 | `_find_and_load`            | `<frozen importlib._bootstrap>:1167`         |
-|   7.6% | 4.28 MiB |   1,289 | `_find_and_load_unlocked`   | `<frozen importlib._bootstrap>:1122`         |
-|   7.6% | 4.28 MiB |   1,288 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`          |
-|   7.6% | 4.27 MiB |   1,286 | `exec_module`               | `<frozen importlib._bootstrap_external>:934` |
-|   7.6% | 4.24 MiB |   1,256 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`          |
-|   5.4% | 3.01 MiB |       4 | `parse`                     | `/usr/lib/python3.11/ast.py:33`              |
-|   2.3% |  1.3 MiB |     318 | `_handle_fromlist`          | `<frozen importlib._bootstrap>:1209`         |
-|   1.9% | 1.05 MiB |      26 | `compile`                   | `/usr/lib/python3.11/re/__init__.py:225`     |
-|   1.9% | 1.05 MiB |      25 | `_compile`                  | `/usr/lib/python3.11/re/__init__.py:272`     |
-|   1.9% | 1.05 MiB |      24 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`    |
-|   1.8% | 1.01 MiB |       6 | `parse`                     | `/usr/lib/python3.11/re/_parser.py:970`      |
-|   1.8% | 1.01 MiB |      15 | `wrap`                      | `/usr/lib/python3.11/dataclasses.py:1209`    |
-|   1.8% | 1.01 MiB |       5 | `_parse_sub`                | `/usr/lib/python3.11/re/_parser.py:447`      |
-|   1.8% | 1.01 MiB |      14 | `_process_class`            | `/usr/lib/python3.11/dataclasses.py:884`     |
-|   1.8% | 1.01 MiB |      11 | `dataclass`                 | `/usr/lib/python3.11/dataclasses.py:1192`    |
-|   1.8% | 1.01 MiB |       4 | `_parse`                    | `/usr/lib/python3.11/re/_parser.py:507`      |
+|      % |     Size | Allocations | Function                    | Location                                     |
+| -----: | -------: | ----------: | --------------------------- | -------------------------------------------- |
+| 100.0% | 55.9 MiB |      22,488 | `run_module`                | `<frozen runpy>:201`                         |
+|  92.3% | 51.6 MiB |      21,189 | `_run_code`                 | `<frozen runpy>:65`                          |
+|  92.3% | 51.6 MiB |      21,189 | `_run_module_code`          | `<frozen runpy>:91`                          |
+|   7.7% | 4.28 MiB |       1,298 | `_get_module_details`       | `<frozen runpy>:105`                         |
+|   7.6% | 4.28 MiB |       1,291 | `_find_and_load`            | `<frozen importlib._bootstrap>:1167`         |
+|   7.6% | 4.28 MiB |       1,289 | `_find_and_load_unlocked`   | `<frozen importlib._bootstrap>:1122`         |
+|   7.6% | 4.28 MiB |       1,288 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`          |
+|   7.6% | 4.27 MiB |       1,286 | `exec_module`               | `<frozen importlib._bootstrap_external>:934` |
+|   7.6% | 4.24 MiB |       1,256 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`          |
+|   5.4% | 3.01 MiB |           4 | `parse`                     | `/usr/lib/python3.11/ast.py:33`              |
+|   2.3% |  1.3 MiB |         318 | `_handle_fromlist`          | `<frozen importlib._bootstrap>:1209`         |
+|   1.9% | 1.05 MiB |          26 | `compile`                   | `/usr/lib/python3.11/re/__init__.py:225`     |
+|   1.9% | 1.05 MiB |          25 | `_compile`                  | `/usr/lib/python3.11/re/__init__.py:272`     |
+|   1.9% | 1.05 MiB |          24 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`    |
+|   1.8% | 1.01 MiB |           6 | `parse`                     | `/usr/lib/python3.11/re/_parser.py:970`      |
+|   1.8% | 1.01 MiB |          15 | `wrap`                      | `/usr/lib/python3.11/dataclasses.py:1209`    |
+|   1.8% | 1.01 MiB |           5 | `_parse_sub`                | `/usr/lib/python3.11/re/_parser.py:447`      |
+|   1.8% | 1.01 MiB |          14 | `_process_class`            | `/usr/lib/python3.11/dataclasses.py:884`     |
+|   1.8% | 1.01 MiB |          11 | `dataclass`                 | `/usr/lib/python3.11/dataclasses.py:1192`    |
+|   1.8% | 1.01 MiB |           4 | `_parse`                    | `/usr/lib/python3.11/re/_parser.py:507`      |
 
 ##### Third-party
 
-|      % |     Size | Samples | Function       | Location                                                                         |
-| -----: | -------: | ------: | -------------- | -------------------------------------------------------------------------------- |
-| 100.0% | 55.9 MiB |  22,489 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40`                   |
-|  92.3% | 51.6 MiB |  21,189 | `__call__`     | `/venv/lib/python3.11/site-packages/click/core.py:1567`                          |
-|  92.3% | 51.6 MiB |  21,188 | `main`         | `/venv/lib/python3.11/site-packages/click/core.py:1422`                          |
-|  92.3% | 51.6 MiB |  21,169 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339`                          |
-|  92.3% | 51.6 MiB |  21,167 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:853`                           |
-|  92.3% | 51.6 MiB |  21,166 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                      |
-|   2.3% | 1.31 MiB |     304 | `<module>`     | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                         |
-|   2.2% | 1.23 MiB |     233 | `<module>`     | `/venv/lib/python3.11/site-packages/click/core.py:1`                             |
-|   1.8% | 1.02 MiB |      24 | `<module>`     | `/venv/lib/python3.11/site-packages/click/formatting.py:1`                       |
-|   1.8% | 1.01 MiB |      11 | `<module>`     | `/venv/lib/python3.11/site-packages/click/parser.py:1`                           |
-|   0.2% |  137 KiB |     140 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`                   |
-|   0.2% |  125 KiB |     127 | `<module>`     | `/venv/lib/python3.11/site-packages/click/types.py:1`                            |
-|   0.2% | 93.8 KiB |     119 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`                      |
-|   0.2% | 91.5 KiB |     115 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`                     |
-|   0.1% | 65.5 KiB |      84 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`                 |
-|   0.1% | 63.6 KiB |      71 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                        |
-|   0.1% | 47.3 KiB |      33 | `decorator`    | `/venv/lib/python3.11/site-packages/click/decorators.py:373`                     |
-|   0.1% | 46.9 KiB |      59 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1` |
-|   0.1% | 45.5 KiB |      32 | `__init__`     | `/venv/lib/python3.11/site-packages/click/core.py:2883`                          |
-|   0.1% | 40.8 KiB |      42 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                      |
+|      % |     Size | Allocations | Function       | Location                                                                         |
+| -----: | -------: | ----------: | -------------- | -------------------------------------------------------------------------------- |
+| 100.0% | 55.9 MiB |      22,489 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40`                   |
+|  92.3% | 51.6 MiB |      21,189 | `__call__`     | `/venv/lib/python3.11/site-packages/click/core.py:1567`                          |
+|  92.3% | 51.6 MiB |      21,188 | `main`         | `/venv/lib/python3.11/site-packages/click/core.py:1422`                          |
+|  92.3% | 51.6 MiB |      21,169 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339`                          |
+|  92.3% | 51.6 MiB |      21,167 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:853`                           |
+|  92.3% | 51.6 MiB |      21,166 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                      |
+|   2.3% | 1.31 MiB |         304 | `<module>`     | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                         |
+|   2.2% | 1.23 MiB |         233 | `<module>`     | `/venv/lib/python3.11/site-packages/click/core.py:1`                             |
+|   1.8% | 1.02 MiB |          24 | `<module>`     | `/venv/lib/python3.11/site-packages/click/formatting.py:1`                       |
+|   1.8% | 1.01 MiB |          11 | `<module>`     | `/venv/lib/python3.11/site-packages/click/parser.py:1`                           |
+|   0.2% |  137 KiB |         140 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`                   |
+|   0.2% |  125 KiB |         127 | `<module>`     | `/venv/lib/python3.11/site-packages/click/types.py:1`                            |
+|   0.2% | 93.8 KiB |         119 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`                      |
+|   0.2% | 91.5 KiB |         115 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`                     |
+|   0.1% | 65.5 KiB |          84 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`                 |
+|   0.1% | 63.6 KiB |          71 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                        |
+|   0.1% | 47.3 KiB |          33 | `decorator`    | `/venv/lib/python3.11/site-packages/click/decorators.py:373`                     |
+|   0.1% | 46.9 KiB |          59 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1` |
+|   0.1% | 45.5 KiB |          32 | `__init__`     | `/venv/lib/python3.11/site-packages/click/core.py:2883`                          |
+|   0.1% | 40.8 KiB |          42 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                      |
 
 #### Callees
 
@@ -2524,398 +2524,398 @@ Callees ranked by contribution to each function's total size. Inlining can make 
 
 ##### `_run_tracker` (`/venv/lib/python3.11/site-packages/memray/commands/run.py:40`)
 
-|      % |     Size | Samples | Callee       | Location             |
-| -----: | -------: | ------: | ------------ | -------------------- |
-| 100.0% | 55.9 MiB |  22,488 | `run_module` | `<frozen runpy>:201` |
+|      % |     Size | Allocations | Callee       | Location             |
+| -----: | -------: | ----------: | ------------ | -------------------- |
+| 100.0% | 55.9 MiB |      22,488 | `run_module` | `<frozen runpy>:201` |
 
 ##### `run_module` (`<frozen runpy>:201`)
 
-|     % |     Size | Samples | Callee                | Location             |
-| ----: | -------: | ------: | --------------------- | -------------------- |
-| 92.3% | 51.6 MiB |  21,189 | `_run_module_code`    | `<frozen runpy>:91`  |
-|  7.7% | 4.28 MiB |   1,298 | `_get_module_details` | `<frozen runpy>:105` |
+|     % |     Size | Allocations | Callee                | Location             |
+| ----: | -------: | ----------: | --------------------- | -------------------- |
+| 92.3% | 51.6 MiB |      21,189 | `_run_module_code`    | `<frozen runpy>:91`  |
+|  7.7% | 4.28 MiB |       1,298 | `_get_module_details` | `<frozen runpy>:105` |
 
 ##### `__call__` (`/venv/lib/python3.11/site-packages/click/core.py:1567`)
 
-|      % |     Size | Samples | Callee | Location                                                |
-| -----: | -------: | ------: | ------ | ------------------------------------------------------- |
-| 100.0% | 51.6 MiB |  21,188 | `main` | `/venv/lib/python3.11/site-packages/click/core.py:1422` |
+|      % |     Size | Allocations | Callee | Location                                                |
+| -----: | -------: | ----------: | ------ | ------------------------------------------------------- |
+| 100.0% | 51.6 MiB |      21,188 | `main` | `/venv/lib/python3.11/site-packages/click/core.py:1422` |
 
 ##### `patched_main` (`black/__init__.py:1594`)
 
-|      % |     Size | Samples | Callee     | Location                                                |
-| -----: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 100.0% | 51.6 MiB |  21,189 | `__call__` | `/venv/lib/python3.11/site-packages/click/core.py:1567` |
+|      % |     Size | Allocations | Callee     | Location                                                |
+| -----: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 100.0% | 51.6 MiB |      21,189 | `__call__` | `/venv/lib/python3.11/site-packages/click/core.py:1567` |
 
 ##### `<module>` (`black/__main__.py:1`)
 
-|      % |     Size | Samples | Callee         | Location                 |
-| -----: | -------: | ------: | -------------- | ------------------------ |
-| 100.0% | 51.6 MiB |  21,189 | `patched_main` | `black/__init__.py:1594` |
+|      % |     Size | Allocations | Callee         | Location                 |
+| -----: | -------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 51.6 MiB |      21,189 | `patched_main` | `black/__init__.py:1594` |
 
 ##### `_run_code` (`<frozen runpy>:65`)
 
-|      % |     Size | Samples | Callee     | Location              |
-| -----: | -------: | ------: | ---------- | --------------------- |
-| 100.0% | 51.6 MiB |  21,189 | `<module>` | `black/__main__.py:1` |
+|      % |     Size | Allocations | Callee     | Location              |
+| -----: | -------: | ----------: | ---------- | --------------------- |
+| 100.0% | 51.6 MiB |      21,189 | `<module>` | `black/__main__.py:1` |
 
 ##### `_run_module_code` (`<frozen runpy>:91`)
 
-|      % |     Size | Samples | Callee      | Location            |
-| -----: | -------: | ------: | ----------- | ------------------- |
-| 100.0% | 51.6 MiB |  21,189 | `_run_code` | `<frozen runpy>:65` |
+|      % |     Size | Allocations | Callee      | Location            |
+| -----: | -------: | ----------: | ----------- | ------------------- |
+| 100.0% | 51.6 MiB |      21,189 | `_run_code` | `<frozen runpy>:65` |
 
 ##### `main` (`/venv/lib/python3.11/site-packages/click/core.py:1422`)
 
-|      % |     Size | Samples | Callee         | Location                                                |
-| -----: | -------: | ------: | -------------- | ------------------------------------------------------- |
-| 100.0% | 51.6 MiB |  21,169 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339` |
-|  <0.1% | 13.6 KiB |      16 | `make_context` | `/venv/lib/python3.11/site-packages/click/core.py:1266` |
-|  <0.1% |    529 B |       2 | `__exit__`     | `/venv/lib/python3.11/site-packages/click/core.py:550`  |
+|      % |     Size | Allocations | Callee         | Location                                                |
+| -----: | -------: | ----------: | -------------- | ------------------------------------------------------- |
+| 100.0% | 51.6 MiB |      21,169 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339` |
+|  <0.1% | 13.6 KiB |          16 | `make_context` | `/venv/lib/python3.11/site-packages/click/core.py:1266` |
+|  <0.1% |    529 B |           2 | `__exit__`     | `/venv/lib/python3.11/site-packages/click/core.py:550`  |
 
 ##### `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:1339`)
 
-|      % |     Size | Samples | Callee   | Location                                               |
-| -----: | -------: | ------: | -------- | ------------------------------------------------------ |
-| 100.0% | 51.6 MiB |  21,167 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
+|      % |     Size | Allocations | Callee   | Location                                               |
+| -----: | -------: | ----------: | -------- | ------------------------------------------------------ |
+| 100.0% | 51.6 MiB |      21,167 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
 
 ##### `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`)
 
-|      % |     Size | Samples | Callee     | Location                                                    |
-| -----: | -------: | ------: | ---------- | ----------------------------------------------------------- |
-| 100.0% | 51.6 MiB |  21,166 | `new_func` | `/venv/lib/python3.11/site-packages/click/decorators.py:33` |
+|      % |     Size | Allocations | Callee     | Location                                                    |
+| -----: | -------: | ----------: | ---------- | ----------------------------------------------------------- |
+| 100.0% | 51.6 MiB |      21,166 | `new_func` | `/venv/lib/python3.11/site-packages/click/decorators.py:33` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Callee | Location                |
-| -----: | -------: | ------: | ------ | ----------------------- |
-| 100.0% | 51.6 MiB |  21,164 | `main` | `black/__init__.py:244` |
+|      % |     Size | Allocations | Callee | Location                |
+| -----: | -------: | ----------: | ------ | ----------------------- |
+| 100.0% | 51.6 MiB |      21,164 | `main` | `black/__init__.py:244` |
 
 ##### `main` (`black/__init__.py:244`)
 
-|      % |     Size | Samples | Callee         | Location                |
-| -----: | -------: | ------: | -------------- | ----------------------- |
-| 100.0% | 51.6 MiB |  21,159 | `reformat_one` | `black/__init__.py:860` |
-|  <0.1% | 2.06 KiB |       2 | `get_sources`  | `black/__init__.py:724` |
+|      % |     Size | Allocations | Callee         | Location                |
+| -----: | -------: | ----------: | -------------- | ----------------------- |
+| 100.0% | 51.6 MiB |      21,159 | `reformat_one` | `black/__init__.py:860` |
+|  <0.1% | 2.06 KiB |           2 | `get_sources`  | `black/__init__.py:724` |
 
 ##### `reformat_one` (`black/__init__.py:860`)
 
-|      % |     Size | Samples | Callee                 | Location                |
-| -----: | -------: | ------: | ---------------------- | ----------------------- |
-| 100.0% | 51.6 MiB |  21,152 | `format_file_in_place` | `black/__init__.py:917` |
-|  <0.1% | 1.92 KiB |       2 | `done`                 | `black/report.py:36`    |
-|  <0.1% | 1.13 KiB |       1 | `read`                 | `black/cache.py:60`     |
-|  <0.1% |     72 B |       2 | `write`                | `black/cache.py:132`    |
+|      % |     Size | Allocations | Callee                 | Location                |
+| -----: | -------: | ----------: | ---------------------- | ----------------------- |
+| 100.0% | 51.6 MiB |      21,152 | `format_file_in_place` | `black/__init__.py:917` |
+|  <0.1% | 1.92 KiB |           2 | `done`                 | `black/report.py:36`    |
+|  <0.1% | 1.13 KiB |           1 | `read`                 | `black/cache.py:60`     |
+|  <0.1% |     72 B |           2 | `write`                | `black/cache.py:132`    |
 
 ##### `format_file_in_place` (`black/__init__.py:917`)
 
-|      % |     Size | Samples | Callee                 | Location                 |
-| -----: | -------: | ------: | ---------------------- | ------------------------ |
-| 100.0% | 51.6 MiB |  21,151 | `format_file_contents` | `black/__init__.py:1054` |
-|  <0.1% |    552 B |       1 | `decode_bytes`         | `black/__init__.py:1290` |
+|      % |     Size | Allocations | Callee                 | Location                 |
+| -----: | -------: | ----------: | ---------------------- | ------------------------ |
+| 100.0% | 51.6 MiB |      21,151 | `format_file_contents` | `black/__init__.py:1054` |
+|  <0.1% |    552 B |           1 | `decode_bytes`         | `black/__init__.py:1290` |
 
 ##### `format_file_contents` (`black/__init__.py:1054`)
 
-|     % |     Size | Samples | Callee                            | Location                 |
-| ----: | -------: | ------: | --------------------------------- | ------------------------ |
-| 52.5% | 27.1 MiB |      85 | `format_str`                      | `black/__init__.py:1189` |
-| 47.5% | 24.5 MiB |  21,066 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+|     % |     Size | Allocations | Callee                            | Location                 |
+| ----: | -------: | ----------: | --------------------------------- | ------------------------ |
+| 52.5% | 27.1 MiB |          85 | `format_str`                      | `black/__init__.py:1189` |
+| 47.5% | 24.5 MiB |      21,066 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
 
 ##### `_format_str_once` (`black/__init__.py:1236`)
 
-|     % |     Size | Samples | Callee                   | Location                 |
-| ----: | -------: | ------: | ------------------------ | ------------------------ |
-| 68.2% | 32.4 MiB |  21,083 | `visit`                  | `black/nodes.py:163`     |
-| 25.3% |   12 MiB |      31 | `lib2to3_parse`          | `black/parsing.py:55`    |
-|  6.5% | 3.08 MiB |      18 | `transform_line`         | `black/linegen.py:601`   |
-| <0.1% | 19.9 KiB |       3 | `normalize_fmt_off`      | `black/comments.py:168`  |
-| <0.1% | 3.49 KiB |       1 | `detect_target_versions` | `black/__init__.py:1464` |
+|     % |     Size | Allocations | Callee                   | Location                 |
+| ----: | -------: | ----------: | ------------------------ | ------------------------ |
+| 68.2% | 32.4 MiB |      21,083 | `visit`                  | `black/nodes.py:163`     |
+| 25.3% |   12 MiB |          31 | `lib2to3_parse`          | `black/parsing.py:55`    |
+|  6.5% | 3.08 MiB |          18 | `transform_line`         | `black/linegen.py:601`   |
+| <0.1% | 19.9 KiB |           3 | `normalize_fmt_off`      | `black/comments.py:168`  |
+| <0.1% | 3.49 KiB |           1 | `detect_target_versions` | `black/__init__.py:1464` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|      % |     Size | Samples | Callee              | Location               |
-| -----: | -------: | ------: | ------------------- | ---------------------- |
-| 100.0% | 32.4 MiB |  21,081 | `visit_default`     | `black/linegen.py:134` |
-|  99.1% | 32.2 MiB |  20,710 | `visit_stmt`        | `black/linegen.py:199` |
-|  98.1% | 31.8 MiB |  20,269 | `visit_funcdef`     | `black/linegen.py:254` |
-|  97.8% | 31.7 MiB |  20,143 | `visit_suite`       | `black/linegen.py:288` |
-|  64.2% | 20.8 MiB |  13,399 | `visit_simple_stmt` | `black/linegen.py:295` |
+|      % |     Size | Allocations | Callee              | Location               |
+| -----: | -------: | ----------: | ------------------- | ---------------------- |
+| 100.0% | 32.4 MiB |      21,081 | `visit_default`     | `black/linegen.py:134` |
+|  99.1% | 32.2 MiB |      20,710 | `visit_stmt`        | `black/linegen.py:199` |
+|  98.1% | 31.8 MiB |      20,269 | `visit_funcdef`     | `black/linegen.py:254` |
+|  97.8% | 31.7 MiB |      20,143 | `visit_suite`       | `black/linegen.py:288` |
+|  64.2% | 20.8 MiB |      13,399 | `visit_simple_stmt` | `black/linegen.py:295` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|      % |     Size | Samples | Callee              | Location               |
-| -----: | -------: | ------: | ------------------- | ---------------------- |
-| 100.0% | 32.4 MiB |  21,081 | `visit_default`     | `black/nodes.py:187`   |
-|  65.6% | 21.3 MiB |  20,886 | `append`            | `black/lines.py:63`    |
-|  15.4% |    5 MiB |       5 | `generate_comments` | `black/comments.py:52` |
-|   3.1% |    1 MiB |       1 | `line`              | `black/linegen.py:109` |
+|      % |     Size | Allocations | Callee              | Location               |
+| -----: | -------: | ----------: | ------------------- | ---------------------- |
+| 100.0% | 32.4 MiB |      21,081 | `visit_default`     | `black/nodes.py:187`   |
+|  65.6% | 21.3 MiB |      20,886 | `append`            | `black/lines.py:63`    |
+|  15.4% |    5 MiB |           5 | `generate_comments` | `black/comments.py:52` |
+|   3.1% |    1 MiB |           1 | `line`              | `black/linegen.py:109` |
 
 ##### `visit_default` (`black/nodes.py:187`)
 
-|      % |     Size | Samples | Callee  | Location             |
-| -----: | -------: | ------: | ------- | -------------------- |
-| 100.0% | 32.4 MiB |  21,081 | `visit` | `black/nodes.py:163` |
+|      % |     Size | Allocations | Callee  | Location             |
+| -----: | -------: | ----------: | ------- | -------------------- |
+| 100.0% | 32.4 MiB |      21,081 | `visit` | `black/nodes.py:163` |
 
 ##### `visit_stmt` (`black/linegen.py:199`)
 
-|     % |     Size | Samples | Callee                       | Location                |
-| ----: | -------: | ------: | ---------------------------- | ----------------------- |
-| 96.9% | 31.2 MiB |  20,707 | `visit`                      | `black/nodes.py:163`    |
-|  9.3% |    3 MiB |       4 | `normalize_invisible_parens` | `black/linegen.py:1328` |
+|     % |     Size | Allocations | Callee                       | Location                |
+| ----: | -------: | ----------: | ---------------------------- | ----------------------- |
+| 96.9% | 31.2 MiB |      20,707 | `visit`                      | `black/nodes.py:163`    |
+|  9.3% |    3 MiB |           4 | `normalize_invisible_parens` | `black/linegen.py:1328` |
 
 ##### `visit_funcdef` (`black/linegen.py:254`)
 
-|      % |     Size | Samples | Callee  | Location             |
-| -----: | -------: | ------: | ------- | -------------------- |
-| 100.0% | 31.8 MiB |  20,269 | `visit` | `black/nodes.py:163` |
+|      % |     Size | Allocations | Callee  | Location             |
+| -----: | -------: | ----------: | ------- | -------------------- |
+| 100.0% | 31.8 MiB |      20,269 | `visit` | `black/nodes.py:163` |
 
 ##### `visit_suite` (`black/linegen.py:288`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 31.7 MiB |  20,143 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 31.7 MiB |      20,143 | `visit_default` | `black/linegen.py:134` |
 
 ##### `format_str` (`black/__init__.py:1189`)
 
-|      % |     Size | Samples | Callee             | Location                 |
-| -----: | -------: | ------: | ------------------ | ------------------------ |
-| 100.0% | 27.1 MiB |      84 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |     Size | Allocations | Callee             | Location                 |
+| -----: | -------: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 27.1 MiB |          84 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `check_stability_and_equivalence` (`black/__init__.py:1037`)
 
-|     % |     Size | Samples | Callee              | Location                 |
-| ----: | -------: | ------: | ------------------- | ------------------------ |
-| 83.7% | 20.5 MiB |  21,059 | `assert_stable`     | `black/__init__.py:1557` |
-| 16.3% | 4.01 MiB |       6 | `assert_equivalent` | `black/__init__.py:1524` |
+|     % |     Size | Allocations | Callee              | Location                 |
+| ----: | -------: | ----------: | ------------------- | ------------------------ |
+| 83.7% | 20.5 MiB |      21,059 | `assert_stable`     | `black/__init__.py:1557` |
+| 16.3% | 4.01 MiB |           6 | `assert_equivalent` | `black/__init__.py:1524` |
 
 ##### `append` (`black/lines.py:63`)
 
-|     % |     Size | Samples | Callee       | Location                 |
-| ----: | -------: | ------: | ------------ | ------------------------ |
-| 76.2% | 16.2 MiB |  20,788 | `mark`       | `black/brackets.py:70`   |
-| 19.0% | 4.05 MiB |      93 | `whitespace` | `black/nodes.py:194`     |
-|  4.7% |    1 MiB |       1 | `prefix`     | `blib2to3/pytree.py:480` |
+|     % |     Size | Allocations | Callee       | Location                 |
+| ----: | -------: | ----------: | ------------ | ------------------------ |
+| 76.2% | 16.2 MiB |      20,788 | `mark`       | `black/brackets.py:70`   |
+| 19.0% | 4.05 MiB |          93 | `whitespace` | `black/nodes.py:194`     |
+|  4.7% |    1 MiB |           1 | `prefix`     | `blib2to3/pytree.py:480` |
 
 ##### `visit_simple_stmt` (`black/linegen.py:295`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 20.8 MiB |  13,399 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 20.8 MiB |      13,399 | `visit_default` | `black/linegen.py:134` |
 
 ##### `assert_stable` (`black/__init__.py:1557`)
 
-|      % |     Size | Samples | Callee             | Location                 |
-| -----: | -------: | ------: | ------------------ | ------------------------ |
-| 100.0% | 20.5 MiB |  21,059 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |     Size | Allocations | Callee             | Location                 |
+| -----: | -------: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 20.5 MiB |      21,059 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `visit_power` (`black/linegen.py:341`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 13.9 MiB |  10,804 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 13.9 MiB |      10,804 | `visit_default` | `black/linegen.py:134` |
 
 ##### `_get_module_details` (`<frozen runpy>:105`)
 
-|     % |     Size | Samples | Callee                | Location                             |
-| ----: | -------: | ------: | --------------------- | ------------------------------------ |
-| 99.9% | 4.28 MiB |   1,291 | `_find_and_load`      | `<frozen importlib._bootstrap>:1167` |
-| 99.9% | 4.28 MiB |   1,291 | `_get_module_details` | `<frozen runpy>:105`                 |
-|  0.1% | 5.66 KiB |       6 | `find_spec`           | `<frozen importlib.util>:73`         |
+|     % |     Size | Allocations | Callee                | Location                             |
+| ----: | -------: | ----------: | --------------------- | ------------------------------------ |
+| 99.9% | 4.28 MiB |       1,291 | `_find_and_load`      | `<frozen importlib._bootstrap>:1167` |
+| 99.9% | 4.28 MiB |       1,291 | `_get_module_details` | `<frozen runpy>:105`                 |
+|  0.1% | 5.66 KiB |           6 | `find_spec`           | `<frozen importlib.util>:73`         |
 
 ##### `_find_and_load` (`<frozen importlib._bootstrap>:1167`)
 
-|      % |     Size | Samples | Callee                    | Location                             |
-| -----: | -------: | ------: | ------------------------- | ------------------------------------ |
-| 100.0% | 4.28 MiB |   1,289 | `_find_and_load_unlocked` | `<frozen importlib._bootstrap>:1122` |
-|  <0.1% |    560 B |       1 | `__enter__`               | `<frozen importlib._bootstrap>:169`  |
+|      % |     Size | Allocations | Callee                    | Location                             |
+| -----: | -------: | ----------: | ------------------------- | ------------------------------------ |
+| 100.0% | 4.28 MiB |       1,289 | `_find_and_load_unlocked` | `<frozen importlib._bootstrap>:1122` |
+|  <0.1% |    560 B |           1 | `__enter__`               | `<frozen importlib._bootstrap>:169`  |
 
 ##### `_find_and_load_unlocked` (`<frozen importlib._bootstrap>:1122`)
 
-|      % |     Size | Samples | Callee                      | Location                             |
-| -----: | -------: | ------: | --------------------------- | ------------------------------------ |
-| 100.0% | 4.28 MiB |   1,288 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`  |
-|   0.8% | 37.2 KiB |      47 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`  |
-|   0.2% | 7.48 KiB |       4 | `_find_spec`                | `<frozen importlib._bootstrap>:1056` |
+|      % |     Size | Allocations | Callee                      | Location                             |
+| -----: | -------: | ----------: | --------------------------- | ------------------------------------ |
+| 100.0% | 4.28 MiB |       1,288 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`  |
+|   0.8% | 37.2 KiB |          47 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`  |
+|   0.2% | 7.48 KiB |           4 | `_find_spec`                | `<frozen importlib._bootstrap>:1056` |
 
 ##### `_load_unlocked` (`<frozen importlib._bootstrap>:666`)
 
-|      % |     Size | Samples | Callee             | Location                                     |
-| -----: | -------: | ------: | ------------------ | -------------------------------------------- |
-| 100.0% | 4.27 MiB |   1,286 | `exec_module`      | `<frozen importlib._bootstrap_external>:934` |
-|  <0.1% | 1.83 KiB |       2 | `module_from_spec` | `<frozen importlib._bootstrap>:566`          |
+|      % |     Size | Allocations | Callee             | Location                                     |
+| -----: | -------: | ----------: | ------------------ | -------------------------------------------- |
+| 100.0% | 4.27 MiB |       1,286 | `exec_module`      | `<frozen importlib._bootstrap_external>:934` |
+|  <0.1% | 1.83 KiB |           2 | `module_from_spec` | `<frozen importlib._bootstrap>:566`          |
 
 ##### `exec_module` (`<frozen importlib._bootstrap_external>:934`)
 
-|     % |     Size | Samples | Callee                      | Location                                      |
-| ----: | -------: | ------: | --------------------------- | --------------------------------------------- |
-| 99.3% | 4.24 MiB |   1,256 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
-| 12.8% |  560 KiB |     606 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
+|     % |     Size | Allocations | Callee                      | Location                                      |
+| ----: | -------: | ----------: | --------------------------- | --------------------------------------------- |
+| 99.3% | 4.24 MiB |       1,256 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
+| 12.8% |  560 KiB |         606 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`)
 
-|      % |     Size | Samples | Callee           | Location                                                 |
-| -----: | -------: | ------: | ---------------- | -------------------------------------------------------- |
-| 100.0% | 4.24 MiB |   1,256 | `<module>`       | `black/__init__.py:1`                                    |
-|  54.2% |  2.3 MiB |     270 | `<module>`       | `black/comments.py:1`                                    |
-|  31.0% | 1.31 MiB |     329 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                     |
-|  30.8% | 1.31 MiB |     304 | `<module>`       | `/venv/lib/python3.11/site-packages/click/__init__.py:1` |
-|  30.3% | 1.29 MiB |     255 | `<module>`       | `black/nodes.py:1`                                       |
+|      % |     Size | Allocations | Callee           | Location                                                 |
+| -----: | -------: | ----------: | ---------------- | -------------------------------------------------------- |
+| 100.0% | 4.24 MiB |       1,256 | `<module>`       | `black/__init__.py:1`                                    |
+|  54.2% |  2.3 MiB |         270 | `<module>`       | `black/comments.py:1`                                    |
+|  31.0% | 1.31 MiB |         329 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                     |
+|  30.8% | 1.31 MiB |         304 | `<module>`       | `/venv/lib/python3.11/site-packages/click/__init__.py:1` |
+|  30.3% | 1.29 MiB |         255 | `<module>`       | `black/nodes.py:1`                                       |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|     % |    Size | Samples | Callee           | Location                             |
-| ----: | ------: | ------: | ---------------- | ------------------------------------ |
-| 99.8% | 1.3 MiB |     303 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |    Size | Allocations | Callee           | Location                             |
+| ----: | ------: | ----------: | ---------------- | ------------------------------------ |
+| 99.8% | 1.3 MiB |         303 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `_handle_fromlist` (`<frozen importlib._bootstrap>:1209`)
 
-|      % |    Size | Samples | Callee                      | Location                            |
-| -----: | ------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 1.3 MiB |     318 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |    Size | Allocations | Callee                      | Location                            |
+| -----: | ------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 1.3 MiB |         318 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|     % |     Size | Samples | Callee             | Location                                               |
-| ----: | -------: | ------: | ------------------ | ------------------------------------------------------ |
-| 85.5% | 1.05 MiB |      53 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167`                   |
-| 11.1% |  140 KiB |     145 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209`                   |
-|  1.1% | 13.9 KiB |       9 | `__new__`          | `<frozen abc>:105`                                     |
-|  0.2% | 2.49 KiB |       3 | `__new__`          | `/usr/lib/python3.11/enum.py:488`                      |
-|  0.1% |    768 B |       1 | `Context`          | `/venv/lib/python3.11/site-packages/click/core.py:204` |
+|     % |     Size | Allocations | Callee             | Location                                               |
+| ----: | -------: | ----------: | ------------------ | ------------------------------------------------------ |
+| 85.5% | 1.05 MiB |          53 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167`                   |
+| 11.1% |  140 KiB |         145 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209`                   |
+|  1.1% | 13.9 KiB |           9 | `__new__`          | `<frozen abc>:105`                                     |
+|  0.2% | 2.49 KiB |           3 | `__new__`          | `/usr/lib/python3.11/enum.py:488`                      |
+|  0.1% |    768 B |           1 | `Context`          | `/venv/lib/python3.11/site-packages/click/core.py:204` |
 
 ##### `compile` (`/usr/lib/python3.11/re/__init__.py:225`)
 
-|     % |     Size | Samples | Callee     | Location                                 |
-| ----: | -------: | ------: | ---------- | ---------------------------------------- |
-| 99.9% | 1.05 MiB |      25 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
+|     % |     Size | Allocations | Callee     | Location                                 |
+| ----: | -------: | ----------: | ---------- | ---------------------------------------- |
+| 99.9% | 1.05 MiB |          25 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
 
 ##### `_compile` (`/usr/lib/python3.11/re/__init__.py:272`)
 
-|     % |     Size | Samples | Callee    | Location                                  |
-| ----: | -------: | ------: | --------- | ----------------------------------------- |
-| 99.9% | 1.05 MiB |      24 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
-|  0.1% |    698 B |       1 | `__and__` | `/usr/lib/python3.11/enum.py:1504`        |
+|     % |     Size | Allocations | Callee    | Location                                  |
+| ----: | -------: | ----------: | --------- | ----------------------------------------- |
+| 99.9% | 1.05 MiB |          24 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
+|  0.1% |    698 B |           1 | `__and__` | `/usr/lib/python3.11/enum.py:1504`        |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|     % |     Size | Samples | Callee  | Location                                  |
-| ----: | -------: | ------: | ------- | ----------------------------------------- |
-| 97.0% | 1.01 MiB |       6 | `parse` | `/usr/lib/python3.11/re/_parser.py:970`   |
-|  0.9% |  9.5 KiB |       6 | `_code` | `/usr/lib/python3.11/re/_compiler.py:571` |
+|     % |     Size | Allocations | Callee  | Location                                  |
+| ----: | -------: | ----------: | ------- | ----------------------------------------- |
+| 97.0% | 1.01 MiB |           6 | `parse` | `/usr/lib/python3.11/re/_parser.py:970`   |
+|  0.9% |  9.5 KiB |           6 | `_code` | `/usr/lib/python3.11/re/_compiler.py:571` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 99.8% | 1.02 MiB |      22 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 99.8% | 1.02 MiB |          22 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `parse` (`/usr/lib/python3.11/re/_parser.py:970`)
 
-|     % |     Size | Samples | Callee       | Location                                |
-| ----: | -------: | ------: | ------------ | --------------------------------------- |
-| 99.9% | 1.01 MiB |       5 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
+|     % |     Size | Allocations | Callee       | Location                                |
+| ----: | -------: | ----------: | ------------ | --------------------------------------- |
+| 99.9% | 1.01 MiB |           5 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|     % |     Size | Samples | Callee           | Location                                 |
-| ----: | -------: | ------: | ---------------- | ---------------------------------------- |
-| 99.7% | 1.01 MiB |      14 | `_process_class` | `/usr/lib/python3.11/dataclasses.py:884` |
+|     % |     Size | Allocations | Callee           | Location                                 |
+| ----: | -------: | ----------: | ---------------- | ---------------------------------------- |
+| 99.7% | 1.01 MiB |          14 | `_process_class` | `/usr/lib/python3.11/dataclasses.py:884` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|     % |     Size | Samples | Callee   | Location                                |
-| ----: | -------: | ------: | -------- | --------------------------------------- |
-| 99.2% | 1.01 MiB |       4 | `_parse` | `/usr/lib/python3.11/re/_parser.py:507` |
+|     % |     Size | Allocations | Callee   | Location                                |
+| ----: | -------: | ----------: | -------- | --------------------------------------- |
+| 99.2% | 1.01 MiB |           4 | `_parse` | `/usr/lib/python3.11/re/_parser.py:507` |
 
 ##### `_process_class` (`/usr/lib/python3.11/dataclasses.py:884`)
 
-|     % |    Size | Samples | Callee               | Location                                 |
-| ----: | ------: | ------: | -------------------- | ---------------------------------------- |
-| 98.9% |   1 MiB |       1 | `_init_fn`           | `/usr/lib/python3.11/dataclasses.py:528` |
-|  0.6% | 6.5 KiB |       5 | `signature`          | `/usr/lib/python3.11/inspect.py:3277`    |
-|  0.1% | 1.5 KiB |       2 | `_set_new_attribute` | `/usr/lib/python3.11/dataclasses.py:827` |
-| <0.1% |   341 B |       1 | `_cmp_fn`            | `/usr/lib/python3.11/dataclasses.py:624` |
-| <0.1% |   336 B |       1 | `_repr_fn`           | `/usr/lib/python3.11/dataclasses.py:588` |
+|     % |    Size | Allocations | Callee               | Location                                 |
+| ----: | ------: | ----------: | -------------------- | ---------------------------------------- |
+| 98.9% |   1 MiB |           1 | `_init_fn`           | `/usr/lib/python3.11/dataclasses.py:528` |
+|  0.6% | 6.5 KiB |           5 | `signature`          | `/usr/lib/python3.11/inspect.py:3277`    |
+|  0.1% | 1.5 KiB |           2 | `_set_new_attribute` | `/usr/lib/python3.11/dataclasses.py:827` |
+| <0.1% |   341 B |           1 | `_cmp_fn`            | `/usr/lib/python3.11/dataclasses.py:624` |
+| <0.1% |   336 B |           1 | `_repr_fn`           | `/usr/lib/python3.11/dataclasses.py:588` |
 
 ##### `dataclass` (`/usr/lib/python3.11/dataclasses.py:1192`)
 
-|      % |     Size | Samples | Callee | Location                                  |
-| -----: | -------: | ------: | ------ | ----------------------------------------- |
-| 100.0% | 1.01 MiB |      11 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
+|      % |     Size | Allocations | Callee | Location                                  |
+| -----: | -------: | ----------: | ------ | ----------------------------------------- |
+| 100.0% | 1.01 MiB |          11 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|     % |  Size | Samples | Callee        | Location                                |
-| ----: | ----: | ------: | ------------- | --------------------------------------- |
-| 99.6% | 1 MiB |       2 | `_parse_sub`  | `/usr/lib/python3.11/re/_parser.py:447` |
-| 99.5% | 1 MiB |       1 | `__getitem__` | `/usr/lib/python3.11/re/_parser.py:162` |
+|     % |  Size | Allocations | Callee        | Location                                |
+| ----: | ----: | ----------: | ------------- | --------------------------------------- |
+| 99.6% | 1 MiB |           2 | `_parse_sub`  | `/usr/lib/python3.11/re/_parser.py:447` |
+| 99.5% | 1 MiB |           1 | `__getitem__` | `/usr/lib/python3.11/re/_parser.py:162` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                                                         |
-| ----: | -------: | ------: | ---------------- | ---------------------------------------------------------------- |
-| 87.6% |  120 KiB |     129 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                             |
-|  6.2% |  8.5 KiB |       2 | `Specifier`      | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220` |
-|  4.4% | 6.07 KiB |       7 | `__new__`        | `<frozen abc>:105`                                               |
+|     % |     Size | Allocations | Callee           | Location                                                         |
+| ----: | -------: | ----------: | ---------------- | ---------------------------------------------------------------- |
+| 87.6% |  120 KiB |         129 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                             |
+|  6.2% |  8.5 KiB |           2 | `Specifier`      | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220` |
+|  4.4% | 6.07 KiB |           7 | `__new__`        | `<frozen abc>:105`                                               |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 53.0% | 66.2 KiB |      58 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
-| 30.6% | 38.2 KiB |      45 | `__new__`        | `<frozen abc>:105`                   |
-| 12.6% | 15.7 KiB |      19 | `__new__`        | `/usr/lib/python3.11/typing.py:2891` |
-|  1.1% | 1.42 KiB |       2 | `inner`          | `/usr/lib/python3.11/typing.py:338`  |
-|  0.4% |    542 B |       1 | `__init__`       | `/usr/lib/python3.11/typing.py:992`  |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 53.0% | 66.2 KiB |          58 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+| 30.6% | 38.2 KiB |          45 | `__new__`        | `<frozen abc>:105`                   |
+| 12.6% | 15.7 KiB |          19 | `__new__`        | `/usr/lib/python3.11/typing.py:2891` |
+|  1.1% | 1.42 KiB |           2 | `inner`          | `/usr/lib/python3.11/typing.py:338`  |
+|  0.4% |    542 B |           1 | `__init__`       | `/usr/lib/python3.11/typing.py:992`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 99.2% | 93.1 KiB |     118 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 99.2% | 93.1 KiB |         118 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`)
 
-|     % |   Size | Samples | Callee           | Location                             |
-| ----: | -----: | ------: | ---------------- | ------------------------------------ |
-| 97.3% | 89 KiB |     112 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |   Size | Allocations | Callee           | Location                             |
+| ----: | -----: | ----------: | ---------------- | ------------------------------------ |
+| 97.3% | 89 KiB |         112 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 98.9% | 64.8 KiB |      83 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 98.9% | 64.8 KiB |          83 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|     % |   Size | Samples | Callee           | Location                             |
-| ----: | -----: | ------: | ---------------- | ------------------------------------ |
-| 94.4% | 60 KiB |      67 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |   Size | Allocations | Callee           | Location                             |
+| ----: | -----: | ----------: | ---------------- | ------------------------------------ |
+| 94.4% | 60 KiB |          67 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `decorator` (`/venv/lib/python3.11/site-packages/click/decorators.py:373`)
 
-|     % |     Size | Samples | Callee     | Location                                                |
-| ----: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 96.2% | 45.5 KiB |      32 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2883` |
+|     % |     Size | Allocations | Callee     | Location                                                |
+| ----: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 96.2% | 45.5 KiB |          32 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2883` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 94.8% | 44.5 KiB |      56 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 94.8% | 44.5 KiB |          56 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|    % |     Size | Samples | Callee     | Location                                                |
-| ---: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 2.6% | 1.17 KiB |       1 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2237` |
+|    % |     Size | Allocations | Callee     | Location                                                |
+| ---: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 2.6% | 1.17 KiB |           1 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2237` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 80.6% | 32.9 KiB |      35 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
-|  4.1% | 1.69 KiB |       2 | `__new__`        | `/usr/lib/python3.11/enum.py:488`    |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 80.6% | 32.9 KiB |          35 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|  4.1% | 1.69 KiB |           2 | `__new__`        | `/usr/lib/python3.11/enum.py:488`    |
 
 ## Hottest call stacks
 
@@ -2923,25 +2923,25 @@ Call stacks ranked by bytes never freed in their leaf frame.
 
 Common call stack: `run_module` (`<frozen runpy>:201`) ← `_run_tracker` (`/venv/lib/python3.11/site-packages/memray/commands/run.py:40`)
 
-|    % |     Size | Samples | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| ---: | -------: | ------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 8.9% |    5 MiB |       5 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `shift` (`blib2to3/pgen2/parse.py:373`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| 5.4% | 3.01 MiB |       4 | `parse` (`/usr/lib/python3.11/ast.py:33`) ← `_parse_single_version` (`black/parsing.py:117`) ← `parse_ast` (129) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| 5.4% |    3 MiB |       3 | `push` (`blib2to3/pgen2/parse.py:386`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| 1.9% | 1.07 MiB |       4 | `transform_line` (`black/linegen.py:601`) ← `_format_str_once` (`black/__init__.py:1236`) ← `assert_stable` (1557) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| 1.8% | 1.01 MiB |      11 | `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                             |
-| 1.8% |    1 MiB |       1 | `__init__` (`blib2to3/pytree.py:248`) ← `wrap_in_parentheses` (`black/nodes.py:935`) ← `normalize_invisible_parens` (`black/linegen.py:1328`) ← `visit_stmt` (199) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `assert_stable` (1557) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| 1.8% |    1 MiB |       1 | `__init__` (`<string>:2`) ← `line` (`black/linegen.py:109`) ← `visit_default` (134) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `assert_stable` (1557) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| 1.8% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `changed` (171) ← `prefix` (480) ← `prefix` (329) ← `wrap_in_parentheses` (`black/nodes.py:935`) ← `normalize_invisible_parens` (`black/linegen.py:1328`) ← `visit_stmt` (199) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| 1.8% |    1 MiB |       1 | `_create_fn` (`/usr/lib/python3.11/dataclasses.py:413`) ← `_init_fn` (528) ← `_process_class` (884) ← `wrap` (1209) ← `dataclass` (1192) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| 1.8% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                    |
-| 1.8% |    1 MiB |       1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| 1.8% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| 1.8% |    1 MiB |       1 | `debug` (`/usr/lib/python3.11/logging/__init__.py:1467`) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| 1.8% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
-| 1.8% |    1 MiB |       1 | `_stringify_ast_with_new_parent` (`black/parsing.py:166`) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| 1.8% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `assert_stable` (1557) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                          |
-| 1.8% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| 1.8% |    1 MiB |       1 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| 1.8% |    1 MiB |       1 | `generate_tokens` (`blib2to3/pgen2/tokenize.py:565`) ← `__next__` (`blib2to3/pgen2/driver.py:80`) ← `parse_tokens` (114) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| 1.8% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `next_sibling` (193) ← `normalize_invisible_parens` (`black/linegen.py:1328`) ← `visit_stmt` (199) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `assert_stable` (1557) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+|    % |     Size | Allocations | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| ---: | -------: | ----------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 8.9% |    5 MiB |           5 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `shift` (`blib2to3/pgen2/parse.py:373`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| 5.4% | 3.01 MiB |           4 | `parse` (`/usr/lib/python3.11/ast.py:33`) ← `_parse_single_version` (`black/parsing.py:117`) ← `parse_ast` (129) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| 5.4% |    3 MiB |           3 | `push` (`blib2to3/pgen2/parse.py:386`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| 1.9% | 1.07 MiB |           4 | `transform_line` (`black/linegen.py:601`) ← `_format_str_once` (`black/__init__.py:1236`) ← `assert_stable` (1557) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| 1.8% | 1.01 MiB |          11 | `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                             |
+| 1.8% |    1 MiB |           1 | `__init__` (`blib2to3/pytree.py:248`) ← `wrap_in_parentheses` (`black/nodes.py:935`) ← `normalize_invisible_parens` (`black/linegen.py:1328`) ← `visit_stmt` (199) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `assert_stable` (1557) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| 1.8% |    1 MiB |           1 | `__init__` (`<string>:2`) ← `line` (`black/linegen.py:109`) ← `visit_default` (134) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `assert_stable` (1557) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| 1.8% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `changed` (171) ← `prefix` (480) ← `prefix` (329) ← `wrap_in_parentheses` (`black/nodes.py:935`) ← `normalize_invisible_parens` (`black/linegen.py:1328`) ← `visit_stmt` (199) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| 1.8% |    1 MiB |           1 | `_create_fn` (`/usr/lib/python3.11/dataclasses.py:413`) ← `_init_fn` (528) ← `_process_class` (884) ← `wrap` (1209) ← `dataclass` (1192) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| 1.8% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                    |
+| 1.8% |    1 MiB |           1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| 1.8% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| 1.8% |    1 MiB |           1 | `debug` (`/usr/lib/python3.11/logging/__init__.py:1467`) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| 1.8% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
+| 1.8% |    1 MiB |           1 | `_stringify_ast_with_new_parent` (`black/parsing.py:166`) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| 1.8% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `assert_stable` (1557) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                          |
+| 1.8% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| 1.8% |    1 MiB |           1 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| 1.8% |    1 MiB |           1 | `generate_tokens` (`blib2to3/pgen2/tokenize.py:565`) ← `__next__` (`blib2to3/pgen2/driver.py:80`) ← `parse_tokens` (114) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| 1.8% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `next_sibling` (193) ← `normalize_invisible_parens` (`black/linegen.py:1328`) ← `visit_stmt` (199) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `assert_stable` (1557) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |

--- a/examples/output/python.memray.aggregated.current.memray.bin.md
+++ b/examples/output/python.memray.aggregated.current.memray.bin.md
@@ -1,12 +1,12 @@
 # Peak memory profile
 
-Held 78.6 MiB over 22,694 samples (3.55 KiB per sample).
+Held 78.6 MiB over 22,694 allocations (3.55 KiB per allocation).
 
-| Category         |     % |     Size | Samples |
-| ---------------- | ----: | -------: | ------: |
-| Ours             | 81.6% | 64.2 MiB |  21,445 |
-| Standard library | 16.7% | 13.2 MiB |   1,015 |
-| Third-party      |  1.6% | 1.27 MiB |     234 |
+| Category         |     % |     Size | Allocations |
+| ---------------- | ----: | -------: | ----------: |
+| Ours             | 81.6% | 64.2 MiB |      21,445 |
+| Standard library | 16.7% | 13.2 MiB |       1,015 |
+| Third-party      |  1.6% | 1.27 MiB |         234 |
 
 ## Hottest functions
 
@@ -14,105 +14,105 @@ Held 78.6 MiB over 22,694 samples (3.55 KiB per sample).
 
 Functions ranked by bytes held at peak memory directly in the function body, excluding callees.
 
-|     % |     Size | Samples | Function                         | Location                                               |
-| ----: | -------: | ------: | -------------------------------- | ------------------------------------------------------ |
-| 23.2% | 18.2 MiB |  20,790 | `mark`                           | `black/brackets.py:70`                                 |
-| 11.6% | 9.12 MiB |     142 | `parse`                          | `/usr/lib/python3.11/ast.py:33`                        |
-|  9.1% | 7.14 MiB |     202 | `update_sibling_maps`            | `blib2to3/pytree.py:369`                               |
-|  9.0% |  7.1 MiB |       4 | `assert_equivalent`              | `black/__init__.py:1524`                               |
-|  8.9% |    7 MiB |       7 | `changed`                        | `blib2to3/pytree.py:171`                               |
-|  7.6% |    6 MiB |       6 | `__new__`                        | `blib2to3/pytree.py:81`                                |
-|  5.1% | 4.05 MiB |      60 | `_stringify_ast`                 | `black/parsing.py:174`                                 |
-|  3.8% |    3 MiB |       3 | `prefix`                         | `blib2to3/pytree.py:480`                               |
-|  3.8% |    3 MiB |       3 | `push`                           | `blib2to3/pgen2/parse.py:386`                          |
-|  2.5% |    2 MiB |       2 | `_stringify_ast_with_new_parent` | `black/parsing.py:166`                                 |
-|  2.5% |    2 MiB |       2 | `generate_comments`              | `black/comments.py:52`                                 |
-|  1.3% | 1.01 MiB |      11 | `<module>`                       | `/venv/lib/python3.11/site-packages/click/parser.py:1` |
-|  1.3% |    1 MiB |       5 | `visit`                          | `black/nodes.py:163`                                   |
-|  1.3% |    1 MiB |       5 | `__init__`                       | `blib2to3/pytree.py:248`                               |
-|  1.3% |    1 MiB |       3 | `_create_fn`                     | `/usr/lib/python3.11/dataclasses.py:413`               |
-|  1.3% |    1 MiB |       1 | `__init__`                       | `<string>:2`                                           |
-|  1.3% |    1 MiB |       1 | `debug`                          | `/usr/lib/python3.11/logging/__init__.py:1467`         |
-|  1.3% |    1 MiB |       1 | `generate_tokens`                | `blib2to3/pgen2/tokenize.py:565`                       |
-|  1.3% |    1 MiB |       1 | `__getitem__`                    | `/usr/lib/python3.11/re/_parser.py:162`                |
-|  0.7% |  560 KiB |     606 | `_compile_bytecode`              | `<frozen importlib._bootstrap_external>:727`           |
+|     % |     Size | Allocations | Function                         | Location                                               |
+| ----: | -------: | ----------: | -------------------------------- | ------------------------------------------------------ |
+| 23.2% | 18.2 MiB |      20,790 | `mark`                           | `black/brackets.py:70`                                 |
+| 11.6% | 9.12 MiB |         142 | `parse`                          | `/usr/lib/python3.11/ast.py:33`                        |
+|  9.1% | 7.14 MiB |         202 | `update_sibling_maps`            | `blib2to3/pytree.py:369`                               |
+|  9.0% |  7.1 MiB |           4 | `assert_equivalent`              | `black/__init__.py:1524`                               |
+|  8.9% |    7 MiB |           7 | `changed`                        | `blib2to3/pytree.py:171`                               |
+|  7.6% |    6 MiB |           6 | `__new__`                        | `blib2to3/pytree.py:81`                                |
+|  5.1% | 4.05 MiB |          60 | `_stringify_ast`                 | `black/parsing.py:174`                                 |
+|  3.8% |    3 MiB |           3 | `prefix`                         | `blib2to3/pytree.py:480`                               |
+|  3.8% |    3 MiB |           3 | `push`                           | `blib2to3/pgen2/parse.py:386`                          |
+|  2.5% |    2 MiB |           2 | `_stringify_ast_with_new_parent` | `black/parsing.py:166`                                 |
+|  2.5% |    2 MiB |           2 | `generate_comments`              | `black/comments.py:52`                                 |
+|  1.3% | 1.01 MiB |          11 | `<module>`                       | `/venv/lib/python3.11/site-packages/click/parser.py:1` |
+|  1.3% |    1 MiB |           5 | `visit`                          | `black/nodes.py:163`                                   |
+|  1.3% |    1 MiB |           5 | `__init__`                       | `blib2to3/pytree.py:248`                               |
+|  1.3% |    1 MiB |           3 | `_create_fn`                     | `/usr/lib/python3.11/dataclasses.py:413`               |
+|  1.3% |    1 MiB |           1 | `__init__`                       | `<string>:2`                                           |
+|  1.3% |    1 MiB |           1 | `debug`                          | `/usr/lib/python3.11/logging/__init__.py:1467`         |
+|  1.3% |    1 MiB |           1 | `generate_tokens`                | `blib2to3/pgen2/tokenize.py:565`                       |
+|  1.3% |    1 MiB |           1 | `__getitem__`                    | `/usr/lib/python3.11/re/_parser.py:162`                |
+|  0.7% |  560 KiB |         606 | `_compile_bytecode`              | `<frozen importlib._bootstrap_external>:727`           |
 
 #### Categories
 
 ##### Ours
 
-|     % |     Size | Samples | Function                         | Location                         |
-| ----: | -------: | ------: | -------------------------------- | -------------------------------- |
-| 23.2% | 18.2 MiB |  20,790 | `mark`                           | `black/brackets.py:70`           |
-|  9.1% | 7.14 MiB |     202 | `update_sibling_maps`            | `blib2to3/pytree.py:369`         |
-|  9.0% |  7.1 MiB |       4 | `assert_equivalent`              | `black/__init__.py:1524`         |
-|  8.9% |    7 MiB |       7 | `changed`                        | `blib2to3/pytree.py:171`         |
-|  7.6% |    6 MiB |       6 | `__new__`                        | `blib2to3/pytree.py:81`          |
-|  5.1% | 4.05 MiB |      60 | `_stringify_ast`                 | `black/parsing.py:174`           |
-|  3.8% |    3 MiB |       3 | `prefix`                         | `blib2to3/pytree.py:480`         |
-|  3.8% |    3 MiB |       3 | `push`                           | `blib2to3/pgen2/parse.py:386`    |
-|  2.5% |    2 MiB |       2 | `_stringify_ast_with_new_parent` | `black/parsing.py:166`           |
-|  2.5% |    2 MiB |       2 | `generate_comments`              | `black/comments.py:52`           |
-|  1.3% |    1 MiB |       5 | `visit`                          | `black/nodes.py:163`             |
-|  1.3% |    1 MiB |       5 | `__init__`                       | `blib2to3/pytree.py:248`         |
-|  1.3% |    1 MiB |       1 | `__init__`                       | `<string>:2`                     |
-|  1.3% |    1 MiB |       1 | `generate_tokens`                | `blib2to3/pgen2/tokenize.py:565` |
-|  0.3% |  225 KiB |       5 | `_format_str_once`               | `black/__init__.py:1236`         |
-|  0.1% | 57.2 KiB |      65 | `normalize_string_prefix`        | `black/strings.py:143`           |
-|  0.1% | 41.5 KiB |      16 | `copy`                           | `blib2to3/pgen2/grammar.py:131`  |
-| <0.1% |   32 KiB |       1 | `classify`                       | `blib2to3/pgen2/parse.py:336`    |
-| <0.1% | 25.3 KiB |      40 | `make_first`                     | `blib2to3/pgen2/pgen.py:74`      |
-| <0.1% | 20.7 KiB |      14 | `<module>`                       | `blib2to3/pgen2/tokenize.py:1`   |
+|     % |     Size | Allocations | Function                         | Location                         |
+| ----: | -------: | ----------: | -------------------------------- | -------------------------------- |
+| 23.2% | 18.2 MiB |      20,790 | `mark`                           | `black/brackets.py:70`           |
+|  9.1% | 7.14 MiB |         202 | `update_sibling_maps`            | `blib2to3/pytree.py:369`         |
+|  9.0% |  7.1 MiB |           4 | `assert_equivalent`              | `black/__init__.py:1524`         |
+|  8.9% |    7 MiB |           7 | `changed`                        | `blib2to3/pytree.py:171`         |
+|  7.6% |    6 MiB |           6 | `__new__`                        | `blib2to3/pytree.py:81`          |
+|  5.1% | 4.05 MiB |          60 | `_stringify_ast`                 | `black/parsing.py:174`           |
+|  3.8% |    3 MiB |           3 | `prefix`                         | `blib2to3/pytree.py:480`         |
+|  3.8% |    3 MiB |           3 | `push`                           | `blib2to3/pgen2/parse.py:386`    |
+|  2.5% |    2 MiB |           2 | `_stringify_ast_with_new_parent` | `black/parsing.py:166`           |
+|  2.5% |    2 MiB |           2 | `generate_comments`              | `black/comments.py:52`           |
+|  1.3% |    1 MiB |           5 | `visit`                          | `black/nodes.py:163`             |
+|  1.3% |    1 MiB |           5 | `__init__`                       | `blib2to3/pytree.py:248`         |
+|  1.3% |    1 MiB |           1 | `__init__`                       | `<string>:2`                     |
+|  1.3% |    1 MiB |           1 | `generate_tokens`                | `blib2to3/pgen2/tokenize.py:565` |
+|  0.3% |  225 KiB |           5 | `_format_str_once`               | `black/__init__.py:1236`         |
+|  0.1% | 57.2 KiB |          65 | `normalize_string_prefix`        | `black/strings.py:143`           |
+|  0.1% | 41.5 KiB |          16 | `copy`                           | `blib2to3/pgen2/grammar.py:131`  |
+| <0.1% |   32 KiB |           1 | `classify`                       | `blib2to3/pgen2/parse.py:336`    |
+| <0.1% | 25.3 KiB |          40 | `make_first`                     | `blib2to3/pgen2/pgen.py:74`      |
+| <0.1% | 20.7 KiB |          14 | `<module>`                       | `blib2to3/pgen2/tokenize.py:1`   |
 
 ##### Standard library
 
-|     % |     Size | Samples | Function            | Location                                          |
-| ----: | -------: | ------: | ------------------- | ------------------------------------------------- |
-| 11.6% | 9.12 MiB |     142 | `parse`             | `/usr/lib/python3.11/ast.py:33`                   |
-|  1.3% |    1 MiB |       3 | `_create_fn`        | `/usr/lib/python3.11/dataclasses.py:413`          |
-|  1.3% |    1 MiB |       1 | `debug`             | `/usr/lib/python3.11/logging/__init__.py:1467`    |
-|  1.3% |    1 MiB |       1 | `__getitem__`       | `/usr/lib/python3.11/re/_parser.py:162`           |
-|  0.7% |  560 KiB |     606 | `_compile_bytecode` | `<frozen importlib._bootstrap_external>:727`      |
-|  0.3% |  222 KiB |       1 | `decode`            | `<frozen codecs>:319`                             |
-|  0.1% | 75.7 KiB |      79 | `__new__`           | `<frozen abc>:105`                                |
-| <0.1% | 24.1 KiB |      27 | `__new__`           | `/usr/lib/python3.11/enum.py:488`                 |
-| <0.1% | 22.6 KiB |      12 | `compile`           | `/usr/lib/python3.11/re/_compiler.py:738`         |
-| <0.1% | 19.8 KiB |      12 | `<module>`          | `/usr/lib/python3.11/tomllib/_parser.py:1`        |
-| <0.1% | 17.4 KiB |      21 | `__new__`           | `/usr/lib/python3.11/typing.py:2891`              |
-| <0.1% |   12 KiB |       3 | `inner`             | `/usr/lib/python3.11/typing.py:338`               |
-| <0.1% |    8 KiB |       4 | `_fill_cache`       | `<frozen importlib._bootstrap_external>:1655`     |
-| <0.1% | 7.97 KiB |       1 | `_parse_sub`        | `/usr/lib/python3.11/re/_parser.py:447`           |
-| <0.1% | 6.73 KiB |       8 | `__setattr__`       | `/usr/lib/python3.11/enum.py:831`                 |
-| <0.1% | 5.63 KiB |       6 | `namedtuple`        | `/usr/lib/python3.11/collections/__init__.py:348` |
-| <0.1% | 5.61 KiB |       3 | `_parse`            | `/usr/lib/python3.11/re/_parser.py:507`           |
-| <0.1% | 5.32 KiB |       2 | `_code`             | `/usr/lib/python3.11/re/_compiler.py:571`         |
-| <0.1% | 4.73 KiB |       6 | `<module>`          | `/usr/lib/python3.11/pkgutil.py:1`                |
-| <0.1% | 2.85 KiB |       1 | `wrap`              | `/usr/lib/python3.11/dataclasses.py:1209`         |
+|     % |     Size | Allocations | Function            | Location                                          |
+| ----: | -------: | ----------: | ------------------- | ------------------------------------------------- |
+| 11.6% | 9.12 MiB |         142 | `parse`             | `/usr/lib/python3.11/ast.py:33`                   |
+|  1.3% |    1 MiB |           3 | `_create_fn`        | `/usr/lib/python3.11/dataclasses.py:413`          |
+|  1.3% |    1 MiB |           1 | `debug`             | `/usr/lib/python3.11/logging/__init__.py:1467`    |
+|  1.3% |    1 MiB |           1 | `__getitem__`       | `/usr/lib/python3.11/re/_parser.py:162`           |
+|  0.7% |  560 KiB |         606 | `_compile_bytecode` | `<frozen importlib._bootstrap_external>:727`      |
+|  0.3% |  222 KiB |           1 | `decode`            | `<frozen codecs>:319`                             |
+|  0.1% | 75.7 KiB |          79 | `__new__`           | `<frozen abc>:105`                                |
+| <0.1% | 24.1 KiB |          27 | `__new__`           | `/usr/lib/python3.11/enum.py:488`                 |
+| <0.1% | 22.6 KiB |          12 | `compile`           | `/usr/lib/python3.11/re/_compiler.py:738`         |
+| <0.1% | 19.8 KiB |          12 | `<module>`          | `/usr/lib/python3.11/tomllib/_parser.py:1`        |
+| <0.1% | 17.4 KiB |          21 | `__new__`           | `/usr/lib/python3.11/typing.py:2891`              |
+| <0.1% |   12 KiB |           3 | `inner`             | `/usr/lib/python3.11/typing.py:338`               |
+| <0.1% |    8 KiB |           4 | `_fill_cache`       | `<frozen importlib._bootstrap_external>:1655`     |
+| <0.1% | 7.97 KiB |           1 | `_parse_sub`        | `/usr/lib/python3.11/re/_parser.py:447`           |
+| <0.1% | 6.73 KiB |           8 | `__setattr__`       | `/usr/lib/python3.11/enum.py:831`                 |
+| <0.1% | 5.63 KiB |           6 | `namedtuple`        | `/usr/lib/python3.11/collections/__init__.py:348` |
+| <0.1% | 5.61 KiB |           3 | `_parse`            | `/usr/lib/python3.11/re/_parser.py:507`           |
+| <0.1% | 5.32 KiB |           2 | `_code`             | `/usr/lib/python3.11/re/_compiler.py:571`         |
+| <0.1% | 4.73 KiB |           6 | `<module>`          | `/usr/lib/python3.11/pkgutil.py:1`                |
+| <0.1% | 2.85 KiB |           1 | `wrap`              | `/usr/lib/python3.11/dataclasses.py:1209`         |
 
 ##### Third-party
 
-|     % |     Size | Samples | Function              | Location                                                                   |
-| ----: | -------: | ------: | --------------------- | -------------------------------------------------------------------------- |
-|  1.3% | 1.01 MiB |      11 | `<module>`            | `/venv/lib/python3.11/site-packages/click/parser.py:1`                     |
-|  0.1% | 44.3 KiB |      31 | `__init__`            | `/venv/lib/python3.11/site-packages/click/core.py:2883`                    |
-|  0.1% |   42 KiB |       7 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                   |
-| <0.1% |   25 KiB |      22 | `<module>`            | `/venv/lib/python3.11/site-packages/click/core.py:1`                       |
-| <0.1% |   15 KiB |      18 | `<module>`            | `/venv/lib/python3.11/site-packages/mypy_extensions.py:1`                  |
-| <0.1% | 13.4 KiB |      15 | `<module>`            | `/venv/lib/python3.11/site-packages/click/exceptions.py:1`                 |
-| <0.1% | 9.61 KiB |       9 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/version.py:1`                |
-| <0.1% | 7.08 KiB |       8 | `<module>`            | `/venv/lib/python3.11/site-packages/click/utils.py:1`                      |
-| <0.1% | 6.48 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/util.py:1`                    |
-| <0.1% | 6.24 KiB |       5 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                |
-| <0.1% |  5.8 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/click/_compat.py:1`                    |
-| <0.1% | 3.82 KiB |       1 | `Specifier`           | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`           |
-| <0.1% | 3.79 KiB |       3 | `new_func`            | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                |
-| <0.1% | 3.72 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`                 |
-| <0.1% | 3.56 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                  |
-| <0.1% | 3.37 KiB |       5 | `handle_parse_result` | `/venv/lib/python3.11/site-packages/click/core.py:2663`                    |
-| <0.1% | 3.19 KiB |       1 | `<module>`            | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                   |
-| <0.1% | 3.19 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`                |
-| <0.1% | 2.81 KiB |       3 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1` |
-| <0.1% | 2.76 KiB |       2 | `<module>`            | `/venv/lib/python3.11/site-packages/click/types.py:1`                      |
+|     % |     Size | Allocations | Function              | Location                                                                   |
+| ----: | -------: | ----------: | --------------------- | -------------------------------------------------------------------------- |
+|  1.3% | 1.01 MiB |          11 | `<module>`            | `/venv/lib/python3.11/site-packages/click/parser.py:1`                     |
+|  0.1% | 44.3 KiB |          31 | `__init__`            | `/venv/lib/python3.11/site-packages/click/core.py:2883`                    |
+|  0.1% |   42 KiB |           7 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                   |
+| <0.1% |   25 KiB |          22 | `<module>`            | `/venv/lib/python3.11/site-packages/click/core.py:1`                       |
+| <0.1% |   15 KiB |          18 | `<module>`            | `/venv/lib/python3.11/site-packages/mypy_extensions.py:1`                  |
+| <0.1% | 13.4 KiB |          15 | `<module>`            | `/venv/lib/python3.11/site-packages/click/exceptions.py:1`                 |
+| <0.1% | 9.61 KiB |           9 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/version.py:1`                |
+| <0.1% | 7.08 KiB |           8 | `<module>`            | `/venv/lib/python3.11/site-packages/click/utils.py:1`                      |
+| <0.1% | 6.48 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/util.py:1`                    |
+| <0.1% | 6.24 KiB |           5 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                |
+| <0.1% |  5.8 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/click/_compat.py:1`                    |
+| <0.1% | 3.82 KiB |           1 | `Specifier`           | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`           |
+| <0.1% | 3.79 KiB |           3 | `new_func`            | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                |
+| <0.1% | 3.72 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`                 |
+| <0.1% | 3.56 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                  |
+| <0.1% | 3.37 KiB |           5 | `handle_parse_result` | `/venv/lib/python3.11/site-packages/click/core.py:2663`                    |
+| <0.1% | 3.19 KiB |           1 | `<module>`            | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                   |
+| <0.1% | 3.19 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`                |
+| <0.1% | 2.81 KiB |           3 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1` |
+| <0.1% | 2.76 KiB |           2 | `<module>`            | `/venv/lib/python3.11/site-packages/click/types.py:1`                      |
 
 #### Lines
 
@@ -120,444 +120,444 @@ Lines ranked by contribution to each function's self size.
 
 ##### `mark` (`black/brackets.py:70`)
 
-|      % |     Size | Samples | Location                |
-| -----: | -------: | ------: | ----------------------- |
-| 100.0% | 18.2 MiB |  20,789 | `black/brackets.py:112` |
-|  <0.1% | 1.49 KiB |       1 | `black/brackets.py:114` |
+|      % |     Size | Allocations | Location                |
+| -----: | -------: | ----------: | ----------------------- |
+| 100.0% | 18.2 MiB |      20,789 | `black/brackets.py:112` |
+|  <0.1% | 1.49 KiB |           1 | `black/brackets.py:114` |
 
 ##### `parse` (`/usr/lib/python3.11/ast.py:33`)
 
-|      % |     Size | Samples | Location                        |
-| -----: | -------: | ------: | ------------------------------- |
-| 100.0% | 9.12 MiB |     142 | `/usr/lib/python3.11/ast.py:50` |
+|      % |     Size | Allocations | Location                        |
+| -----: | -------: | ----------: | ------------------------------- |
+| 100.0% | 9.12 MiB |         142 | `/usr/lib/python3.11/ast.py:50` |
 
 ##### `update_sibling_maps` (`blib2to3/pytree.py:369`)
 
-|     % |     Size | Samples | Location                 |
-| ----: | -------: | ------: | ------------------------ |
-| 57.0% | 4.07 MiB |      97 | `blib2to3/pytree.py:377` |
-| 29.0% | 2.07 MiB |      95 | `blib2to3/pytree.py:376` |
-| 14.0% |    1 MiB |       1 | `blib2to3/pytree.py:370` |
-|  0.1% | 4.99 KiB |       9 | `blib2to3/pytree.py:379` |
+|     % |     Size | Allocations | Location                 |
+| ----: | -------: | ----------: | ------------------------ |
+| 57.0% | 4.07 MiB |          97 | `blib2to3/pytree.py:377` |
+| 29.0% | 2.07 MiB |          95 | `blib2to3/pytree.py:376` |
+| 14.0% |    1 MiB |           1 | `blib2to3/pytree.py:370` |
+|  0.1% | 4.99 KiB |           9 | `blib2to3/pytree.py:379` |
 
 ##### `assert_equivalent` (`black/__init__.py:1524`)
 
-|     % |     Size | Samples | Location                 |
-| ----: | -------: | ------: | ------------------------ |
-| 55.4% | 3.93 MiB |       2 | `black/__init__.py:1547` |
-| 44.6% | 3.17 MiB |       2 | `black/__init__.py:1546` |
+|     % |     Size | Allocations | Location                 |
+| ----: | -------: | ----------: | ------------------------ |
+| 55.4% | 3.93 MiB |           2 | `black/__init__.py:1547` |
+| 44.6% | 3.17 MiB |           2 | `black/__init__.py:1546` |
 
 ##### `changed` (`blib2to3/pytree.py:171`)
 
-|     % |  Size | Samples | Location                 |
-| ----: | ----: | ------: | ------------------------ |
-| 71.4% | 5 MiB |       5 | `blib2to3/pytree.py:176` |
-| 28.6% | 2 MiB |       2 | `blib2to3/pytree.py:175` |
+|     % |  Size | Allocations | Location                 |
+| ----: | ----: | ----------: | ------------------------ |
+| 71.4% | 5 MiB |           5 | `blib2to3/pytree.py:176` |
+| 28.6% | 2 MiB |           2 | `blib2to3/pytree.py:175` |
 
 ##### `__new__` (`blib2to3/pytree.py:81`)
 
-|      % |  Size | Samples | Location                |
-| -----: | ----: | ------: | ----------------------- |
-| 100.0% | 6 MiB |       6 | `blib2to3/pytree.py:84` |
+|      % |  Size | Allocations | Location                |
+| -----: | ----: | ----------: | ----------------------- |
+| 100.0% | 6 MiB |           6 | `blib2to3/pytree.py:84` |
 
 ##### `_stringify_ast` (`black/parsing.py:174`)
 
-|     % |     Size | Samples | Location               |
-| ----: | -------: | ------: | ---------------------- |
-| 74.2% |    3 MiB |       3 | `black/parsing.py:197` |
-| 24.7% |    1 MiB |       1 | `black/parsing.py:185` |
-|  1.1% | 46.8 KiB |      56 | `black/parsing.py:240` |
+|     % |     Size | Allocations | Location               |
+| ----: | -------: | ----------: | ---------------------- |
+| 74.2% |    3 MiB |           3 | `black/parsing.py:197` |
+| 24.7% |    1 MiB |           1 | `black/parsing.py:185` |
+|  1.1% | 46.8 KiB |          56 | `black/parsing.py:240` |
 
 ##### `prefix` (`blib2to3/pytree.py:480`)
 
-|      % |  Size | Samples | Location                 |
-| -----: | ----: | ------: | ------------------------ |
-| 100.0% | 3 MiB |       3 | `blib2to3/pytree.py:482` |
+|      % |  Size | Allocations | Location                 |
+| -----: | ----: | ----------: | ------------------------ |
+| 100.0% | 3 MiB |           3 | `blib2to3/pytree.py:482` |
 
 ##### `push` (`blib2to3/pgen2/parse.py:386`)
 
-|      % |  Size | Samples | Location                      |
-| -----: | ----: | ------: | ----------------------------- |
-| 100.0% | 3 MiB |       3 | `blib2to3/pgen2/parse.py:394` |
+|      % |  Size | Allocations | Location                      |
+| -----: | ----: | ----------: | ----------------------------- |
+| 100.0% | 3 MiB |           3 | `blib2to3/pgen2/parse.py:394` |
 
 ##### `_stringify_ast_with_new_parent` (`black/parsing.py:166`)
 
-|      % |  Size | Samples | Location               |
-| -----: | ----: | ------: | ---------------------- |
-| 100.0% | 2 MiB |       2 | `black/parsing.py:170` |
+|      % |  Size | Allocations | Location               |
+| -----: | ----: | ----------: | ---------------------- |
+| 100.0% | 2 MiB |           2 | `black/parsing.py:170` |
 
 ##### `generate_comments` (`black/comments.py:52`)
 
-|      % |  Size | Samples | Location               |
-| -----: | ----: | ------: | ---------------------- |
-| 100.0% | 2 MiB |       2 | `black/comments.py:76` |
+|      % |  Size | Allocations | Location               |
+| -----: | ----: | ----------: | ---------------------- |
+| 100.0% | 2 MiB |           2 | `black/comments.py:76` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`)
 
-|     % |     Size | Samples | Location                                                 |
-| ----: | -------: | ------: | -------------------------------------------------------- |
-| 99.4% |    1 MiB |       3 | `/venv/lib/python3.11/site-packages/click/parser.py:185` |
-|  0.2% | 2.29 KiB |       3 | `/venv/lib/python3.11/site-packages/click/parser.py:224` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:127` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:216` |
-|  0.1% |    768 B |       1 | `/venv/lib/python3.11/site-packages/click/parser.py:51`  |
+|     % |     Size | Allocations | Location                                                 |
+| ----: | -------: | ----------: | -------------------------------------------------------- |
+| 99.4% |    1 MiB |           3 | `/venv/lib/python3.11/site-packages/click/parser.py:185` |
+|  0.2% | 2.29 KiB |           3 | `/venv/lib/python3.11/site-packages/click/parser.py:224` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:127` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:216` |
+|  0.1% |    768 B |           1 | `/venv/lib/python3.11/site-packages/click/parser.py:51`  |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|     % |     Size | Samples | Location             |
-| ----: | -------: | ------: | -------------------- |
-| 99.7% |    1 MiB |       1 | `black/nodes.py:181` |
-|  0.3% | 2.68 KiB |       3 | `black/nodes.py:183` |
-|  0.1% |    690 B |       1 | `black/nodes.py:185` |
+|     % |     Size | Allocations | Location             |
+| ----: | -------: | ----------: | -------------------- |
+| 99.7% |    1 MiB |           1 | `black/nodes.py:181` |
+|  0.3% | 2.68 KiB |           3 | `black/nodes.py:183` |
+|  0.1% |    690 B |           1 | `black/nodes.py:185` |
 
 ##### `__init__` (`blib2to3/pytree.py:248`)
 
-|      % |  Size | Samples | Location                 |
-| -----: | ----: | ------: | ------------------------ |
-| 100.0% | 1 MiB |       5 | `blib2to3/pytree.py:266` |
+|      % |  Size | Allocations | Location                 |
+| -----: | ----: | ----------: | ------------------------ |
+| 100.0% | 1 MiB |           5 | `blib2to3/pytree.py:266` |
 
 ##### `_create_fn` (`/usr/lib/python3.11/dataclasses.py:413`)
 
-|      % |  Size | Samples | Location                                 |
-| -----: | ----: | ------: | ---------------------------------------- |
-| 100.0% | 1 MiB |       3 | `/usr/lib/python3.11/dataclasses.py:433` |
+|      % |  Size | Allocations | Location                                 |
+| -----: | ----: | ----------: | ---------------------------------------- |
+| 100.0% | 1 MiB |           3 | `/usr/lib/python3.11/dataclasses.py:433` |
 
 ##### `__init__` (`<string>:2`)
 
-|      % |  Size | Samples | Location     |
-| -----: | ----: | ------: | ------------ |
-| 100.0% | 1 MiB |       1 | `<string>:9` |
+|      % |  Size | Allocations | Location     |
+| -----: | ----: | ----------: | ------------ |
+| 100.0% | 1 MiB |           1 | `<string>:9` |
 
 ##### `debug` (`/usr/lib/python3.11/logging/__init__.py:1467`)
 
-|      % |  Size | Samples | Location                                       |
-| -----: | ----: | ------: | ---------------------------------------------- |
-| 100.0% | 1 MiB |       1 | `/usr/lib/python3.11/logging/__init__.py:1476` |
+|      % |  Size | Allocations | Location                                       |
+| -----: | ----: | ----------: | ---------------------------------------------- |
+| 100.0% | 1 MiB |           1 | `/usr/lib/python3.11/logging/__init__.py:1476` |
 
 ##### `generate_tokens` (`blib2to3/pgen2/tokenize.py:565`)
 
-|      % |  Size | Samples | Location                         |
-| -----: | ----: | ------: | -------------------------------- |
-| 100.0% | 1 MiB |       1 | `blib2to3/pgen2/tokenize.py:972` |
+|      % |  Size | Allocations | Location                         |
+| -----: | ----: | ----------: | -------------------------------- |
+| 100.0% | 1 MiB |           1 | `blib2to3/pgen2/tokenize.py:972` |
 
 ##### `__getitem__` (`/usr/lib/python3.11/re/_parser.py:162`)
 
-|      % |  Size | Samples | Location                                |
-| -----: | ----: | ------: | --------------------------------------- |
-| 100.0% | 1 MiB |       1 | `/usr/lib/python3.11/re/_parser.py:164` |
+|      % |  Size | Allocations | Location                                |
+| -----: | ----: | ----------: | --------------------------------------- |
+| 100.0% | 1 MiB |           1 | `/usr/lib/python3.11/re/_parser.py:164` |
 
 ##### `_compile_bytecode` (`<frozen importlib._bootstrap_external>:727`)
 
-|      % |    Size | Samples | Location                                     |
-| -----: | ------: | ------: | -------------------------------------------- |
-| 100.0% | 560 KiB |     606 | `<frozen importlib._bootstrap_external>:729` |
+|      % |    Size | Allocations | Location                                     |
+| -----: | ------: | ----------: | -------------------------------------------- |
+| 100.0% | 560 KiB |         606 | `<frozen importlib._bootstrap_external>:729` |
 
 ##### `_format_str_once` (`black/__init__.py:1236`)
 
-|     % |     Size | Samples | Location                 |
-| ----: | -------: | ------: | ------------------------ |
-| 98.6% |  222 KiB |       1 | `black/__init__.py:1287` |
-|  0.5% | 1.07 KiB |       1 | `black/__init__.py:1271` |
-|  0.3% |    800 B |       1 | `black/__init__.py:1239` |
-|  0.3% |    644 B |       1 | `black/__init__.py:1269` |
-|  0.3% |    638 B |       1 | `black/__init__.py:1244` |
+|     % |     Size | Allocations | Location                 |
+| ----: | -------: | ----------: | ------------------------ |
+| 98.6% |  222 KiB |           1 | `black/__init__.py:1287` |
+|  0.5% | 1.07 KiB |           1 | `black/__init__.py:1271` |
+|  0.3% |    800 B |           1 | `black/__init__.py:1239` |
+|  0.3% |    644 B |           1 | `black/__init__.py:1269` |
+|  0.3% |    638 B |           1 | `black/__init__.py:1244` |
 
 ##### `decode` (`<frozen codecs>:319`)
 
-|      % |    Size | Samples | Location              |
-| -----: | ------: | ------: | --------------------- |
-| 100.0% | 222 KiB |       1 | `<frozen codecs>:322` |
+|      % |    Size | Allocations | Location              |
+| -----: | ------: | ----------: | --------------------- |
+| 100.0% | 222 KiB |           1 | `<frozen codecs>:322` |
 
 ##### `__new__` (`<frozen abc>:105`)
 
-|      % |     Size | Samples | Location           |
-| -----: | -------: | ------: | ------------------ |
-| 100.0% | 75.7 KiB |      79 | `<frozen abc>:106` |
+|      % |     Size | Allocations | Location           |
+| -----: | -------: | ----------: | ------------------ |
+| 100.0% | 75.7 KiB |          79 | `<frozen abc>:106` |
 
 ##### `normalize_string_prefix` (`black/strings.py:143`)
 
-|      % |     Size | Samples | Location               |
-| -----: | -------: | ------: | ---------------------- |
-| 100.0% | 57.2 KiB |      65 | `black/strings.py:158` |
+|      % |     Size | Allocations | Location               |
+| -----: | -------: | ----------: | ---------------------- |
+| 100.0% | 57.2 KiB |          65 | `black/strings.py:158` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|     % |   Size | Samples | Location                                                |
-| ----: | -----: | ------: | ------------------------------------------------------- |
-| 97.1% | 43 KiB |      29 | `/venv/lib/python3.11/site-packages/click/core.py:3023` |
-|  1.6% |  704 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2905` |
-|  1.4% |  614 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2907` |
+|     % |   Size | Allocations | Location                                                |
+| ----: | -----: | ----------: | ------------------------------------------------------- |
+| 97.1% | 43 KiB |          29 | `/venv/lib/python3.11/site-packages/click/core.py:3023` |
+|  1.6% |  704 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2905` |
+|  1.4% |  614 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2907` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|     % |     Size | Samples | Location                                                   |
-| ----: | -------: | ------: | ---------------------------------------------------------- |
-| 89.8% | 37.7 KiB |       3 | `/venv/lib/python3.11/site-packages/packaging/tags.py:118` |
-|  3.5% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:322` |
-|  2.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:93`  |
-|  2.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:101` |
-|  2.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:110` |
+|     % |     Size | Allocations | Location                                                   |
+| ----: | -------: | ----------: | ---------------------------------------------------------- |
+| 89.8% | 37.7 KiB |           3 | `/venv/lib/python3.11/site-packages/packaging/tags.py:118` |
+|  3.5% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:322` |
+|  2.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:93`  |
+|  2.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:101` |
+|  2.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:110` |
 
 ##### `copy` (`blib2to3/pgen2/grammar.py:131`)
 
-|     % |     Size | Samples | Location                        |
-| ----: | -------: | ------: | ------------------------------- |
-| 88.2% | 36.6 KiB |      12 | `blib2to3/pgen2/grammar.py:145` |
-|  7.6% | 3.16 KiB |       2 | `blib2to3/pgen2/grammar.py:146` |
-|  4.2% | 1.75 KiB |       2 | `blib2to3/pgen2/grammar.py:147` |
+|     % |     Size | Allocations | Location                        |
+| ----: | -------: | ----------: | ------------------------------- |
+| 88.2% | 36.6 KiB |          12 | `blib2to3/pgen2/grammar.py:145` |
+|  7.6% | 3.16 KiB |           2 | `blib2to3/pgen2/grammar.py:146` |
+|  4.2% | 1.75 KiB |           2 | `blib2to3/pgen2/grammar.py:147` |
 
 ##### `classify` (`blib2to3/pgen2/parse.py:336`)
 
-|      % |   Size | Samples | Location                      |
-| -----: | -----: | ------: | ----------------------------- |
-| 100.0% | 32 KiB |       1 | `blib2to3/pgen2/parse.py:343` |
+|      % |   Size | Allocations | Location                      |
+| -----: | -----: | ----------: | ----------------------------- |
+| 100.0% | 32 KiB |           1 | `blib2to3/pgen2/parse.py:343` |
 
 ##### `make_first` (`blib2to3/pgen2/pgen.py:74`)
 
-|      % |     Size | Samples | Location                    |
-| -----: | -------: | ------: | --------------------------- |
-| 100.0% | 25.3 KiB |      40 | `blib2to3/pgen2/pgen.py:81` |
+|      % |     Size | Allocations | Location                    |
+| -----: | -------: | ----------: | --------------------------- |
+| 100.0% | 25.3 KiB |          40 | `blib2to3/pgen2/pgen.py:81` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 30.4% |  7.6 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:204`  |
-| 19.2% | 4.79 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:956`  |
-| 15.7% | 3.92 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:1587` |
-|  9.5% | 2.37 KiB |       3 | `/venv/lib/python3.11/site-packages/click/core.py:2057` |
-|  6.8% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/core.py:1580` |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 30.4% |  7.6 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:204`  |
+| 19.2% | 4.79 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:956`  |
+| 15.7% | 3.92 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:1587` |
+|  9.5% | 2.37 KiB |           3 | `/venv/lib/python3.11/site-packages/click/core.py:2057` |
+|  6.8% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/core.py:1580` |
 
 ##### `__new__` (`/usr/lib/python3.11/enum.py:488`)
 
-|      % |     Size | Samples | Location                          |
-| -----: | -------: | ------: | --------------------------------- |
-| 100.0% | 24.1 KiB |      27 | `/usr/lib/python3.11/enum.py:554` |
+|      % |     Size | Allocations | Location                          |
+| -----: | -------: | ----------: | --------------------------------- |
+| 100.0% | 24.1 KiB |          27 | `/usr/lib/python3.11/enum.py:554` |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|      % |     Size | Samples | Location                                  |
-| -----: | -------: | ------: | ----------------------------------------- |
-| 100.0% | 22.6 KiB |      12 | `/usr/lib/python3.11/re/_compiler.py:759` |
+|      % |     Size | Allocations | Location                                  |
+| -----: | -------: | ----------: | ----------------------------------------- |
+| 100.0% | 22.6 KiB |          12 | `/usr/lib/python3.11/re/_compiler.py:759` |
 
 ##### `<module>` (`blib2to3/pgen2/tokenize.py:1`)
 
-|     % |     Size | Samples | Location                         |
-| ----: | -------: | ------: | -------------------------------- |
-| 15.4% | 3.19 KiB |       1 | `blib2to3/pgen2/tokenize.py:170` |
-| 15.4% | 3.19 KiB |       1 | `blib2to3/pgen2/tokenize.py:208` |
-| 14.7% | 3.04 KiB |       3 | `blib2to3/pgen2/tokenize.py:490` |
-|  9.7% |    2 KiB |       1 | `blib2to3/pgen2/tokenize.py:229` |
-|  9.7% |    2 KiB |       1 | `blib2to3/pgen2/tokenize.py:234` |
+|     % |     Size | Allocations | Location                         |
+| ----: | -------: | ----------: | -------------------------------- |
+| 15.4% | 3.19 KiB |           1 | `blib2to3/pgen2/tokenize.py:170` |
+| 15.4% | 3.19 KiB |           1 | `blib2to3/pgen2/tokenize.py:208` |
+| 14.7% | 3.04 KiB |           3 | `blib2to3/pgen2/tokenize.py:490` |
+|  9.7% |    2 KiB |           1 | `blib2to3/pgen2/tokenize.py:229` |
+|  9.7% |    2 KiB |           1 | `blib2to3/pgen2/tokenize.py:234` |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/_parser.py:1`)
 
-|     % |  Size | Samples | Location                                    |
-| ----: | ----: | ------: | ------------------------------------------- |
-| 20.2% | 4 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:37` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:38` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:27` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:36` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:22` |
+|     % |  Size | Allocations | Location                                    |
+| ----: | ----: | ----------: | ------------------------------------------- |
+| 20.2% | 4 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:37` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:38` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:27` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:36` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:22` |
 
 ##### `__new__` (`/usr/lib/python3.11/typing.py:2891`)
 
-|      % |     Size | Samples | Location                             |
-| -----: | -------: | ------: | ------------------------------------ |
-| 100.0% | 17.4 KiB |      21 | `/usr/lib/python3.11/typing.py:2909` |
+|      % |     Size | Allocations | Location                             |
+| -----: | -------: | ----------: | ------------------------------------ |
+| 100.0% | 17.4 KiB |          21 | `/usr/lib/python3.11/typing.py:2909` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/mypy_extensions.py:1`)
 
-|     % |     Size | Samples | Location                                                    |
-| ----: | -------: | ------: | ----------------------------------------------------------- |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:191` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:167` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:175` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:154` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:212` |
+|     % |     Size | Allocations | Location                                                    |
+| ----: | -------: | ----------: | ----------------------------------------------------------- |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:191` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:167` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:175` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:154` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:212` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/exceptions.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 18.4% | 2.45 KiB |       3 | `/venv/lib/python3.11/site-packages/click/exceptions.py:114` |
-| 11.5% | 1.53 KiB |       2 | `/venv/lib/python3.11/site-packages/click/exceptions.py:366` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:68`  |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:362` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:342` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 18.4% | 2.45 KiB |           3 | `/venv/lib/python3.11/site-packages/click/exceptions.py:114` |
+| 11.5% | 1.53 KiB |           2 | `/venv/lib/python3.11/site-packages/click/exceptions.py:366` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:68`  |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:362` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:342` |
 
 ##### `inner` (`/usr/lib/python3.11/typing.py:338`)
 
-|      % |   Size | Samples | Location                            |
-| -----: | -----: | ------: | ----------------------------------- |
-| 100.0% | 12 KiB |       3 | `/usr/lib/python3.11/typing.py:341` |
+|      % |   Size | Allocations | Location                            |
+| -----: | -----: | ----------: | ----------------------------------- |
+| 100.0% | 12 KiB |           3 | `/usr/lib/python3.11/typing.py:341` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/version.py:1`)
 
-|     % |     Size | Samples | Location                                                      |
-| ----: | -------: | ------: | ------------------------------------------------------------- |
-| 38.2% | 3.68 KiB |       3 | `/venv/lib/python3.11/site-packages/packaging/version.py:340` |
-| 15.5% | 1.49 KiB |       2 | `/venv/lib/python3.11/site-packages/packaging/version.py:124` |
-| 15.4% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:285` |
-| 11.3% | 1.09 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:228` |
-|  9.8% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:134` |
+|     % |     Size | Allocations | Location                                                      |
+| ----: | -------: | ----------: | ------------------------------------------------------------- |
+| 38.2% | 3.68 KiB |           3 | `/venv/lib/python3.11/site-packages/packaging/version.py:340` |
+| 15.5% | 1.49 KiB |           2 | `/venv/lib/python3.11/site-packages/packaging/version.py:124` |
+| 15.4% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:285` |
+| 11.3% | 1.09 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:228` |
+|  9.8% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:134` |
 
 ##### `_fill_cache` (`<frozen importlib._bootstrap_external>:1655`)
 
-|      % |  Size | Samples | Location                                      |
-| -----: | ----: | ------: | --------------------------------------------- |
-| 100.0% | 8 KiB |       4 | `<frozen importlib._bootstrap_external>:1667` |
+|      % |  Size | Allocations | Location                                      |
+| -----: | ----: | ----------: | --------------------------------------------- |
+| 100.0% | 8 KiB |           4 | `<frozen importlib._bootstrap_external>:1667` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|      % |     Size | Samples | Location                                |
-| -----: | -------: | ------: | --------------------------------------- |
-| 100.0% | 7.97 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:455` |
+|      % |     Size | Allocations | Location                                |
+| -----: | -------: | ----------: | --------------------------------------- |
+| 100.0% | 7.97 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:455` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/utils.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 44.8% | 3.17 KiB |       3 | `/venv/lib/python3.11/site-packages/click/utils.py:522` |
-| 31.4% | 2.22 KiB |       3 | `/venv/lib/python3.11/site-packages/click/utils.py:207` |
-| 23.8% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/utils.py:113` |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 44.8% | 3.17 KiB |           3 | `/venv/lib/python3.11/site-packages/click/utils.py:522` |
+| 31.4% | 2.22 KiB |           3 | `/venv/lib/python3.11/site-packages/click/utils.py:207` |
+| 23.8% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/utils.py:113` |
 
 ##### `__setattr__` (`/usr/lib/python3.11/enum.py:831`)
 
-|      % |     Size | Samples | Location                          |
-| -----: | -------: | ------: | --------------------------------- |
-| 100.0% | 6.73 KiB |       8 | `/usr/lib/python3.11/enum.py:842` |
+|      % |     Size | Allocations | Location                          |
+| -----: | -------: | ----------: | --------------------------------- |
+| 100.0% | 6.73 KiB |           8 | `/usr/lib/python3.11/enum.py:842` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/util.py:1`)
 
-|     % |     Size | Samples | Location                                                  |
-| ----: | -------: | ------: | --------------------------------------------------------- |
-| 22.9% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:254` |
-| 16.9% | 1.09 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:765` |
-| 16.3% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:710` |
-| 15.1% |   1000 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:741` |
-| 14.5% |    960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:604` |
+|     % |     Size | Allocations | Location                                                  |
+| ----: | -------: | ----------: | --------------------------------------------------------- |
+| 22.9% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:254` |
+| 16.9% | 1.09 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:765` |
+| 16.3% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:710` |
+| 15.1% |   1000 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:741` |
+| 14.5% |    960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:604` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|     % |     Size | Samples | Location                                                      |
-| ----: | -------: | ------: | ------------------------------------------------------------- |
-| 23.8% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:681` |
-| 23.0% | 1.43 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:44`  |
-| 19.4% | 1.21 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:63`  |
-| 16.9% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:236` |
-| 16.9% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:179` |
+|     % |     Size | Allocations | Location                                                      |
+| ----: | -------: | ----------: | ------------------------------------------------------------- |
+| 23.8% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:681` |
+| 23.0% | 1.43 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:44`  |
+| 19.4% | 1.21 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:63`  |
+| 16.9% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:236` |
+| 16.9% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:179` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/_compat.py:1`)
 
-|     % |     Size | Samples | Location                                                  |
-| ----: | -------: | ------: | --------------------------------------------------------- |
-| 29.1% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/_compat.py:82`  |
-| 29.1% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/_compat.py:452` |
-| 25.6% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/click/_compat.py:344` |
-| 16.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/_compat.py:56`  |
+|     % |     Size | Allocations | Location                                                  |
+| ----: | -------: | ----------: | --------------------------------------------------------- |
+| 29.1% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/_compat.py:82`  |
+| 29.1% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/_compat.py:452` |
+| 25.6% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/click/_compat.py:344` |
+| 16.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/_compat.py:56`  |
 
 ##### `namedtuple` (`/usr/lib/python3.11/collections/__init__.py:348`)
 
-|      % |     Size | Samples | Location                                          |
-| -----: | -------: | ------: | ------------------------------------------------- |
-| 100.0% | 5.63 KiB |       6 | `/usr/lib/python3.11/collections/__init__.py:501` |
+|      % |     Size | Allocations | Location                                          |
+| -----: | -------: | ----------: | ------------------------------------------------- |
+| 100.0% | 5.63 KiB |           6 | `/usr/lib/python3.11/collections/__init__.py:501` |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|     % |     Size | Samples | Location                                |
-| ----: | -------: | ------: | --------------------------------------- |
-| 43.4% | 2.43 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:539` |
-| 33.9% |  1.9 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:568` |
-| 22.7% | 1.28 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:838` |
+|     % |     Size | Allocations | Location                                |
+| ----: | -------: | ----------: | --------------------------------------- |
+| 43.4% | 2.43 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:539` |
+| 33.9% |  1.9 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:568` |
+| 22.7% | 1.28 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:838` |
 
 ##### `_code` (`/usr/lib/python3.11/re/_compiler.py:571`)
 
-|     % |     Size | Samples | Location                                  |
-| ----: | -------: | ------: | ----------------------------------------- |
-| 81.6% | 4.34 KiB |       1 | `/usr/lib/python3.11/re/_compiler.py:580` |
-| 18.4% |   1002 B |       1 | `/usr/lib/python3.11/re/_compiler.py:577` |
+|     % |     Size | Allocations | Location                                  |
+| ----: | -------: | ----------: | ----------------------------------------- |
+| 81.6% | 4.34 KiB |           1 | `/usr/lib/python3.11/re/_compiler.py:580` |
+| 18.4% |   1002 B |           1 | `/usr/lib/python3.11/re/_compiler.py:577` |
 
 ##### `<module>` (`/usr/lib/python3.11/pkgutil.py:1`)
 
-|     % |     Size | Samples | Location                             |
-| ----: | -------: | ------: | ------------------------------------ |
-| 35.7% | 1.69 KiB |       2 | `/usr/lib/python3.11/pkgutil.py:194` |
-| 35.7% | 1.69 KiB |       2 | `/usr/lib/python3.11/pkgutil.py:269` |
-| 15.9% |    768 B |       1 | `/usr/lib/python3.11/pkgutil.py:137` |
-| 12.8% |    620 B |       1 | `/usr/lib/python3.11/pkgutil.py:184` |
+|     % |     Size | Allocations | Location                             |
+| ----: | -------: | ----------: | ------------------------------------ |
+| 35.7% | 1.69 KiB |           2 | `/usr/lib/python3.11/pkgutil.py:194` |
+| 35.7% | 1.69 KiB |           2 | `/usr/lib/python3.11/pkgutil.py:269` |
+| 15.9% |    768 B |           1 | `/usr/lib/python3.11/pkgutil.py:137` |
+| 12.8% |    620 B |           1 | `/usr/lib/python3.11/pkgutil.py:184` |
 
 ##### `Specifier` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`)
 
-|      % |     Size | Samples | Location                                                         |
-| -----: | -------: | ------: | ---------------------------------------------------------------- |
-| 100.0% | 3.82 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:340` |
+|      % |     Size | Allocations | Location                                                         |
+| -----: | -------: | ----------: | ---------------------------------------------------------------- |
+| 100.0% | 3.82 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:340` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Location                                                    |
-| -----: | -------: | ------: | ----------------------------------------------------------- |
-| 100.0% | 3.79 KiB |       3 | `/venv/lib/python3.11/site-packages/click/decorators.py:34` |
+|      % |     Size | Allocations | Location                                                    |
+| -----: | -------: | ----------: | ----------------------------------------------------------- |
+| 100.0% | 3.79 KiB |           3 | `/venv/lib/python3.11/site-packages/click/decorators.py:34` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 46.4% | 1.73 KiB |       2 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:29`  |
-| 27.3% | 1.02 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:90`  |
-| 26.3% |   1000 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:245` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 46.4% | 1.73 KiB |           2 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:29`  |
+| 27.3% | 1.02 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:90`  |
+| 26.3% |   1000 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:245` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|     % |  Size | Samples | Location                                                   |
-| ----: | ----: | ------: | ---------------------------------------------------------- |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:62` |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:46` |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:54` |
-| 21.1% | 768 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:27` |
+|     % |  Size | Allocations | Location                                                   |
+| ----: | ----: | ----------: | ---------------------------------------------------------- |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:62` |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:46` |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:54` |
+| 21.1% | 768 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:27` |
 
 ##### `handle_parse_result` (`/venv/lib/python3.11/site-packages/click/core.py:2663`)
 
-|     % |    Size | Samples | Location                                                |
-| ----: | ------: | ------: | ------------------------------------------------------- |
-| 38.5% | 1.3 KiB |       2 | `/venv/lib/python3.11/site-packages/click/core.py:2686` |
-| 22.3% |   768 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2740` |
-| 22.3% |   768 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2739` |
-| 17.0% |   586 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2711` |
+|     % |    Size | Allocations | Location                                                |
+| ----: | ------: | ----------: | ------------------------------------------------------- |
+| 38.5% | 1.3 KiB |           2 | `/venv/lib/python3.11/site-packages/click/core.py:2686` |
+| 22.3% |   768 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2740` |
+| 22.3% |   768 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2739` |
+| 17.0% |   586 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2711` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|      % |     Size | Samples | Location                                                  |
-| -----: | -------: | ------: | --------------------------------------------------------- |
-| 100.0% | 3.19 KiB |       1 | `/venv/lib/python3.11/site-packages/click/__init__.py:74` |
+|      % |     Size | Allocations | Location                                                  |
+| -----: | -------: | ----------: | --------------------------------------------------------- |
+| 100.0% | 3.19 KiB |           1 | `/venv/lib/python3.11/site-packages/click/__init__.py:74` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 76.5% | 2.44 KiB |       3 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:55` |
-| 23.5% |    768 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:14` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 76.5% | 2.44 KiB |           3 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:55` |
+| 23.5% |    768 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:14` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|      % |     Size | Samples | Location                                  |
-| -----: | -------: | ------: | ----------------------------------------- |
-| 100.0% | 2.85 KiB |       1 | `/usr/lib/python3.11/dataclasses.py:1210` |
+|      % |     Size | Allocations | Location                                  |
+| -----: | -------: | ----------: | ----------------------------------------- |
+| 100.0% | 2.85 KiB |           1 | `/usr/lib/python3.11/dataclasses.py:1210` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1`)
 
-|     % |  Size | Samples | Location                                                                     |
-| ----: | ----: | ------: | ---------------------------------------------------------------------------- |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:22`  |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:205` |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:197` |
+|     % |  Size | Allocations | Location                                                                     |
+| ----: | ----: | ----------: | ---------------------------------------------------------------------------- |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:22`  |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:205` |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:197` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 53.7% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/click/types.py:464` |
-| 46.3% | 1.28 KiB |       1 | `/venv/lib/python3.11/site-packages/click/types.py:37`  |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 53.7% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/click/types.py:464` |
+| 46.3% | 1.28 KiB |           1 | `/venv/lib/python3.11/site-packages/click/types.py:37`  |
 
 #### Callers
 
@@ -565,484 +565,484 @@ Callers ranked by contribution to each function's self size. Inlining can make c
 
 ##### `mark` (`black/brackets.py:70`)
 
-|      % |     Size | Samples | Caller   | Location            |
-| -----: | -------: | ------: | -------- | ------------------- |
-| 100.0% | 18.2 MiB |  20,790 | `append` | `black/lines.py:63` |
+|      % |     Size | Allocations | Caller   | Location            |
+| -----: | -------: | ----------: | -------- | ------------------- |
+| 100.0% | 18.2 MiB |      20,790 | `append` | `black/lines.py:63` |
 
 ##### `parse` (`/usr/lib/python3.11/ast.py:33`)
 
-|      % |     Size | Samples | Caller                  | Location               |
-| -----: | -------: | ------: | ----------------------- | ---------------------- |
-| 100.0% | 9.12 MiB |     142 | `_parse_single_version` | `black/parsing.py:117` |
+|      % |     Size | Allocations | Caller                  | Location               |
+| -----: | -------: | ----------: | ----------------------- | ---------------------- |
+| 100.0% | 9.12 MiB |         142 | `_parse_single_version` | `black/parsing.py:117` |
 
 ##### `update_sibling_maps` (`blib2to3/pytree.py:369`)
 
-|      % |     Size | Samples | Caller         | Location                 |
-| -----: | -------: | ------: | -------------- | ------------------------ |
-| 100.0% | 7.14 MiB |     202 | `prev_sibling` | `blib2to3/pytree.py:207` |
+|      % |     Size | Allocations | Caller         | Location                 |
+| -----: | -------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 7.14 MiB |         202 | `prev_sibling` | `blib2to3/pytree.py:207` |
 
 ##### `assert_equivalent` (`black/__init__.py:1524`)
 
-|      % |    Size | Samples | Caller                            | Location                 |
-| -----: | ------: | ------: | --------------------------------- | ------------------------ |
-| 100.0% | 7.1 MiB |       4 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+|      % |    Size | Allocations | Caller                            | Location                 |
+| -----: | ------: | ----------: | --------------------------------- | ------------------------ |
+| 100.0% | 7.1 MiB |           4 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
 
 ##### `changed` (`blib2to3/pytree.py:171`)
 
-|     % |  Size | Samples | Caller    | Location                 |
-| ----: | ----: | ------: | --------- | ------------------------ |
-| 85.7% | 6 MiB |       6 | `changed` | `blib2to3/pytree.py:171` |
-| 14.3% | 1 MiB |       1 | `prefix`  | `blib2to3/pytree.py:480` |
+|     % |  Size | Allocations | Caller    | Location                 |
+| ----: | ----: | ----------: | --------- | ------------------------ |
+| 85.7% | 6 MiB |           6 | `changed` | `blib2to3/pytree.py:171` |
+| 14.3% | 1 MiB |           1 | `prefix`  | `blib2to3/pytree.py:480` |
 
 ##### `__new__` (`blib2to3/pytree.py:81`)
 
-|      % |  Size | Samples | Caller    | Location                 |
-| -----: | ----: | ------: | --------- | ------------------------ |
-| 100.0% | 6 MiB |       6 | `convert` | `blib2to3/pytree.py:486` |
+|      % |  Size | Allocations | Caller    | Location                 |
+| -----: | ----: | ----------: | --------- | ------------------------ |
+| 100.0% | 6 MiB |           6 | `convert` | `blib2to3/pytree.py:486` |
 
 ##### `_stringify_ast` (`black/parsing.py:174`)
 
-|      % |     Size | Samples | Caller                           | Location               |
-| -----: | -------: | ------: | -------------------------------- | ---------------------- |
-| 100.0% | 4.05 MiB |      60 | `_stringify_ast_with_new_parent` | `black/parsing.py:166` |
+|      % |     Size | Allocations | Caller                           | Location               |
+| -----: | -------: | ----------: | -------------------------------- | ---------------------- |
+| 100.0% | 4.05 MiB |          60 | `_stringify_ast_with_new_parent` | `black/parsing.py:166` |
 
 ##### `prefix` (`blib2to3/pytree.py:480`)
 
-|      % |  Size | Samples | Caller   | Location            |
-| -----: | ----: | ------: | -------- | ------------------- |
-| 100.0% | 3 MiB |       3 | `append` | `black/lines.py:63` |
+|      % |  Size | Allocations | Caller   | Location            |
+| -----: | ----: | ----------: | -------- | ------------------- |
+| 100.0% | 3 MiB |           3 | `append` | `black/lines.py:63` |
 
 ##### `push` (`blib2to3/pgen2/parse.py:386`)
 
-|      % |  Size | Samples | Caller      | Location                      |
-| -----: | ----: | ------: | ----------- | ----------------------------- |
-| 100.0% | 3 MiB |       3 | `_addtoken` | `blib2to3/pgen2/parse.py:290` |
+|      % |  Size | Allocations | Caller      | Location                      |
+| -----: | ----: | ----------: | ----------- | ----------------------------- |
+| 100.0% | 3 MiB |           3 | `_addtoken` | `blib2to3/pgen2/parse.py:290` |
 
 ##### `_stringify_ast_with_new_parent` (`black/parsing.py:166`)
 
-|      % |  Size | Samples | Caller           | Location               |
-| -----: | ----: | ------: | ---------------- | ---------------------- |
-| 100.0% | 2 MiB |       2 | `_stringify_ast` | `black/parsing.py:174` |
+|      % |  Size | Allocations | Caller           | Location               |
+| -----: | ----: | ----------: | ---------------- | ---------------------- |
+| 100.0% | 2 MiB |           2 | `_stringify_ast` | `black/parsing.py:174` |
 
 ##### `generate_comments` (`black/comments.py:52`)
 
-|      % |  Size | Samples | Caller          | Location               |
-| -----: | ----: | ------: | --------------- | ---------------------- |
-| 100.0% | 2 MiB |       2 | `visit_default` | `black/linegen.py:134` |
+|      % |  Size | Allocations | Caller          | Location               |
+| -----: | ----: | ----------: | --------------- | ---------------------- |
+| 100.0% | 2 MiB |           2 | `visit_default` | `black/linegen.py:134` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 1.01 MiB |      11 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 1.01 MiB |          11 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|     % |     Size | Samples | Caller             | Location                 |
-| ----: | -------: | ------: | ------------------ | ------------------------ |
-| 99.7% |    1 MiB |       1 | `visit_stmt`       | `black/linegen.py:199`   |
-|  0.3% | 2.68 KiB |       3 | `visit_default`    | `black/nodes.py:187`     |
-|  0.1% |    690 B |       1 | `_format_str_once` | `black/__init__.py:1236` |
+|     % |     Size | Allocations | Caller             | Location                 |
+| ----: | -------: | ----------: | ------------------ | ------------------------ |
+| 99.7% |    1 MiB |           1 | `visit_stmt`       | `black/linegen.py:199`   |
+|  0.3% | 2.68 KiB |           3 | `visit_default`    | `black/nodes.py:187`     |
+|  0.1% |    690 B |           1 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `__init__` (`blib2to3/pytree.py:248`)
 
-|      % |  Size | Samples | Caller    | Location                 |
-| -----: | ----: | ------: | --------- | ------------------------ |
-| 100.0% | 1 MiB |       5 | `convert` | `blib2to3/pytree.py:486` |
+|      % |  Size | Allocations | Caller    | Location                 |
+| -----: | ----: | ----------: | --------- | ------------------------ |
+| 100.0% | 1 MiB |           5 | `convert` | `blib2to3/pytree.py:486` |
 
 ##### `_create_fn` (`/usr/lib/python3.11/dataclasses.py:413`)
 
-|     % |  Size | Samples | Caller     | Location                                 |
-| ----: | ----: | ------: | ---------- | ---------------------------------------- |
-| 99.9% | 1 MiB |       1 | `_init_fn` | `/usr/lib/python3.11/dataclasses.py:528` |
-| <0.1% | 341 B |       1 | `_cmp_fn`  | `/usr/lib/python3.11/dataclasses.py:624` |
-| <0.1% | 336 B |       1 | `_repr_fn` | `/usr/lib/python3.11/dataclasses.py:588` |
+|     % |  Size | Allocations | Caller     | Location                                 |
+| ----: | ----: | ----------: | ---------- | ---------------------------------------- |
+| 99.9% | 1 MiB |           1 | `_init_fn` | `/usr/lib/python3.11/dataclasses.py:528` |
+| <0.1% | 341 B |           1 | `_cmp_fn`  | `/usr/lib/python3.11/dataclasses.py:624` |
+| <0.1% | 336 B |           1 | `_repr_fn` | `/usr/lib/python3.11/dataclasses.py:588` |
 
 ##### `__init__` (`<string>:2`)
 
-|      % |  Size | Samples | Caller     | Location     |
-| -----: | ----: | ------: | ---------- | ------------ |
-| 100.0% | 1 MiB |       1 | `__init__` | `<string>:2` |
+|      % |  Size | Allocations | Caller     | Location     |
+| -----: | ----: | ----------: | ---------- | ------------ |
+| 100.0% | 1 MiB |           1 | `__init__` | `<string>:2` |
 
 ##### `debug` (`/usr/lib/python3.11/logging/__init__.py:1467`)
 
-|      % |  Size | Samples | Caller         | Location                       |
-| -----: | ----: | ------: | -------------- | ------------------------------ |
-| 100.0% | 1 MiB |       1 | `parse_tokens` | `blib2to3/pgen2/driver.py:114` |
+|      % |  Size | Allocations | Caller         | Location                       |
+| -----: | ----: | ----------: | -------------- | ------------------------------ |
+| 100.0% | 1 MiB |           1 | `parse_tokens` | `blib2to3/pgen2/driver.py:114` |
 
 ##### `generate_tokens` (`blib2to3/pgen2/tokenize.py:565`)
 
-|      % |  Size | Samples | Caller     | Location                      |
-| -----: | ----: | ------: | ---------- | ----------------------------- |
-| 100.0% | 1 MiB |       1 | `__next__` | `blib2to3/pgen2/driver.py:80` |
+|      % |  Size | Allocations | Caller     | Location                      |
+| -----: | ----: | ----------: | ---------- | ----------------------------- |
+| 100.0% | 1 MiB |           1 | `__next__` | `blib2to3/pgen2/driver.py:80` |
 
 ##### `__getitem__` (`/usr/lib/python3.11/re/_parser.py:162`)
 
-|      % |  Size | Samples | Caller   | Location                                |
-| -----: | ----: | ------: | -------- | --------------------------------------- |
-| 100.0% | 1 MiB |       1 | `_parse` | `/usr/lib/python3.11/re/_parser.py:507` |
+|      % |  Size | Allocations | Caller   | Location                                |
+| -----: | ----: | ----------: | -------- | --------------------------------------- |
+| 100.0% | 1 MiB |           1 | `_parse` | `/usr/lib/python3.11/re/_parser.py:507` |
 
 ##### `_compile_bytecode` (`<frozen importlib._bootstrap_external>:727`)
 
-|      % |    Size | Samples | Caller     | Location                                      |
-| -----: | ------: | ------: | ---------- | --------------------------------------------- |
-| 100.0% | 560 KiB |     606 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
+|      % |    Size | Allocations | Caller     | Location                                      |
+| -----: | ------: | ----------: | ---------- | --------------------------------------------- |
+| 100.0% | 560 KiB |         606 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `_format_str_once` (`black/__init__.py:1236`)
 
-|      % |    Size | Samples | Caller       | Location                 |
-| -----: | ------: | ------: | ------------ | ------------------------ |
-| 100.0% | 225 KiB |       5 | `format_str` | `black/__init__.py:1189` |
+|      % |    Size | Allocations | Caller       | Location                 |
+| -----: | ------: | ----------: | ------------ | ------------------------ |
+| 100.0% | 225 KiB |           5 | `format_str` | `black/__init__.py:1189` |
 
 ##### `decode` (`<frozen codecs>:319`)
 
-|      % |    Size | Samples | Caller         | Location                 |
-| -----: | ------: | ------: | -------------- | ------------------------ |
-| 100.0% | 222 KiB |       1 | `decode_bytes` | `black/__init__.py:1290` |
+|      % |    Size | Allocations | Caller         | Location                 |
+| -----: | ------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 222 KiB |           1 | `decode_bytes` | `black/__init__.py:1290` |
 
 ##### `__new__` (`<frozen abc>:105`)
 
-|     % |     Size | Samples | Caller     | Location                                                       |
-| ----: | -------: | ------: | ---------- | -------------------------------------------------------------- |
-| 50.5% | 38.2 KiB |      45 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`          |
-| 23.1% | 17.5 KiB |      18 | `<module>` | `black/trans.py:1`                                             |
-| 18.3% | 13.9 KiB |       9 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`           |
-|  8.0% | 6.07 KiB |       7 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
+|     % |     Size | Allocations | Caller     | Location                                                       |
+| ----: | -------: | ----------: | ---------- | -------------------------------------------------------------- |
+| 50.5% | 38.2 KiB |          45 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`          |
+| 23.1% | 17.5 KiB |          18 | `<module>` | `black/trans.py:1`                                             |
+| 18.3% | 13.9 KiB |           9 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`           |
+|  8.0% | 6.07 KiB |           7 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
 
 ##### `normalize_string_prefix` (`black/strings.py:143`)
 
-|      % |     Size | Samples | Caller         | Location               |
-| -----: | -------: | ------: | -------------- | ---------------------- |
-| 100.0% | 57.2 KiB |      65 | `visit_STRING` | `black/linegen.py:413` |
+|      % |     Size | Allocations | Caller         | Location               |
+| -----: | -------: | ----------: | -------------- | ---------------------- |
+| 100.0% | 57.2 KiB |          65 | `visit_STRING` | `black/linegen.py:413` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|      % |     Size | Samples | Caller      | Location                                                     |
-| -----: | -------: | ------: | ----------- | ------------------------------------------------------------ |
-| 100.0% | 44.3 KiB |      31 | `decorator` | `/venv/lib/python3.11/site-packages/click/decorators.py:373` |
+|      % |     Size | Allocations | Caller      | Location                                                     |
+| -----: | -------: | ----------: | ----------- | ------------------------------------------------------------ |
+| 100.0% | 44.3 KiB |          31 | `decorator` | `/venv/lib/python3.11/site-packages/click/decorators.py:373` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 42 KiB |       7 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 42 KiB |           7 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `copy` (`blib2to3/pgen2/grammar.py:131`)
 
-|      % |     Size | Samples | Caller       | Location                 |
-| -----: | -------: | ------: | ------------ | ------------------------ |
-| 100.0% | 41.5 KiB |      16 | `initialize` | `blib2to3/pygram.py:165` |
+|      % |     Size | Allocations | Caller       | Location                 |
+| -----: | -------: | ----------: | ------------ | ------------------------ |
+| 100.0% | 41.5 KiB |          16 | `initialize` | `blib2to3/pygram.py:165` |
 
 ##### `classify` (`blib2to3/pgen2/parse.py:336`)
 
-|      % |   Size | Samples | Caller     | Location                      |
-| -----: | -----: | ------: | ---------- | ----------------------------- |
-| 100.0% | 32 KiB |       1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
+|      % |   Size | Allocations | Caller     | Location                      |
+| -----: | -----: | ----------: | ---------- | ----------------------------- |
+| 100.0% | 32 KiB |           1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
 
 ##### `make_first` (`blib2to3/pgen2/pgen.py:74`)
 
-|      % |     Size | Samples | Caller         | Location                    |
-| -----: | -------: | ------: | -------------- | --------------------------- |
-| 100.0% | 25.3 KiB |      40 | `make_grammar` | `blib2to3/pgen2/pgen.py:49` |
+|      % |     Size | Allocations | Caller         | Location                    |
+| -----: | -------: | ----------: | -------------- | --------------------------- |
+| 100.0% | 25.3 KiB |          40 | `make_grammar` | `blib2to3/pgen2/pgen.py:49` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 25 KiB |      22 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 25 KiB |          22 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__new__` (`/usr/lib/python3.11/enum.py:488`)
 
-|     % |     Size | Samples | Caller     | Location                                                     |
-| ----: | -------: | ------: | ---------- | ------------------------------------------------------------ |
-| 31.7% | 7.64 KiB |       9 | `<module>` | `black/mode.py:1`                                            |
-| 16.2% | 3.89 KiB |       4 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/_elffile.py:1` |
-| 13.7% |  3.3 KiB |       3 | `<module>` | `/venv/lib/python3.11/site-packages/click/_utils.py:1`       |
-| 10.1% | 2.44 KiB |       3 | `<module>` | `black/__init__.py:1`                                        |
-|  7.2% | 1.74 KiB |       2 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`         |
+|     % |     Size | Allocations | Caller     | Location                                                     |
+| ----: | -------: | ----------: | ---------- | ------------------------------------------------------------ |
+| 31.7% | 7.64 KiB |           9 | `<module>` | `black/mode.py:1`                                            |
+| 16.2% | 3.89 KiB |           4 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/_elffile.py:1` |
+| 13.7% |  3.3 KiB |           3 | `<module>` | `/venv/lib/python3.11/site-packages/click/_utils.py:1`       |
+| 10.1% | 2.44 KiB |           3 | `<module>` | `black/__init__.py:1`                                        |
+|  7.2% | 1.74 KiB |           2 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`         |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|      % |     Size | Samples | Caller     | Location                                 |
-| -----: | -------: | ------: | ---------- | ---------------------------------------- |
-| 100.0% | 22.6 KiB |      12 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
+|      % |     Size | Allocations | Caller     | Location                                 |
+| -----: | -------: | ----------: | ---------- | ---------------------------------------- |
+| 100.0% | 22.6 KiB |          12 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
 
 ##### `<module>` (`blib2to3/pgen2/tokenize.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 20.7 KiB |      14 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 20.7 KiB |          14 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/_parser.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 19.8 KiB |      12 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 19.8 KiB |          12 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__new__` (`/usr/lib/python3.11/typing.py:2891`)
 
-|     % |     Size | Samples | Caller     | Location                                                    |
-| ----: | -------: | ------: | ---------- | ----------------------------------------------------------- |
-| 90.3% | 15.7 KiB |      19 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`       |
-|  9.7% | 1.69 KiB |       2 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/version.py:1` |
+|     % |     Size | Allocations | Caller     | Location                                                    |
+| ----: | -------: | ----------: | ---------- | ----------------------------------------------------------- |
+| 90.3% | 15.7 KiB |          19 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`       |
+|  9.7% | 1.69 KiB |           2 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/version.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/mypy_extensions.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 15 KiB |      18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 15 KiB |          18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/exceptions.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 13.4 KiB |      15 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 13.4 KiB |          15 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `inner` (`/usr/lib/python3.11/typing.py:338`)
 
-|     % |     Size | Samples | Caller        | Location                                              |
-| ----: | -------: | ------: | ------------- | ----------------------------------------------------- |
-| 75.3% | 9.02 KiB |       1 | `Line`        | `black/lines.py:49`                                   |
-| 17.9% | 2.15 KiB |       1 | `__getitem__` | `/usr/lib/python3.11/typing.py:467`                   |
-|  6.7% |    826 B |       1 | `<module>`    | `/venv/lib/python3.11/site-packages/click/types.py:1` |
+|     % |     Size | Allocations | Caller        | Location                                              |
+| ----: | -------: | ----------: | ------------- | ----------------------------------------------------- |
+| 75.3% | 9.02 KiB |           1 | `Line`        | `black/lines.py:49`                                   |
+| 17.9% | 2.15 KiB |           1 | `__getitem__` | `/usr/lib/python3.11/typing.py:467`                   |
+|  6.7% |    826 B |           1 | `<module>`    | `/venv/lib/python3.11/site-packages/click/types.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/version.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 9.61 KiB |       9 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 9.61 KiB |           9 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `_fill_cache` (`<frozen importlib._bootstrap_external>:1655`)
 
-|      % |  Size | Samples | Caller      | Location                                      |
-| -----: | ----: | ------: | ----------- | --------------------------------------------- |
-| 100.0% | 8 KiB |       4 | `find_spec` | `<frozen importlib._bootstrap_external>:1604` |
+|      % |  Size | Allocations | Caller      | Location                                      |
+| -----: | ----: | ----------: | ----------- | --------------------------------------------- |
+| 100.0% | 8 KiB |           4 | `find_spec` | `<frozen importlib._bootstrap_external>:1604` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|      % |     Size | Samples | Caller  | Location                                |
-| -----: | -------: | ------: | ------- | --------------------------------------- |
-| 100.0% | 7.97 KiB |       1 | `parse` | `/usr/lib/python3.11/re/_parser.py:970` |
+|      % |     Size | Allocations | Caller  | Location                                |
+| -----: | -------: | ----------: | ------- | --------------------------------------- |
+| 100.0% | 7.97 KiB |           1 | `parse` | `/usr/lib/python3.11/re/_parser.py:970` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/utils.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 7.08 KiB |       8 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 7.08 KiB |           8 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__setattr__` (`/usr/lib/python3.11/enum.py:831`)
 
-|     % |     Size | Samples | Caller         | Location                          |
-| ----: | -------: | ------: | -------------- | --------------------------------- |
-| 66.6% | 4.48 KiB |       5 | `__set_name__` | `/usr/lib/python3.11/enum.py:237` |
-| 33.4% | 2.25 KiB |       3 | `__new__`      | `/usr/lib/python3.11/enum.py:488` |
+|     % |     Size | Allocations | Caller         | Location                          |
+| ----: | -------: | ----------: | -------------- | --------------------------------- |
+| 66.6% | 4.48 KiB |           5 | `__set_name__` | `/usr/lib/python3.11/enum.py:237` |
+| 33.4% | 2.25 KiB |           3 | `__new__`      | `/usr/lib/python3.11/enum.py:488` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/util.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 6.48 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 6.48 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 6.24 KiB |       5 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 6.24 KiB |           5 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/_compat.py:1`)
 
-|      % |    Size | Samples | Caller                      | Location                            |
-| -----: | ------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 5.8 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |    Size | Allocations | Caller                      | Location                            |
+| -----: | ------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 5.8 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `namedtuple` (`/usr/lib/python3.11/collections/__init__.py:348`)
 
-|     % |     Size | Samples | Caller          | Location                             |
-| ----: | -------: | ------: | --------------- | ------------------------------------ |
-| 83.3% | 4.69 KiB |       5 | `_make_nmtuple` | `/usr/lib/python3.11/typing.py:2795` |
-| 16.7% |    960 B |       1 | `<module>`      | `/usr/lib/python3.11/pkgutil.py:1`   |
+|     % |     Size | Allocations | Caller          | Location                             |
+| ----: | -------: | ----------: | --------------- | ------------------------------------ |
+| 83.3% | 4.69 KiB |           5 | `_make_nmtuple` | `/usr/lib/python3.11/typing.py:2795` |
+| 16.7% |    960 B |           1 | `<module>`      | `/usr/lib/python3.11/pkgutil.py:1`   |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|      % |     Size | Samples | Caller       | Location                                |
-| -----: | -------: | ------: | ------------ | --------------------------------------- |
-| 100.0% | 5.61 KiB |       3 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
+|      % |     Size | Allocations | Caller       | Location                                |
+| -----: | -------: | ----------: | ------------ | --------------------------------------- |
+| 100.0% | 5.61 KiB |           3 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
 
 ##### `_code` (`/usr/lib/python3.11/re/_compiler.py:571`)
 
-|      % |     Size | Samples | Caller    | Location                                  |
-| -----: | -------: | ------: | --------- | ----------------------------------------- |
-| 100.0% | 5.32 KiB |       2 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
+|      % |     Size | Allocations | Caller    | Location                                  |
+| -----: | -------: | ----------: | --------- | ----------------------------------------- |
+| 100.0% | 5.32 KiB |           2 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
 
 ##### `<module>` (`/usr/lib/python3.11/pkgutil.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 4.73 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 4.73 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `Specifier` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`)
 
-|      % |     Size | Samples | Caller     | Location                                                       |
-| -----: | -------: | ------: | ---------- | -------------------------------------------------------------- |
-| 100.0% | 3.82 KiB |       1 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
+|      % |     Size | Allocations | Caller     | Location                                                       |
+| -----: | -------: | ----------: | ---------- | -------------------------------------------------------------- |
+| 100.0% | 3.82 KiB |           1 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Caller   | Location                                               |
-| -----: | -------: | ------: | -------- | ------------------------------------------------------ |
-| 100.0% | 3.79 KiB |       3 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
+|      % |     Size | Allocations | Caller   | Location                                               |
+| -----: | -------: | ----------: | -------- | ------------------------------------------------------ |
+| 100.0% | 3.79 KiB |           3 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.72 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.72 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.56 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.56 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `handle_parse_result` (`/venv/lib/python3.11/site-packages/click/core.py:2663`)
 
-|      % |     Size | Samples | Caller       | Location                                                |
-| -----: | -------: | ------: | ------------ | ------------------------------------------------------- |
-| 100.0% | 3.37 KiB |       5 | `parse_args` | `/venv/lib/python3.11/site-packages/click/core.py:1303` |
+|      % |     Size | Allocations | Caller       | Location                                                |
+| -----: | -------: | ----------: | ------------ | ------------------------------------------------------- |
+| 100.0% | 3.37 KiB |           5 | `parse_args` | `/venv/lib/python3.11/site-packages/click/core.py:1303` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.19 KiB |       1 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.19 KiB |           1 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.19 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.19 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|      % |     Size | Samples | Caller     | Location                                                   |
-| -----: | -------: | ------: | ---------- | ---------------------------------------------------------- |
-| 100.0% | 2.85 KiB |       1 | `<module>` | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1` |
+|      % |     Size | Allocations | Caller     | Location                                                   |
+| -----: | -------: | ----------: | ---------- | ---------------------------------------------------------- |
+| 100.0% | 2.85 KiB |           1 | `<module>` | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.81 KiB |       3 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.81 KiB |           3 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.76 KiB |       2 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.76 KiB |           2 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ### Total size
 
 Functions ranked by total bytes held at peak memory in the function and all its callees.
 
-|      % |     Size | Samples | Function               | Location                                                       |
-| -----: | -------: | ------: | ---------------------- | -------------------------------------------------------------- |
-| 100.0% | 78.6 MiB |  22,694 | `_run_tracker`         | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
-| 100.0% | 78.6 MiB |  22,693 | `run_module`           | `<frozen runpy>:201`                                           |
-|  94.5% | 74.3 MiB |  21,393 | `__call__`             | `/venv/lib/python3.11/site-packages/click/core.py:1567`        |
-|  94.5% | 74.3 MiB |  21,393 | `patched_main`         | `black/__init__.py:1594`                                       |
-|  94.5% | 74.3 MiB |  21,393 | `<module>`             | `black/__main__.py:1`                                          |
-|  94.5% | 74.3 MiB |  21,393 | `_run_code`            | `<frozen runpy>:65`                                            |
-|  94.5% | 74.3 MiB |  21,393 | `_run_module_code`     | `<frozen runpy>:91`                                            |
-|  94.5% | 74.3 MiB |  21,392 | `main`                 | `/venv/lib/python3.11/site-packages/click/core.py:1422`        |
-|  94.5% | 74.2 MiB |  21,373 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:1339`        |
-|  94.5% | 74.2 MiB |  21,370 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:853`         |
-|  94.5% | 74.2 MiB |  21,368 | `new_func`             | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
-|  94.5% | 74.2 MiB |  21,365 | `main`                 | `black/__init__.py:244`                                        |
-|  94.5% | 74.2 MiB |  21,361 | `reformat_one`         | `black/__init__.py:860`                                        |
-|  94.5% | 74.2 MiB |  21,358 | `format_file_in_place` | `black/__init__.py:917`                                        |
-|  94.2% |   74 MiB |  21,355 | `format_file_contents` | `black/__init__.py:1054`                                       |
-|  65.9% | 51.8 MiB |  21,146 | `format_str`           | `black/__init__.py:1189`                                       |
-|  65.9% | 51.8 MiB |  21,145 | `_format_str_once`     | `black/__init__.py:1236`                                       |
-|  50.2% | 39.4 MiB |  21,090 | `visit`                | `black/nodes.py:163`                                           |
-|  50.2% | 39.4 MiB |  21,088 | `visit_default`        | `black/linegen.py:134`                                         |
-|  50.2% | 39.4 MiB |  21,088 | `visit_default`        | `black/nodes.py:187`                                           |
+|      % |     Size | Allocations | Function               | Location                                                       |
+| -----: | -------: | ----------: | ---------------------- | -------------------------------------------------------------- |
+| 100.0% | 78.6 MiB |      22,694 | `_run_tracker`         | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
+| 100.0% | 78.6 MiB |      22,693 | `run_module`           | `<frozen runpy>:201`                                           |
+|  94.5% | 74.3 MiB |      21,393 | `__call__`             | `/venv/lib/python3.11/site-packages/click/core.py:1567`        |
+|  94.5% | 74.3 MiB |      21,393 | `patched_main`         | `black/__init__.py:1594`                                       |
+|  94.5% | 74.3 MiB |      21,393 | `<module>`             | `black/__main__.py:1`                                          |
+|  94.5% | 74.3 MiB |      21,393 | `_run_code`            | `<frozen runpy>:65`                                            |
+|  94.5% | 74.3 MiB |      21,393 | `_run_module_code`     | `<frozen runpy>:91`                                            |
+|  94.5% | 74.3 MiB |      21,392 | `main`                 | `/venv/lib/python3.11/site-packages/click/core.py:1422`        |
+|  94.5% | 74.2 MiB |      21,373 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:1339`        |
+|  94.5% | 74.2 MiB |      21,370 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:853`         |
+|  94.5% | 74.2 MiB |      21,368 | `new_func`             | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
+|  94.5% | 74.2 MiB |      21,365 | `main`                 | `black/__init__.py:244`                                        |
+|  94.5% | 74.2 MiB |      21,361 | `reformat_one`         | `black/__init__.py:860`                                        |
+|  94.5% | 74.2 MiB |      21,358 | `format_file_in_place` | `black/__init__.py:917`                                        |
+|  94.2% |   74 MiB |      21,355 | `format_file_contents` | `black/__init__.py:1054`                                       |
+|  65.9% | 51.8 MiB |      21,146 | `format_str`           | `black/__init__.py:1189`                                       |
+|  65.9% | 51.8 MiB |      21,145 | `_format_str_once`     | `black/__init__.py:1236`                                       |
+|  50.2% | 39.4 MiB |      21,090 | `visit`                | `black/nodes.py:163`                                           |
+|  50.2% | 39.4 MiB |      21,088 | `visit_default`        | `black/linegen.py:134`                                         |
+|  50.2% | 39.4 MiB |      21,088 | `visit_default`        | `black/nodes.py:187`                                           |
 
 #### Categories
 
 ##### Ours
 
-|     % |     Size | Samples | Function                          | Location                 |
-| ----: | -------: | ------: | --------------------------------- | ------------------------ |
-| 94.5% | 74.3 MiB |  21,393 | `patched_main`                    | `black/__init__.py:1594` |
-| 94.5% | 74.3 MiB |  21,393 | `<module>`                        | `black/__main__.py:1`    |
-| 94.5% | 74.2 MiB |  21,365 | `main`                            | `black/__init__.py:244`  |
-| 94.5% | 74.2 MiB |  21,361 | `reformat_one`                    | `black/__init__.py:860`  |
-| 94.5% | 74.2 MiB |  21,358 | `format_file_in_place`            | `black/__init__.py:917`  |
-| 94.2% |   74 MiB |  21,355 | `format_file_contents`            | `black/__init__.py:1054` |
-| 65.9% | 51.8 MiB |  21,146 | `format_str`                      | `black/__init__.py:1189` |
-| 65.9% | 51.8 MiB |  21,145 | `_format_str_once`                | `black/__init__.py:1236` |
-| 50.2% | 39.4 MiB |  21,090 | `visit`                           | `black/nodes.py:163`     |
-| 50.2% | 39.4 MiB |  21,088 | `visit_default`                   | `black/linegen.py:134`   |
-| 50.2% | 39.4 MiB |  21,088 | `visit_default`                   | `black/nodes.py:187`     |
-| 49.8% | 39.2 MiB |  20,717 | `visit_stmt`                      | `black/linegen.py:199`   |
-| 46.9% | 36.8 MiB |  20,274 | `visit_funcdef`                   | `black/linegen.py:254`   |
-| 46.7% | 36.7 MiB |  20,148 | `visit_suite`                     | `black/linegen.py:288`   |
-| 36.0% | 28.3 MiB |  20,893 | `append`                          | `black/lines.py:63`      |
-| 31.6% | 24.8 MiB |  13,403 | `visit_simple_stmt`               | `black/linegen.py:295`   |
-| 28.3% | 22.3 MiB |     209 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
-| 28.3% | 22.3 MiB |     208 | `assert_equivalent`               | `black/__init__.py:1524` |
-| 23.2% | 18.2 MiB |  20,790 | `mark`                            | `black/brackets.py:70`   |
-| 22.8% | 17.9 MiB |  10,809 | `visit_power`                     | `black/linegen.py:341`   |
+|     % |     Size | Allocations | Function                          | Location                 |
+| ----: | -------: | ----------: | --------------------------------- | ------------------------ |
+| 94.5% | 74.3 MiB |      21,393 | `patched_main`                    | `black/__init__.py:1594` |
+| 94.5% | 74.3 MiB |      21,393 | `<module>`                        | `black/__main__.py:1`    |
+| 94.5% | 74.2 MiB |      21,365 | `main`                            | `black/__init__.py:244`  |
+| 94.5% | 74.2 MiB |      21,361 | `reformat_one`                    | `black/__init__.py:860`  |
+| 94.5% | 74.2 MiB |      21,358 | `format_file_in_place`            | `black/__init__.py:917`  |
+| 94.2% |   74 MiB |      21,355 | `format_file_contents`            | `black/__init__.py:1054` |
+| 65.9% | 51.8 MiB |      21,146 | `format_str`                      | `black/__init__.py:1189` |
+| 65.9% | 51.8 MiB |      21,145 | `_format_str_once`                | `black/__init__.py:1236` |
+| 50.2% | 39.4 MiB |      21,090 | `visit`                           | `black/nodes.py:163`     |
+| 50.2% | 39.4 MiB |      21,088 | `visit_default`                   | `black/linegen.py:134`   |
+| 50.2% | 39.4 MiB |      21,088 | `visit_default`                   | `black/nodes.py:187`     |
+| 49.8% | 39.2 MiB |      20,717 | `visit_stmt`                      | `black/linegen.py:199`   |
+| 46.9% | 36.8 MiB |      20,274 | `visit_funcdef`                   | `black/linegen.py:254`   |
+| 46.7% | 36.7 MiB |      20,148 | `visit_suite`                     | `black/linegen.py:288`   |
+| 36.0% | 28.3 MiB |      20,893 | `append`                          | `black/lines.py:63`      |
+| 31.6% | 24.8 MiB |      13,403 | `visit_simple_stmt`               | `black/linegen.py:295`   |
+| 28.3% | 22.3 MiB |         209 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+| 28.3% | 22.3 MiB |         208 | `assert_equivalent`               | `black/__init__.py:1524` |
+| 23.2% | 18.2 MiB |      20,790 | `mark`                            | `black/brackets.py:70`   |
+| 22.8% | 17.9 MiB |      10,809 | `visit_power`                     | `black/linegen.py:341`   |
 
 ##### Standard library
 
-|      % |     Size | Samples | Function                    | Location                                     |
-| -----: | -------: | ------: | --------------------------- | -------------------------------------------- |
-| 100.0% | 78.6 MiB |  22,693 | `run_module`                | `<frozen runpy>:201`                         |
-|  94.5% | 74.3 MiB |  21,393 | `_run_code`                 | `<frozen runpy>:65`                          |
-|  94.5% | 74.3 MiB |  21,393 | `_run_module_code`          | `<frozen runpy>:91`                          |
-|  11.6% | 9.12 MiB |     142 | `parse`                     | `/usr/lib/python3.11/ast.py:33`              |
-|   5.5% | 4.32 MiB |   1,299 | `_get_module_details`       | `<frozen runpy>:105`                         |
-|   5.5% | 4.31 MiB |   1,292 | `_find_and_load`            | `<frozen importlib._bootstrap>:1167`         |
-|   5.5% | 4.31 MiB |   1,290 | `_find_and_load_unlocked`   | `<frozen importlib._bootstrap>:1122`         |
-|   5.5% | 4.31 MiB |   1,289 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`          |
-|   5.5% | 4.31 MiB |   1,287 | `exec_module`               | `<frozen importlib._bootstrap_external>:934` |
-|   5.4% | 4.28 MiB |   1,257 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`          |
-|   1.7% |  1.3 MiB |     318 | `_handle_fromlist`          | `<frozen importlib._bootstrap>:1209`         |
-|   1.3% | 1.05 MiB |      26 | `compile`                   | `/usr/lib/python3.11/re/__init__.py:225`     |
-|   1.3% | 1.05 MiB |      25 | `_compile`                  | `/usr/lib/python3.11/re/__init__.py:272`     |
-|   1.3% | 1.05 MiB |      24 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`    |
-|   1.3% | 1.01 MiB |       6 | `parse`                     | `/usr/lib/python3.11/re/_parser.py:970`      |
-|   1.3% | 1.01 MiB |      15 | `wrap`                      | `/usr/lib/python3.11/dataclasses.py:1209`    |
-|   1.3% | 1.01 MiB |       5 | `_parse_sub`                | `/usr/lib/python3.11/re/_parser.py:447`      |
-|   1.3% | 1.01 MiB |      14 | `_process_class`            | `/usr/lib/python3.11/dataclasses.py:884`     |
-|   1.3% | 1.01 MiB |      11 | `dataclass`                 | `/usr/lib/python3.11/dataclasses.py:1192`    |
-|   1.3% | 1.01 MiB |       4 | `_parse`                    | `/usr/lib/python3.11/re/_parser.py:507`      |
+|      % |     Size | Allocations | Function                    | Location                                     |
+| -----: | -------: | ----------: | --------------------------- | -------------------------------------------- |
+| 100.0% | 78.6 MiB |      22,693 | `run_module`                | `<frozen runpy>:201`                         |
+|  94.5% | 74.3 MiB |      21,393 | `_run_code`                 | `<frozen runpy>:65`                          |
+|  94.5% | 74.3 MiB |      21,393 | `_run_module_code`          | `<frozen runpy>:91`                          |
+|  11.6% | 9.12 MiB |         142 | `parse`                     | `/usr/lib/python3.11/ast.py:33`              |
+|   5.5% | 4.32 MiB |       1,299 | `_get_module_details`       | `<frozen runpy>:105`                         |
+|   5.5% | 4.31 MiB |       1,292 | `_find_and_load`            | `<frozen importlib._bootstrap>:1167`         |
+|   5.5% | 4.31 MiB |       1,290 | `_find_and_load_unlocked`   | `<frozen importlib._bootstrap>:1122`         |
+|   5.5% | 4.31 MiB |       1,289 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`          |
+|   5.5% | 4.31 MiB |       1,287 | `exec_module`               | `<frozen importlib._bootstrap_external>:934` |
+|   5.4% | 4.28 MiB |       1,257 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`          |
+|   1.7% |  1.3 MiB |         318 | `_handle_fromlist`          | `<frozen importlib._bootstrap>:1209`         |
+|   1.3% | 1.05 MiB |          26 | `compile`                   | `/usr/lib/python3.11/re/__init__.py:225`     |
+|   1.3% | 1.05 MiB |          25 | `_compile`                  | `/usr/lib/python3.11/re/__init__.py:272`     |
+|   1.3% | 1.05 MiB |          24 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`    |
+|   1.3% | 1.01 MiB |           6 | `parse`                     | `/usr/lib/python3.11/re/_parser.py:970`      |
+|   1.3% | 1.01 MiB |          15 | `wrap`                      | `/usr/lib/python3.11/dataclasses.py:1209`    |
+|   1.3% | 1.01 MiB |           5 | `_parse_sub`                | `/usr/lib/python3.11/re/_parser.py:447`      |
+|   1.3% | 1.01 MiB |          14 | `_process_class`            | `/usr/lib/python3.11/dataclasses.py:884`     |
+|   1.3% | 1.01 MiB |          11 | `dataclass`                 | `/usr/lib/python3.11/dataclasses.py:1192`    |
+|   1.3% | 1.01 MiB |           4 | `_parse`                    | `/usr/lib/python3.11/re/_parser.py:507`      |
 
 ##### Third-party
 
-|      % |     Size | Samples | Function       | Location                                                                         |
-| -----: | -------: | ------: | -------------- | -------------------------------------------------------------------------------- |
-| 100.0% | 78.6 MiB |  22,694 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40`                   |
-|  94.5% | 74.3 MiB |  21,393 | `__call__`     | `/venv/lib/python3.11/site-packages/click/core.py:1567`                          |
-|  94.5% | 74.3 MiB |  21,392 | `main`         | `/venv/lib/python3.11/site-packages/click/core.py:1422`                          |
-|  94.5% | 74.2 MiB |  21,373 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339`                          |
-|  94.5% | 74.2 MiB |  21,370 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:853`                           |
-|  94.5% | 74.2 MiB |  21,368 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                      |
-|   1.7% | 1.31 MiB |     304 | `<module>`     | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                         |
-|   1.6% | 1.23 MiB |     233 | `<module>`     | `/venv/lib/python3.11/site-packages/click/core.py:1`                             |
-|   1.3% | 1.02 MiB |      24 | `<module>`     | `/venv/lib/python3.11/site-packages/click/formatting.py:1`                       |
-|   1.3% | 1.01 MiB |      11 | `<module>`     | `/venv/lib/python3.11/site-packages/click/parser.py:1`                           |
-|   0.2% |  173 KiB |     141 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`                   |
-|   0.2% |  125 KiB |     127 | `<module>`     | `/venv/lib/python3.11/site-packages/click/types.py:1`                            |
-|   0.1% | 99.6 KiB |      72 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                        |
-|   0.1% | 93.8 KiB |     119 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`                      |
-|   0.1% | 91.5 KiB |     115 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`                     |
-|   0.1% | 74.5 KiB |      43 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                         |
-|   0.1% | 65.5 KiB |      84 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`                 |
-|   0.1% | 47.3 KiB |      33 | `decorator`    | `/venv/lib/python3.11/site-packages/click/decorators.py:373`                     |
-|   0.1% | 46.9 KiB |      59 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1` |
-|   0.1% | 45.5 KiB |      32 | `__init__`     | `/venv/lib/python3.11/site-packages/click/core.py:2883`                          |
+|      % |     Size | Allocations | Function       | Location                                                                         |
+| -----: | -------: | ----------: | -------------- | -------------------------------------------------------------------------------- |
+| 100.0% | 78.6 MiB |      22,694 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40`                   |
+|  94.5% | 74.3 MiB |      21,393 | `__call__`     | `/venv/lib/python3.11/site-packages/click/core.py:1567`                          |
+|  94.5% | 74.3 MiB |      21,392 | `main`         | `/venv/lib/python3.11/site-packages/click/core.py:1422`                          |
+|  94.5% | 74.2 MiB |      21,373 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339`                          |
+|  94.5% | 74.2 MiB |      21,370 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:853`                           |
+|  94.5% | 74.2 MiB |      21,368 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                      |
+|   1.7% | 1.31 MiB |         304 | `<module>`     | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                         |
+|   1.6% | 1.23 MiB |         233 | `<module>`     | `/venv/lib/python3.11/site-packages/click/core.py:1`                             |
+|   1.3% | 1.02 MiB |          24 | `<module>`     | `/venv/lib/python3.11/site-packages/click/formatting.py:1`                       |
+|   1.3% | 1.01 MiB |          11 | `<module>`     | `/venv/lib/python3.11/site-packages/click/parser.py:1`                           |
+|   0.2% |  173 KiB |         141 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`                   |
+|   0.2% |  125 KiB |         127 | `<module>`     | `/venv/lib/python3.11/site-packages/click/types.py:1`                            |
+|   0.1% | 99.6 KiB |          72 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                        |
+|   0.1% | 93.8 KiB |         119 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`                      |
+|   0.1% | 91.5 KiB |         115 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`                     |
+|   0.1% | 74.5 KiB |          43 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                         |
+|   0.1% | 65.5 KiB |          84 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`                 |
+|   0.1% | 47.3 KiB |          33 | `decorator`    | `/venv/lib/python3.11/site-packages/click/decorators.py:373`                     |
+|   0.1% | 46.9 KiB |          59 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1` |
+|   0.1% | 45.5 KiB |          32 | `__init__`     | `/venv/lib/python3.11/site-packages/click/core.py:2883`                          |
 
 #### Callees
 
@@ -1050,396 +1050,396 @@ Callees ranked by contribution to each function's total size. Inlining can make 
 
 ##### `_run_tracker` (`/venv/lib/python3.11/site-packages/memray/commands/run.py:40`)
 
-|      % |     Size | Samples | Callee       | Location             |
-| -----: | -------: | ------: | ------------ | -------------------- |
-| 100.0% | 78.6 MiB |  22,693 | `run_module` | `<frozen runpy>:201` |
+|      % |     Size | Allocations | Callee       | Location             |
+| -----: | -------: | ----------: | ------------ | -------------------- |
+| 100.0% | 78.6 MiB |      22,693 | `run_module` | `<frozen runpy>:201` |
 
 ##### `run_module` (`<frozen runpy>:201`)
 
-|     % |     Size | Samples | Callee                | Location             |
-| ----: | -------: | ------: | --------------------- | -------------------- |
-| 94.5% | 74.3 MiB |  21,393 | `_run_module_code`    | `<frozen runpy>:91`  |
-|  5.5% | 4.32 MiB |   1,299 | `_get_module_details` | `<frozen runpy>:105` |
+|     % |     Size | Allocations | Callee                | Location             |
+| ----: | -------: | ----------: | --------------------- | -------------------- |
+| 94.5% | 74.3 MiB |      21,393 | `_run_module_code`    | `<frozen runpy>:91`  |
+|  5.5% | 4.32 MiB |       1,299 | `_get_module_details` | `<frozen runpy>:105` |
 
 ##### `__call__` (`/venv/lib/python3.11/site-packages/click/core.py:1567`)
 
-|      % |     Size | Samples | Callee | Location                                                |
-| -----: | -------: | ------: | ------ | ------------------------------------------------------- |
-| 100.0% | 74.3 MiB |  21,392 | `main` | `/venv/lib/python3.11/site-packages/click/core.py:1422` |
+|      % |     Size | Allocations | Callee | Location                                                |
+| -----: | -------: | ----------: | ------ | ------------------------------------------------------- |
+| 100.0% | 74.3 MiB |      21,392 | `main` | `/venv/lib/python3.11/site-packages/click/core.py:1422` |
 
 ##### `patched_main` (`black/__init__.py:1594`)
 
-|      % |     Size | Samples | Callee     | Location                                                |
-| -----: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 100.0% | 74.3 MiB |  21,393 | `__call__` | `/venv/lib/python3.11/site-packages/click/core.py:1567` |
+|      % |     Size | Allocations | Callee     | Location                                                |
+| -----: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 100.0% | 74.3 MiB |      21,393 | `__call__` | `/venv/lib/python3.11/site-packages/click/core.py:1567` |
 
 ##### `<module>` (`black/__main__.py:1`)
 
-|      % |     Size | Samples | Callee         | Location                 |
-| -----: | -------: | ------: | -------------- | ------------------------ |
-| 100.0% | 74.3 MiB |  21,393 | `patched_main` | `black/__init__.py:1594` |
+|      % |     Size | Allocations | Callee         | Location                 |
+| -----: | -------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 74.3 MiB |      21,393 | `patched_main` | `black/__init__.py:1594` |
 
 ##### `_run_code` (`<frozen runpy>:65`)
 
-|      % |     Size | Samples | Callee     | Location              |
-| -----: | -------: | ------: | ---------- | --------------------- |
-| 100.0% | 74.3 MiB |  21,393 | `<module>` | `black/__main__.py:1` |
+|      % |     Size | Allocations | Callee     | Location              |
+| -----: | -------: | ----------: | ---------- | --------------------- |
+| 100.0% | 74.3 MiB |      21,393 | `<module>` | `black/__main__.py:1` |
 
 ##### `_run_module_code` (`<frozen runpy>:91`)
 
-|      % |     Size | Samples | Callee      | Location            |
-| -----: | -------: | ------: | ----------- | ------------------- |
-| 100.0% | 74.3 MiB |  21,393 | `_run_code` | `<frozen runpy>:65` |
+|      % |     Size | Allocations | Callee      | Location            |
+| -----: | -------: | ----------: | ----------- | ------------------- |
+| 100.0% | 74.3 MiB |      21,393 | `_run_code` | `<frozen runpy>:65` |
 
 ##### `main` (`/venv/lib/python3.11/site-packages/click/core.py:1422`)
 
-|      % |     Size | Samples | Callee         | Location                                                |
-| -----: | -------: | ------: | -------------- | ------------------------------------------------------- |
-| 100.0% | 74.2 MiB |  21,373 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339` |
-|  <0.1% | 14.1 KiB |      17 | `make_context` | `/venv/lib/python3.11/site-packages/click/core.py:1266` |
-|  <0.1% |     32 B |       1 | `__enter__`    | `/venv/lib/python3.11/site-packages/click/core.py:545`  |
+|      % |     Size | Allocations | Callee         | Location                                                |
+| -----: | -------: | ----------: | -------------- | ------------------------------------------------------- |
+| 100.0% | 74.2 MiB |      21,373 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339` |
+|  <0.1% | 14.1 KiB |          17 | `make_context` | `/venv/lib/python3.11/site-packages/click/core.py:1266` |
+|  <0.1% |     32 B |           1 | `__enter__`    | `/venv/lib/python3.11/site-packages/click/core.py:545`  |
 
 ##### `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:1339`)
 
-|      % |     Size | Samples | Callee   | Location                                               |
-| -----: | -------: | ------: | -------- | ------------------------------------------------------ |
-| 100.0% | 74.2 MiB |  21,370 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
+|      % |     Size | Allocations | Callee   | Location                                               |
+| -----: | -------: | ----------: | -------- | ------------------------------------------------------ |
+| 100.0% | 74.2 MiB |      21,370 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
 
 ##### `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`)
 
-|      % |     Size | Samples | Callee     | Location                                                    |
-| -----: | -------: | ------: | ---------- | ----------------------------------------------------------- |
-| 100.0% | 74.2 MiB |  21,368 | `new_func` | `/venv/lib/python3.11/site-packages/click/decorators.py:33` |
+|      % |     Size | Allocations | Callee     | Location                                                    |
+| -----: | -------: | ----------: | ---------- | ----------------------------------------------------------- |
+| 100.0% | 74.2 MiB |      21,368 | `new_func` | `/venv/lib/python3.11/site-packages/click/decorators.py:33` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Callee | Location                |
-| -----: | -------: | ------: | ------ | ----------------------- |
-| 100.0% | 74.2 MiB |  21,365 | `main` | `black/__init__.py:244` |
+|      % |     Size | Allocations | Callee | Location                |
+| -----: | -------: | ----------: | ------ | ----------------------- |
+| 100.0% | 74.2 MiB |      21,365 | `main` | `black/__init__.py:244` |
 
 ##### `main` (`black/__init__.py:244`)
 
-|      % |     Size | Samples | Callee         | Location                |
-| -----: | -------: | ------: | -------------- | ----------------------- |
-| 100.0% | 74.2 MiB |  21,361 | `reformat_one` | `black/__init__.py:860` |
-|  <0.1% | 2.06 KiB |       2 | `get_sources`  | `black/__init__.py:724` |
+|      % |     Size | Allocations | Callee         | Location                |
+| -----: | -------: | ----------: | -------------- | ----------------------- |
+| 100.0% | 74.2 MiB |      21,361 | `reformat_one` | `black/__init__.py:860` |
+|  <0.1% | 2.06 KiB |           2 | `get_sources`  | `black/__init__.py:724` |
 
 ##### `reformat_one` (`black/__init__.py:860`)
 
-|      % |     Size | Samples | Callee                 | Location                |
-| -----: | -------: | ------: | ---------------------- | ----------------------- |
-| 100.0% | 74.2 MiB |  21,358 | `format_file_in_place` | `black/__init__.py:917` |
-|  <0.1% | 1.13 KiB |       1 | `read`                 | `black/cache.py:60`     |
+|      % |     Size | Allocations | Callee                 | Location                |
+| -----: | -------: | ----------: | ---------------------- | ----------------------- |
+| 100.0% | 74.2 MiB |      21,358 | `format_file_in_place` | `black/__init__.py:917` |
+|  <0.1% | 1.13 KiB |           1 | `read`                 | `black/cache.py:60`     |
 
 ##### `format_file_in_place` (`black/__init__.py:917`)
 
-|     % |    Size | Samples | Callee                 | Location                 |
-| ----: | ------: | ------: | ---------------------- | ------------------------ |
-| 99.7% |  74 MiB |  21,355 | `format_file_contents` | `black/__init__.py:1054` |
-|  0.3% | 223 KiB |       2 | `decode_bytes`         | `black/__init__.py:1290` |
+|     % |    Size | Allocations | Callee                 | Location                 |
+| ----: | ------: | ----------: | ---------------------- | ------------------------ |
+| 99.7% |  74 MiB |      21,355 | `format_file_contents` | `black/__init__.py:1054` |
+|  0.3% | 223 KiB |           2 | `decode_bytes`         | `black/__init__.py:1290` |
 
 ##### `format_file_contents` (`black/__init__.py:1054`)
 
-|     % |     Size | Samples | Callee                            | Location                 |
-| ----: | -------: | ------: | --------------------------------- | ------------------------ |
-| 69.9% | 51.8 MiB |  21,146 | `format_str`                      | `black/__init__.py:1189` |
-| 30.1% | 22.3 MiB |     209 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+|     % |     Size | Allocations | Callee                            | Location                 |
+| ----: | -------: | ----------: | --------------------------------- | ------------------------ |
+| 69.9% | 51.8 MiB |      21,146 | `format_str`                      | `black/__init__.py:1189` |
+| 30.1% | 22.3 MiB |         209 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
 
 ##### `format_str` (`black/__init__.py:1189`)
 
-|      % |     Size | Samples | Callee             | Location                 |
-| -----: | -------: | ------: | ------------------ | ------------------------ |
-| 100.0% | 51.8 MiB |  21,145 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |     Size | Allocations | Callee             | Location                 |
+| -----: | -------: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 51.8 MiB |      21,145 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `_format_str_once` (`black/__init__.py:1236`)
 
-|     % |     Size | Samples | Callee                   | Location                 |
-| ----: | -------: | ------: | ------------------------ | ------------------------ |
-| 76.2% | 39.4 MiB |  21,090 | `visit`                  | `black/nodes.py:163`     |
-| 23.3% |   12 MiB |      31 | `lib2to3_parse`          | `black/parsing.py:55`    |
-| <0.1% | 19.9 KiB |       3 | `normalize_fmt_off`      | `black/comments.py:168`  |
-| <0.1% | 12.2 KiB |      12 | `transform_line`         | `black/linegen.py:601`   |
-| <0.1% | 3.49 KiB |       1 | `detect_target_versions` | `black/__init__.py:1464` |
+|     % |     Size | Allocations | Callee                   | Location                 |
+| ----: | -------: | ----------: | ------------------------ | ------------------------ |
+| 76.2% | 39.4 MiB |      21,090 | `visit`                  | `black/nodes.py:163`     |
+| 23.3% |   12 MiB |          31 | `lib2to3_parse`          | `black/parsing.py:55`    |
+| <0.1% | 19.9 KiB |           3 | `normalize_fmt_off`      | `black/comments.py:168`  |
+| <0.1% | 12.2 KiB |          12 | `transform_line`         | `black/linegen.py:601`   |
+| <0.1% | 3.49 KiB |           1 | `detect_target_versions` | `black/__init__.py:1464` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|      % |     Size | Samples | Callee              | Location               |
-| -----: | -------: | ------: | ------------------- | ---------------------- |
-| 100.0% | 39.4 MiB |  21,088 | `visit_default`     | `black/linegen.py:134` |
-|  99.3% | 39.2 MiB |  20,717 | `visit_stmt`        | `black/linegen.py:199` |
-|  93.3% | 36.8 MiB |  20,274 | `visit_funcdef`     | `black/linegen.py:254` |
-|  93.1% | 36.7 MiB |  20,148 | `visit_suite`       | `black/linegen.py:288` |
-|  62.9% | 24.8 MiB |  13,403 | `visit_simple_stmt` | `black/linegen.py:295` |
+|      % |     Size | Allocations | Callee              | Location               |
+| -----: | -------: | ----------: | ------------------- | ---------------------- |
+| 100.0% | 39.4 MiB |      21,088 | `visit_default`     | `black/linegen.py:134` |
+|  99.3% | 39.2 MiB |      20,717 | `visit_stmt`        | `black/linegen.py:199` |
+|  93.3% | 36.8 MiB |      20,274 | `visit_funcdef`     | `black/linegen.py:254` |
+|  93.1% | 36.7 MiB |      20,148 | `visit_suite`       | `black/linegen.py:288` |
+|  62.9% | 24.8 MiB |      13,403 | `visit_simple_stmt` | `black/linegen.py:295` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|      % |     Size | Samples | Callee              | Location               |
-| -----: | -------: | ------: | ------------------- | ---------------------- |
-| 100.0% | 39.4 MiB |  21,088 | `visit_default`     | `black/nodes.py:187`   |
-|  71.7% | 28.3 MiB |  20,893 | `append`            | `black/lines.py:63`    |
-|  20.3% |    8 MiB |       8 | `generate_comments` | `black/comments.py:52` |
-|   2.5% |    1 MiB |       1 | `line`              | `black/linegen.py:109` |
+|      % |     Size | Allocations | Callee              | Location               |
+| -----: | -------: | ----------: | ------------------- | ---------------------- |
+| 100.0% | 39.4 MiB |      21,088 | `visit_default`     | `black/nodes.py:187`   |
+|  71.7% | 28.3 MiB |      20,893 | `append`            | `black/lines.py:63`    |
+|  20.3% |    8 MiB |           8 | `generate_comments` | `black/comments.py:52` |
+|   2.5% |    1 MiB |           1 | `line`              | `black/linegen.py:109` |
 
 ##### `visit_default` (`black/nodes.py:187`)
 
-|      % |     Size | Samples | Callee  | Location             |
-| -----: | -------: | ------: | ------- | -------------------- |
-| 100.0% | 39.4 MiB |  21,088 | `visit` | `black/nodes.py:163` |
+|      % |     Size | Allocations | Callee  | Location             |
+| -----: | -------: | ----------: | ------- | -------------------- |
+| 100.0% | 39.4 MiB |      21,088 | `visit` | `black/nodes.py:163` |
 
 ##### `visit_stmt` (`black/linegen.py:199`)
 
-|      % |     Size | Samples | Callee                       | Location                |
-| -----: | -------: | ------: | ---------------------------- | ----------------------- |
-| 100.0% | 39.2 MiB |  20,715 | `visit`                      | `black/nodes.py:163`    |
-|   2.6% |    1 MiB |       2 | `normalize_invisible_parens` | `black/linegen.py:1328` |
+|      % |     Size | Allocations | Callee                       | Location                |
+| -----: | -------: | ----------: | ---------------------------- | ----------------------- |
+| 100.0% | 39.2 MiB |      20,715 | `visit`                      | `black/nodes.py:163`    |
+|   2.6% |    1 MiB |           2 | `normalize_invisible_parens` | `black/linegen.py:1328` |
 
 ##### `visit_funcdef` (`black/linegen.py:254`)
 
-|      % |     Size | Samples | Callee  | Location             |
-| -----: | -------: | ------: | ------- | -------------------- |
-| 100.0% | 36.8 MiB |  20,274 | `visit` | `black/nodes.py:163` |
+|      % |     Size | Allocations | Callee  | Location             |
+| -----: | -------: | ----------: | ------- | -------------------- |
+| 100.0% | 36.8 MiB |      20,274 | `visit` | `black/nodes.py:163` |
 
 ##### `visit_suite` (`black/linegen.py:288`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 36.7 MiB |  20,148 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 36.7 MiB |      20,148 | `visit_default` | `black/linegen.py:134` |
 
 ##### `append` (`black/lines.py:63`)
 
-|     % |     Size | Samples | Callee       | Location                 |
-| ----: | -------: | ------: | ------------ | ------------------------ |
-| 64.4% | 18.2 MiB |  20,790 | `mark`       | `black/brackets.py:70`   |
-| 24.9% | 7.05 MiB |      96 | `whitespace` | `black/nodes.py:194`     |
-| 10.6% |    3 MiB |       3 | `prefix`     | `blib2to3/pytree.py:480` |
+|     % |     Size | Allocations | Callee       | Location                 |
+| ----: | -------: | ----------: | ------------ | ------------------------ |
+| 64.4% | 18.2 MiB |      20,790 | `mark`       | `black/brackets.py:70`   |
+| 24.9% | 7.05 MiB |          96 | `whitespace` | `black/nodes.py:194`     |
+| 10.6% |    3 MiB |           3 | `prefix`     | `blib2to3/pytree.py:480` |
 
 ##### `visit_simple_stmt` (`black/linegen.py:295`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 24.8 MiB |  13,403 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 24.8 MiB |      13,403 | `visit_default` | `black/linegen.py:134` |
 
 ##### `check_stability_and_equivalence` (`black/__init__.py:1037`)
 
-|      % |     Size | Samples | Callee              | Location                 |
-| -----: | -------: | ------: | ------------------- | ------------------------ |
-| 100.0% | 22.3 MiB |     208 | `assert_equivalent` | `black/__init__.py:1524` |
+|      % |     Size | Allocations | Callee              | Location                 |
+| -----: | -------: | ----------: | ------------------- | ------------------------ |
+| 100.0% | 22.3 MiB |         208 | `assert_equivalent` | `black/__init__.py:1524` |
 
 ##### `assert_equivalent` (`black/__init__.py:1524`)
 
-|     % |     Size | Samples | Callee           | Location               |
-| ----: | -------: | ------: | ---------------- | ---------------------- |
-| 41.0% | 9.12 MiB |     142 | `parse_ast`      | `black/parsing.py:129` |
-| 27.2% | 6.05 MiB |      62 | `_stringify_ast` | `black/parsing.py:174` |
+|     % |     Size | Allocations | Callee           | Location               |
+| ----: | -------: | ----------: | ---------------- | ---------------------- |
+| 41.0% | 9.12 MiB |         142 | `parse_ast`      | `black/parsing.py:129` |
+| 27.2% | 6.05 MiB |          62 | `_stringify_ast` | `black/parsing.py:174` |
 
 ##### `visit_power` (`black/linegen.py:341`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 17.9 MiB |  10,808 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 17.9 MiB |      10,808 | `visit_default` | `black/linegen.py:134` |
 
 ##### `_get_module_details` (`<frozen runpy>:105`)
 
-|     % |     Size | Samples | Callee                | Location                             |
-| ----: | -------: | ------: | --------------------- | ------------------------------------ |
-| 99.9% | 4.31 MiB |   1,292 | `_find_and_load`      | `<frozen importlib._bootstrap>:1167` |
-| 99.9% | 4.31 MiB |   1,292 | `_get_module_details` | `<frozen runpy>:105`                 |
-|  0.1% | 5.66 KiB |       6 | `find_spec`           | `<frozen importlib.util>:73`         |
+|     % |     Size | Allocations | Callee                | Location                             |
+| ----: | -------: | ----------: | --------------------- | ------------------------------------ |
+| 99.9% | 4.31 MiB |       1,292 | `_find_and_load`      | `<frozen importlib._bootstrap>:1167` |
+| 99.9% | 4.31 MiB |       1,292 | `_get_module_details` | `<frozen runpy>:105`                 |
+|  0.1% | 5.66 KiB |           6 | `find_spec`           | `<frozen importlib.util>:73`         |
 
 ##### `_find_and_load` (`<frozen importlib._bootstrap>:1167`)
 
-|      % |     Size | Samples | Callee                    | Location                             |
-| -----: | -------: | ------: | ------------------------- | ------------------------------------ |
-| 100.0% | 4.31 MiB |   1,290 | `_find_and_load_unlocked` | `<frozen importlib._bootstrap>:1122` |
-|  <0.1% |    560 B |       1 | `__enter__`               | `<frozen importlib._bootstrap>:169`  |
+|      % |     Size | Allocations | Callee                    | Location                             |
+| -----: | -------: | ----------: | ------------------------- | ------------------------------------ |
+| 100.0% | 4.31 MiB |       1,290 | `_find_and_load_unlocked` | `<frozen importlib._bootstrap>:1122` |
+|  <0.1% |    560 B |           1 | `__enter__`               | `<frozen importlib._bootstrap>:169`  |
 
 ##### `_find_and_load_unlocked` (`<frozen importlib._bootstrap>:1122`)
 
-|      % |     Size | Samples | Callee                      | Location                             |
-| -----: | -------: | ------: | --------------------------- | ------------------------------------ |
-| 100.0% | 4.31 MiB |   1,289 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`  |
-|   0.8% | 37.2 KiB |      47 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`  |
-|   0.2% | 7.48 KiB |       4 | `_find_spec`                | `<frozen importlib._bootstrap>:1056` |
+|      % |     Size | Allocations | Callee                      | Location                             |
+| -----: | -------: | ----------: | --------------------------- | ------------------------------------ |
+| 100.0% | 4.31 MiB |       1,289 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`  |
+|   0.8% | 37.2 KiB |          47 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`  |
+|   0.2% | 7.48 KiB |           4 | `_find_spec`                | `<frozen importlib._bootstrap>:1056` |
 
 ##### `_load_unlocked` (`<frozen importlib._bootstrap>:666`)
 
-|      % |     Size | Samples | Callee             | Location                                     |
-| -----: | -------: | ------: | ------------------ | -------------------------------------------- |
-| 100.0% | 4.31 MiB |   1,287 | `exec_module`      | `<frozen importlib._bootstrap_external>:934` |
-|  <0.1% | 1.83 KiB |       2 | `module_from_spec` | `<frozen importlib._bootstrap>:566`          |
+|      % |     Size | Allocations | Callee             | Location                                     |
+| -----: | -------: | ----------: | ------------------ | -------------------------------------------- |
+| 100.0% | 4.31 MiB |       1,287 | `exec_module`      | `<frozen importlib._bootstrap_external>:934` |
+|  <0.1% | 1.83 KiB |           2 | `module_from_spec` | `<frozen importlib._bootstrap>:566`          |
 
 ##### `exec_module` (`<frozen importlib._bootstrap_external>:934`)
 
-|     % |     Size | Samples | Callee                      | Location                                      |
-| ----: | -------: | ------: | --------------------------- | --------------------------------------------- |
-| 99.3% | 4.28 MiB |   1,257 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
-| 12.7% |  560 KiB |     606 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
+|     % |     Size | Allocations | Callee                      | Location                                      |
+| ----: | -------: | ----------: | --------------------------- | --------------------------------------------- |
+| 99.3% | 4.28 MiB |       1,257 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
+| 12.7% |  560 KiB |         606 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`)
 
-|      % |     Size | Samples | Callee           | Location                                                 |
-| -----: | -------: | ------: | ---------------- | -------------------------------------------------------- |
-| 100.0% | 4.28 MiB |   1,257 | `<module>`       | `black/__init__.py:1`                                    |
-|  53.8% |  2.3 MiB |     270 | `<module>`       | `black/comments.py:1`                                    |
-|  30.7% | 1.31 MiB |     329 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                     |
-|  30.5% | 1.31 MiB |     304 | `<module>`       | `/venv/lib/python3.11/site-packages/click/__init__.py:1` |
-|  30.1% | 1.29 MiB |     255 | `<module>`       | `black/nodes.py:1`                                       |
+|      % |     Size | Allocations | Callee           | Location                                                 |
+| -----: | -------: | ----------: | ---------------- | -------------------------------------------------------- |
+| 100.0% | 4.28 MiB |       1,257 | `<module>`       | `black/__init__.py:1`                                    |
+|  53.8% |  2.3 MiB |         270 | `<module>`       | `black/comments.py:1`                                    |
+|  30.7% | 1.31 MiB |         329 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                     |
+|  30.5% | 1.31 MiB |         304 | `<module>`       | `/venv/lib/python3.11/site-packages/click/__init__.py:1` |
+|  30.1% | 1.29 MiB |         255 | `<module>`       | `black/nodes.py:1`                                       |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|     % |    Size | Samples | Callee           | Location                             |
-| ----: | ------: | ------: | ---------------- | ------------------------------------ |
-| 99.8% | 1.3 MiB |     303 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |    Size | Allocations | Callee           | Location                             |
+| ----: | ------: | ----------: | ---------------- | ------------------------------------ |
+| 99.8% | 1.3 MiB |         303 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `_handle_fromlist` (`<frozen importlib._bootstrap>:1209`)
 
-|      % |    Size | Samples | Callee                      | Location                            |
-| -----: | ------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 1.3 MiB |     318 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |    Size | Allocations | Callee                      | Location                            |
+| -----: | ------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 1.3 MiB |         318 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|     % |     Size | Samples | Callee             | Location                                               |
-| ----: | -------: | ------: | ------------------ | ------------------------------------------------------ |
-| 85.5% | 1.05 MiB |      53 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167`                   |
-| 11.1% |  140 KiB |     145 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209`                   |
-|  1.1% | 13.9 KiB |       9 | `__new__`          | `<frozen abc>:105`                                     |
-|  0.2% | 2.49 KiB |       3 | `__new__`          | `/usr/lib/python3.11/enum.py:488`                      |
-|  0.1% |    768 B |       1 | `Context`          | `/venv/lib/python3.11/site-packages/click/core.py:204` |
+|     % |     Size | Allocations | Callee             | Location                                               |
+| ----: | -------: | ----------: | ------------------ | ------------------------------------------------------ |
+| 85.5% | 1.05 MiB |          53 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167`                   |
+| 11.1% |  140 KiB |         145 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209`                   |
+|  1.1% | 13.9 KiB |           9 | `__new__`          | `<frozen abc>:105`                                     |
+|  0.2% | 2.49 KiB |           3 | `__new__`          | `/usr/lib/python3.11/enum.py:488`                      |
+|  0.1% |    768 B |           1 | `Context`          | `/venv/lib/python3.11/site-packages/click/core.py:204` |
 
 ##### `compile` (`/usr/lib/python3.11/re/__init__.py:225`)
 
-|     % |     Size | Samples | Callee     | Location                                 |
-| ----: | -------: | ------: | ---------- | ---------------------------------------- |
-| 99.9% | 1.05 MiB |      25 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
+|     % |     Size | Allocations | Callee     | Location                                 |
+| ----: | -------: | ----------: | ---------- | ---------------------------------------- |
+| 99.9% | 1.05 MiB |          25 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
 
 ##### `_compile` (`/usr/lib/python3.11/re/__init__.py:272`)
 
-|     % |     Size | Samples | Callee    | Location                                  |
-| ----: | -------: | ------: | --------- | ----------------------------------------- |
-| 99.9% | 1.05 MiB |      24 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
-|  0.1% |    698 B |       1 | `__and__` | `/usr/lib/python3.11/enum.py:1504`        |
+|     % |     Size | Allocations | Callee    | Location                                  |
+| ----: | -------: | ----------: | --------- | ----------------------------------------- |
+| 99.9% | 1.05 MiB |          24 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
+|  0.1% |    698 B |           1 | `__and__` | `/usr/lib/python3.11/enum.py:1504`        |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|     % |     Size | Samples | Callee  | Location                                  |
-| ----: | -------: | ------: | ------- | ----------------------------------------- |
-| 97.0% | 1.01 MiB |       6 | `parse` | `/usr/lib/python3.11/re/_parser.py:970`   |
-|  0.9% |  9.5 KiB |       6 | `_code` | `/usr/lib/python3.11/re/_compiler.py:571` |
+|     % |     Size | Allocations | Callee  | Location                                  |
+| ----: | -------: | ----------: | ------- | ----------------------------------------- |
+| 97.0% | 1.01 MiB |           6 | `parse` | `/usr/lib/python3.11/re/_parser.py:970`   |
+|  0.9% |  9.5 KiB |           6 | `_code` | `/usr/lib/python3.11/re/_compiler.py:571` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 99.8% | 1.02 MiB |      22 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 99.8% | 1.02 MiB |          22 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `parse` (`/usr/lib/python3.11/re/_parser.py:970`)
 
-|     % |     Size | Samples | Callee       | Location                                |
-| ----: | -------: | ------: | ------------ | --------------------------------------- |
-| 99.9% | 1.01 MiB |       5 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
+|     % |     Size | Allocations | Callee       | Location                                |
+| ----: | -------: | ----------: | ------------ | --------------------------------------- |
+| 99.9% | 1.01 MiB |           5 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|     % |     Size | Samples | Callee           | Location                                 |
-| ----: | -------: | ------: | ---------------- | ---------------------------------------- |
-| 99.7% | 1.01 MiB |      14 | `_process_class` | `/usr/lib/python3.11/dataclasses.py:884` |
+|     % |     Size | Allocations | Callee           | Location                                 |
+| ----: | -------: | ----------: | ---------------- | ---------------------------------------- |
+| 99.7% | 1.01 MiB |          14 | `_process_class` | `/usr/lib/python3.11/dataclasses.py:884` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|     % |     Size | Samples | Callee   | Location                                |
-| ----: | -------: | ------: | -------- | --------------------------------------- |
-| 99.2% | 1.01 MiB |       4 | `_parse` | `/usr/lib/python3.11/re/_parser.py:507` |
+|     % |     Size | Allocations | Callee   | Location                                |
+| ----: | -------: | ----------: | -------- | --------------------------------------- |
+| 99.2% | 1.01 MiB |           4 | `_parse` | `/usr/lib/python3.11/re/_parser.py:507` |
 
 ##### `_process_class` (`/usr/lib/python3.11/dataclasses.py:884`)
 
-|     % |    Size | Samples | Callee               | Location                                 |
-| ----: | ------: | ------: | -------------------- | ---------------------------------------- |
-| 98.9% |   1 MiB |       1 | `_init_fn`           | `/usr/lib/python3.11/dataclasses.py:528` |
-|  0.6% | 6.5 KiB |       5 | `signature`          | `/usr/lib/python3.11/inspect.py:3277`    |
-|  0.1% | 1.5 KiB |       2 | `_set_new_attribute` | `/usr/lib/python3.11/dataclasses.py:827` |
-| <0.1% |   341 B |       1 | `_cmp_fn`            | `/usr/lib/python3.11/dataclasses.py:624` |
-| <0.1% |   336 B |       1 | `_repr_fn`           | `/usr/lib/python3.11/dataclasses.py:588` |
+|     % |    Size | Allocations | Callee               | Location                                 |
+| ----: | ------: | ----------: | -------------------- | ---------------------------------------- |
+| 98.9% |   1 MiB |           1 | `_init_fn`           | `/usr/lib/python3.11/dataclasses.py:528` |
+|  0.6% | 6.5 KiB |           5 | `signature`          | `/usr/lib/python3.11/inspect.py:3277`    |
+|  0.1% | 1.5 KiB |           2 | `_set_new_attribute` | `/usr/lib/python3.11/dataclasses.py:827` |
+| <0.1% |   341 B |           1 | `_cmp_fn`            | `/usr/lib/python3.11/dataclasses.py:624` |
+| <0.1% |   336 B |           1 | `_repr_fn`           | `/usr/lib/python3.11/dataclasses.py:588` |
 
 ##### `dataclass` (`/usr/lib/python3.11/dataclasses.py:1192`)
 
-|      % |     Size | Samples | Callee | Location                                  |
-| -----: | -------: | ------: | ------ | ----------------------------------------- |
-| 100.0% | 1.01 MiB |      11 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
+|      % |     Size | Allocations | Callee | Location                                  |
+| -----: | -------: | ----------: | ------ | ----------------------------------------- |
+| 100.0% | 1.01 MiB |          11 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|     % |  Size | Samples | Callee        | Location                                |
-| ----: | ----: | ------: | ------------- | --------------------------------------- |
-| 99.6% | 1 MiB |       2 | `_parse_sub`  | `/usr/lib/python3.11/re/_parser.py:447` |
-| 99.5% | 1 MiB |       1 | `__getitem__` | `/usr/lib/python3.11/re/_parser.py:162` |
+|     % |  Size | Allocations | Callee        | Location                                |
+| ----: | ----: | ----------: | ------------- | --------------------------------------- |
+| 99.6% | 1 MiB |           2 | `_parse_sub`  | `/usr/lib/python3.11/re/_parser.py:447` |
+| 99.5% | 1 MiB |           1 | `__getitem__` | `/usr/lib/python3.11/re/_parser.py:162` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                                                         |
-| ----: | -------: | ------: | ---------------- | ---------------------------------------------------------------- |
-| 90.2% |  156 KiB |     130 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                             |
-|  4.9% |  8.5 KiB |       2 | `Specifier`      | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220` |
-|  3.5% | 6.07 KiB |       7 | `__new__`        | `<frozen abc>:105`                                               |
+|     % |     Size | Allocations | Callee           | Location                                                         |
+| ----: | -------: | ----------: | ---------------- | ---------------------------------------------------------------- |
+| 90.2% |  156 KiB |         130 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                             |
+|  4.9% |  8.5 KiB |           2 | `Specifier`      | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220` |
+|  3.5% | 6.07 KiB |           7 | `__new__`        | `<frozen abc>:105`                                               |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 53.0% | 66.2 KiB |      58 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
-| 30.6% | 38.2 KiB |      45 | `__new__`        | `<frozen abc>:105`                   |
-| 12.6% | 15.7 KiB |      19 | `__new__`        | `/usr/lib/python3.11/typing.py:2891` |
-|  1.1% | 1.42 KiB |       2 | `inner`          | `/usr/lib/python3.11/typing.py:338`  |
-|  0.4% |    542 B |       1 | `__init__`       | `/usr/lib/python3.11/typing.py:992`  |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 53.0% | 66.2 KiB |          58 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+| 30.6% | 38.2 KiB |          45 | `__new__`        | `<frozen abc>:105`                   |
+| 12.6% | 15.7 KiB |          19 | `__new__`        | `/usr/lib/python3.11/typing.py:2891` |
+|  1.1% | 1.42 KiB |           2 | `inner`          | `/usr/lib/python3.11/typing.py:338`  |
+|  0.4% |    542 B |           1 | `__init__`       | `/usr/lib/python3.11/typing.py:992`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 96.4% | 96.1 KiB |      68 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 96.4% | 96.1 KiB |          68 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 99.2% | 93.1 KiB |     118 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 99.2% | 93.1 KiB |         118 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`)
 
-|     % |   Size | Samples | Callee           | Location                             |
-| ----: | -----: | ------: | ---------------- | ------------------------------------ |
-| 97.3% | 89 KiB |     112 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |   Size | Allocations | Callee           | Location                             |
+| ----: | -----: | ----------: | ---------------- | ------------------------------------ |
+| 97.3% | 89 KiB |         112 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|     % |     Size | Samples | Callee             | Location                             |
-| ----: | -------: | ------: | ------------------ | ------------------------------------ |
-| 22.4% | 16.7 KiB |      17 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167` |
-| 21.2% | 15.8 KiB |      19 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209` |
+|     % |     Size | Allocations | Callee             | Location                             |
+| ----: | -------: | ----------: | ------------------ | ------------------------------------ |
+| 22.4% | 16.7 KiB |          17 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167` |
+| 21.2% | 15.8 KiB |          19 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 98.9% | 64.8 KiB |      83 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 98.9% | 64.8 KiB |          83 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `decorator` (`/venv/lib/python3.11/site-packages/click/decorators.py:373`)
 
-|     % |     Size | Samples | Callee     | Location                                                |
-| ----: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 96.2% | 45.5 KiB |      32 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2883` |
+|     % |     Size | Allocations | Callee     | Location                                                |
+| ----: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 96.2% | 45.5 KiB |          32 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2883` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 94.8% | 44.5 KiB |      56 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 94.8% | 44.5 KiB |          56 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|    % |     Size | Samples | Callee     | Location                                                |
-| ---: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 2.6% | 1.17 KiB |       1 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2237` |
+|    % |     Size | Allocations | Callee     | Location                                                |
+| ---: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 2.6% | 1.17 KiB |           1 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2237` |
 
 ## Hottest call stacks
 
@@ -1447,38 +1447,38 @@ Call stacks ranked by bytes held at peak memory in their leaf frame.
 
 Common call stack: `run_module` (`<frozen runpy>:201`) ← `_run_tracker` (`/venv/lib/python3.11/site-packages/memray/commands/run.py:40`)
 
-|     % |     Size | Samples | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| ----: | -------: | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 11.6% | 9.12 MiB |     142 | `parse` (`/usr/lib/python3.11/ast.py:33`) ← `_parse_single_version` (`black/parsing.py:117`) ← `parse_ast` (129) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-|  9.0% |  7.1 MiB |       4 | `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-|  6.4% |    5 MiB |       5 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `shift` (`blib2to3/pgen2/parse.py:373`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-|  3.8% |    3 MiB |       3 | `push` (`blib2to3/pgen2/parse.py:386`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-|  2.6% | 2.03 MiB |      38 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-|  2.5% |    2 MiB |       2 | `_stringify_ast_with_new_parent` (`black/parsing.py:166`) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-|  2.5% |    2 MiB |       2 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-|  2.5% |    2 MiB |       2 | `_stringify_ast` (`black/parsing.py:174`) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-|  1.4% | 1.09 MiB |     125 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-|  1.3% | 1.01 MiB |      11 | `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-|  1.3% |    1 MiB |       5 | `__init__` (`blib2to3/pytree.py:248`) ← `convert` (486) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-|  1.3% |    1 MiB |       1 | `_stringify_ast` (`black/parsing.py:174`) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-|  1.3% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-|  1.3% |    1 MiB |       1 | `_create_fn` (`/usr/lib/python3.11/dataclasses.py:413`) ← `_init_fn` (528) ← `_process_class` (884) ← `wrap` (1209) ← `dataclass` (1192) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-|  1.3% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-|  1.3% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-|  1.3% |    1 MiB |       1 | `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-|  1.3% |    1 MiB |       1 | `_stringify_ast` (`black/parsing.py:174`) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-|  1.3% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_factor` (379) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                               |
-|  1.3% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
+|     % |     Size | Allocations | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ----: | -------: | ----------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 11.6% | 9.12 MiB |         142 | `parse` (`/usr/lib/python3.11/ast.py:33`) ← `_parse_single_version` (`black/parsing.py:117`) ← `parse_ast` (129) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+|  9.0% |  7.1 MiB |           4 | `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+|  6.4% |    5 MiB |           5 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `shift` (`blib2to3/pgen2/parse.py:373`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+|  3.8% |    3 MiB |           3 | `push` (`blib2to3/pgen2/parse.py:386`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+|  2.6% | 2.03 MiB |          38 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+|  2.5% |    2 MiB |           2 | `_stringify_ast_with_new_parent` (`black/parsing.py:166`) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+|  2.5% |    2 MiB |           2 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+|  2.5% |    2 MiB |           2 | `_stringify_ast` (`black/parsing.py:174`) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+|  1.4% | 1.09 MiB |         125 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+|  1.3% | 1.01 MiB |          11 | `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+|  1.3% |    1 MiB |           5 | `__init__` (`blib2to3/pytree.py:248`) ← `convert` (486) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+|  1.3% |    1 MiB |           1 | `_stringify_ast` (`black/parsing.py:174`) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+|  1.3% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+|  1.3% |    1 MiB |           1 | `_create_fn` (`/usr/lib/python3.11/dataclasses.py:413`) ← `_init_fn` (528) ← `_process_class` (884) ← `wrap` (1209) ← `dataclass` (1192) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+|  1.3% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+|  1.3% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+|  1.3% |    1 MiB |           1 | `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+|  1.3% |    1 MiB |           1 | `_stringify_ast` (`black/parsing.py:174`) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+|  1.3% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_factor` (379) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                               |
+|  1.3% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
 
 # Leaked memory profile
 
-Leaked 55.9 MiB over 22,489 samples (2.55 KiB per sample).
+Leaked 55.9 MiB over 22,489 allocations (2.55 KiB per allocation).
 
-| Category         |     % |     Size | Samples |
-| ---------------- | ----: | -------: | ------: |
-| Ours             | 85.6% | 47.9 MiB |  21,383 |
-| Standard library | 12.2% | 6.83 MiB |     876 |
-| Third-party      |  2.2% | 1.23 MiB |     230 |
+| Category         |     % |     Size | Allocations |
+| ---------------- | ----: | -------: | ----------: |
+| Ours             | 85.6% | 47.9 MiB |      21,383 |
+| Standard library | 12.2% | 6.83 MiB |         876 |
+| Third-party      |  2.2% | 1.23 MiB |         230 |
 
 ## Hottest functions
 
@@ -1486,105 +1486,105 @@ Leaked 55.9 MiB over 22,489 samples (2.55 KiB per sample).
 
 Functions ranked by bytes never freed directly in the function body, excluding callees.
 
-|     % |     Size | Samples | Function                  | Location                                               |
-| ----: | -------: | ------: | ------------------------- | ------------------------------------------------------ |
-| 30.8% | 17.2 MiB |  20,789 | `mark`                    | `black/brackets.py:70`                                 |
-| 11.0% | 6.14 MiB |     201 | `update_sibling_maps`     | `blib2to3/pytree.py:369`                               |
-| 10.7% |    6 MiB |       6 | `changed`                 | `blib2to3/pytree.py:171`                               |
-| 10.7% |    6 MiB |       6 | `__new__`                 | `blib2to3/pytree.py:81`                                |
-|  5.4% | 3.01 MiB |       4 | `parse`                   | `/usr/lib/python3.11/ast.py:33`                        |
-|  5.4% |    3 MiB |       3 | `generate_comments`       | `black/comments.py:52`                                 |
-|  5.4% |    3 MiB |       3 | `push`                    | `blib2to3/pgen2/parse.py:386`                          |
-|  3.6% |    2 MiB |       2 | `prefix`                  | `blib2to3/pytree.py:480`                               |
-|  1.8% | 1.01 MiB |      11 | `<module>`                | `/venv/lib/python3.11/site-packages/click/parser.py:1` |
-|  1.8% |    1 MiB |       5 | `visit`                   | `black/nodes.py:163`                                   |
-|  1.8% |    1 MiB |       5 | `__init__`                | `blib2to3/pytree.py:248`                               |
-|  1.8% |    1 MiB |       3 | `_create_fn`              | `/usr/lib/python3.11/dataclasses.py:413`               |
-|  1.8% |    1 MiB |       1 | `_stringify_ast`          | `black/parsing.py:174`                                 |
-|  1.8% |    1 MiB |       1 | `debug`                   | `/usr/lib/python3.11/logging/__init__.py:1467`         |
-|  1.8% |    1 MiB |       1 | `generate_tokens`         | `blib2to3/pgen2/tokenize.py:565`                       |
-|  1.8% |    1 MiB |       1 | `__getitem__`             | `/usr/lib/python3.11/re/_parser.py:162`                |
-|  1.0% |  560 KiB |     606 | `_compile_bytecode`       | `<frozen importlib._bootstrap_external>:727`           |
-|  0.1% | 76.5 KiB |       6 | `transform_line`          | `black/linegen.py:601`                                 |
-|  0.1% | 75.7 KiB |      79 | `__new__`                 | `<frozen abc>:105`                                     |
-|  0.1% | 57.2 KiB |      65 | `normalize_string_prefix` | `black/strings.py:143`                                 |
+|     % |     Size | Allocations | Function                  | Location                                               |
+| ----: | -------: | ----------: | ------------------------- | ------------------------------------------------------ |
+| 30.8% | 17.2 MiB |      20,789 | `mark`                    | `black/brackets.py:70`                                 |
+| 11.0% | 6.14 MiB |         201 | `update_sibling_maps`     | `blib2to3/pytree.py:369`                               |
+| 10.7% |    6 MiB |           6 | `changed`                 | `blib2to3/pytree.py:171`                               |
+| 10.7% |    6 MiB |           6 | `__new__`                 | `blib2to3/pytree.py:81`                                |
+|  5.4% | 3.01 MiB |           4 | `parse`                   | `/usr/lib/python3.11/ast.py:33`                        |
+|  5.4% |    3 MiB |           3 | `generate_comments`       | `black/comments.py:52`                                 |
+|  5.4% |    3 MiB |           3 | `push`                    | `blib2to3/pgen2/parse.py:386`                          |
+|  3.6% |    2 MiB |           2 | `prefix`                  | `blib2to3/pytree.py:480`                               |
+|  1.8% | 1.01 MiB |          11 | `<module>`                | `/venv/lib/python3.11/site-packages/click/parser.py:1` |
+|  1.8% |    1 MiB |           5 | `visit`                   | `black/nodes.py:163`                                   |
+|  1.8% |    1 MiB |           5 | `__init__`                | `blib2to3/pytree.py:248`                               |
+|  1.8% |    1 MiB |           3 | `_create_fn`              | `/usr/lib/python3.11/dataclasses.py:413`               |
+|  1.8% |    1 MiB |           1 | `_stringify_ast`          | `black/parsing.py:174`                                 |
+|  1.8% |    1 MiB |           1 | `debug`                   | `/usr/lib/python3.11/logging/__init__.py:1467`         |
+|  1.8% |    1 MiB |           1 | `generate_tokens`         | `blib2to3/pgen2/tokenize.py:565`                       |
+|  1.8% |    1 MiB |           1 | `__getitem__`             | `/usr/lib/python3.11/re/_parser.py:162`                |
+|  1.0% |  560 KiB |         606 | `_compile_bytecode`       | `<frozen importlib._bootstrap_external>:727`           |
+|  0.1% | 76.5 KiB |           6 | `transform_line`          | `black/linegen.py:601`                                 |
+|  0.1% | 75.7 KiB |          79 | `__new__`                 | `<frozen abc>:105`                                     |
+|  0.1% | 57.2 KiB |          65 | `normalize_string_prefix` | `black/strings.py:143`                                 |
 
 #### Categories
 
 ##### Ours
 
-|     % |     Size | Samples | Function                   | Location                         |
-| ----: | -------: | ------: | -------------------------- | -------------------------------- |
-| 30.8% | 17.2 MiB |  20,789 | `mark`                     | `black/brackets.py:70`           |
-| 11.0% | 6.14 MiB |     201 | `update_sibling_maps`      | `blib2to3/pytree.py:369`         |
-| 10.7% |    6 MiB |       6 | `changed`                  | `blib2to3/pytree.py:171`         |
-| 10.7% |    6 MiB |       6 | `__new__`                  | `blib2to3/pytree.py:81`          |
-|  5.4% |    3 MiB |       3 | `generate_comments`        | `black/comments.py:52`           |
-|  5.4% |    3 MiB |       3 | `push`                     | `blib2to3/pgen2/parse.py:386`    |
-|  3.6% |    2 MiB |       2 | `prefix`                   | `blib2to3/pytree.py:480`         |
-|  1.8% |    1 MiB |       5 | `visit`                    | `black/nodes.py:163`             |
-|  1.8% |    1 MiB |       5 | `__init__`                 | `blib2to3/pytree.py:248`         |
-|  1.8% |    1 MiB |       1 | `_stringify_ast`           | `black/parsing.py:174`           |
-|  1.8% |    1 MiB |       1 | `generate_tokens`          | `blib2to3/pgen2/tokenize.py:565` |
-|  0.1% | 76.5 KiB |       6 | `transform_line`           | `black/linegen.py:601`           |
-|  0.1% | 57.2 KiB |      65 | `normalize_string_prefix`  | `black/strings.py:143`           |
-|  0.1% | 41.5 KiB |      16 | `copy`                     | `blib2to3/pgen2/grammar.py:131`  |
-|  0.1% |   32 KiB |       1 | `classify`                 | `blib2to3/pgen2/parse.py:336`    |
-| <0.1% | 25.3 KiB |      40 | `make_first`               | `blib2to3/pgen2/pgen.py:74`      |
-| <0.1% | 20.7 KiB |      14 | `<module>`                 | `blib2to3/pgen2/tokenize.py:1`   |
-| <0.1% | 18.6 KiB |       2 | `convert_one_fmt_off_pair` | `black/comments.py:177`          |
-| <0.1% |   15 KiB |      18 | `<module>`                 | `blib2to3/pytree.py:1`           |
-| <0.1% | 14.2 KiB |       5 | `make_grammar`             | `blib2to3/pgen2/pgen.py:49`      |
+|     % |     Size | Allocations | Function                   | Location                         |
+| ----: | -------: | ----------: | -------------------------- | -------------------------------- |
+| 30.8% | 17.2 MiB |      20,789 | `mark`                     | `black/brackets.py:70`           |
+| 11.0% | 6.14 MiB |         201 | `update_sibling_maps`      | `blib2to3/pytree.py:369`         |
+| 10.7% |    6 MiB |           6 | `changed`                  | `blib2to3/pytree.py:171`         |
+| 10.7% |    6 MiB |           6 | `__new__`                  | `blib2to3/pytree.py:81`          |
+|  5.4% |    3 MiB |           3 | `generate_comments`        | `black/comments.py:52`           |
+|  5.4% |    3 MiB |           3 | `push`                     | `blib2to3/pgen2/parse.py:386`    |
+|  3.6% |    2 MiB |           2 | `prefix`                   | `blib2to3/pytree.py:480`         |
+|  1.8% |    1 MiB |           5 | `visit`                    | `black/nodes.py:163`             |
+|  1.8% |    1 MiB |           5 | `__init__`                 | `blib2to3/pytree.py:248`         |
+|  1.8% |    1 MiB |           1 | `_stringify_ast`           | `black/parsing.py:174`           |
+|  1.8% |    1 MiB |           1 | `generate_tokens`          | `blib2to3/pgen2/tokenize.py:565` |
+|  0.1% | 76.5 KiB |           6 | `transform_line`           | `black/linegen.py:601`           |
+|  0.1% | 57.2 KiB |          65 | `normalize_string_prefix`  | `black/strings.py:143`           |
+|  0.1% | 41.5 KiB |          16 | `copy`                     | `blib2to3/pgen2/grammar.py:131`  |
+|  0.1% |   32 KiB |           1 | `classify`                 | `blib2to3/pgen2/parse.py:336`    |
+| <0.1% | 25.3 KiB |          40 | `make_first`               | `blib2to3/pgen2/pgen.py:74`      |
+| <0.1% | 20.7 KiB |          14 | `<module>`                 | `blib2to3/pgen2/tokenize.py:1`   |
+| <0.1% | 18.6 KiB |           2 | `convert_one_fmt_off_pair` | `black/comments.py:177`          |
+| <0.1% |   15 KiB |          18 | `<module>`                 | `blib2to3/pytree.py:1`           |
+| <0.1% | 14.2 KiB |           5 | `make_grammar`             | `blib2to3/pgen2/pgen.py:49`      |
 
 ##### Standard library
 
-|     % |     Size | Samples | Function            | Location                                          |
-| ----: | -------: | ------: | ------------------- | ------------------------------------------------- |
-|  5.4% | 3.01 MiB |       4 | `parse`             | `/usr/lib/python3.11/ast.py:33`                   |
-|  1.8% |    1 MiB |       3 | `_create_fn`        | `/usr/lib/python3.11/dataclasses.py:413`          |
-|  1.8% |    1 MiB |       1 | `debug`             | `/usr/lib/python3.11/logging/__init__.py:1467`    |
-|  1.8% |    1 MiB |       1 | `__getitem__`       | `/usr/lib/python3.11/re/_parser.py:162`           |
-|  1.0% |  560 KiB |     606 | `_compile_bytecode` | `<frozen importlib._bootstrap_external>:727`      |
-|  0.1% | 75.7 KiB |      79 | `__new__`           | `<frozen abc>:105`                                |
-| <0.1% | 24.1 KiB |      27 | `__new__`           | `/usr/lib/python3.11/enum.py:488`                 |
-| <0.1% | 22.6 KiB |      12 | `compile`           | `/usr/lib/python3.11/re/_compiler.py:738`         |
-| <0.1% | 19.8 KiB |      12 | `<module>`          | `/usr/lib/python3.11/tomllib/_parser.py:1`        |
-| <0.1% | 17.4 KiB |      21 | `__new__`           | `/usr/lib/python3.11/typing.py:2891`              |
-| <0.1% |   12 KiB |       3 | `inner`             | `/usr/lib/python3.11/typing.py:338`               |
-| <0.1% |    8 KiB |       4 | `_fill_cache`       | `<frozen importlib._bootstrap_external>:1655`     |
-| <0.1% | 7.97 KiB |       1 | `_parse_sub`        | `/usr/lib/python3.11/re/_parser.py:447`           |
-| <0.1% | 6.73 KiB |       8 | `__setattr__`       | `/usr/lib/python3.11/enum.py:831`                 |
-| <0.1% | 5.63 KiB |       6 | `namedtuple`        | `/usr/lib/python3.11/collections/__init__.py:348` |
-| <0.1% | 5.61 KiB |       3 | `_parse`            | `/usr/lib/python3.11/re/_parser.py:507`           |
-| <0.1% | 5.32 KiB |       2 | `_code`             | `/usr/lib/python3.11/re/_compiler.py:571`         |
-| <0.1% | 4.73 KiB |       6 | `<module>`          | `/usr/lib/python3.11/pkgutil.py:1`                |
-| <0.1% | 2.85 KiB |       1 | `wrap`              | `/usr/lib/python3.11/dataclasses.py:1209`         |
-| <0.1% | 2.85 KiB |       4 | `_process_class`    | `/usr/lib/python3.11/dataclasses.py:884`          |
+|     % |     Size | Allocations | Function            | Location                                          |
+| ----: | -------: | ----------: | ------------------- | ------------------------------------------------- |
+|  5.4% | 3.01 MiB |           4 | `parse`             | `/usr/lib/python3.11/ast.py:33`                   |
+|  1.8% |    1 MiB |           3 | `_create_fn`        | `/usr/lib/python3.11/dataclasses.py:413`          |
+|  1.8% |    1 MiB |           1 | `debug`             | `/usr/lib/python3.11/logging/__init__.py:1467`    |
+|  1.8% |    1 MiB |           1 | `__getitem__`       | `/usr/lib/python3.11/re/_parser.py:162`           |
+|  1.0% |  560 KiB |         606 | `_compile_bytecode` | `<frozen importlib._bootstrap_external>:727`      |
+|  0.1% | 75.7 KiB |          79 | `__new__`           | `<frozen abc>:105`                                |
+| <0.1% | 24.1 KiB |          27 | `__new__`           | `/usr/lib/python3.11/enum.py:488`                 |
+| <0.1% | 22.6 KiB |          12 | `compile`           | `/usr/lib/python3.11/re/_compiler.py:738`         |
+| <0.1% | 19.8 KiB |          12 | `<module>`          | `/usr/lib/python3.11/tomllib/_parser.py:1`        |
+| <0.1% | 17.4 KiB |          21 | `__new__`           | `/usr/lib/python3.11/typing.py:2891`              |
+| <0.1% |   12 KiB |           3 | `inner`             | `/usr/lib/python3.11/typing.py:338`               |
+| <0.1% |    8 KiB |           4 | `_fill_cache`       | `<frozen importlib._bootstrap_external>:1655`     |
+| <0.1% | 7.97 KiB |           1 | `_parse_sub`        | `/usr/lib/python3.11/re/_parser.py:447`           |
+| <0.1% | 6.73 KiB |           8 | `__setattr__`       | `/usr/lib/python3.11/enum.py:831`                 |
+| <0.1% | 5.63 KiB |           6 | `namedtuple`        | `/usr/lib/python3.11/collections/__init__.py:348` |
+| <0.1% | 5.61 KiB |           3 | `_parse`            | `/usr/lib/python3.11/re/_parser.py:507`           |
+| <0.1% | 5.32 KiB |           2 | `_code`             | `/usr/lib/python3.11/re/_compiler.py:571`         |
+| <0.1% | 4.73 KiB |           6 | `<module>`          | `/usr/lib/python3.11/pkgutil.py:1`                |
+| <0.1% | 2.85 KiB |           1 | `wrap`              | `/usr/lib/python3.11/dataclasses.py:1209`         |
+| <0.1% | 2.85 KiB |           4 | `_process_class`    | `/usr/lib/python3.11/dataclasses.py:884`          |
 
 ##### Third-party
 
-|     % |     Size | Samples | Function              | Location                                                                   |
-| ----: | -------: | ------: | --------------------- | -------------------------------------------------------------------------- |
-|  1.8% | 1.01 MiB |      11 | `<module>`            | `/venv/lib/python3.11/site-packages/click/parser.py:1`                     |
-|  0.1% | 44.3 KiB |      31 | `__init__`            | `/venv/lib/python3.11/site-packages/click/core.py:2883`                    |
-| <0.1% |   25 KiB |      22 | `<module>`            | `/venv/lib/python3.11/site-packages/click/core.py:1`                       |
-| <0.1% |   15 KiB |      18 | `<module>`            | `/venv/lib/python3.11/site-packages/mypy_extensions.py:1`                  |
-| <0.1% | 13.4 KiB |      15 | `<module>`            | `/venv/lib/python3.11/site-packages/click/exceptions.py:1`                 |
-| <0.1% | 9.61 KiB |       9 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/version.py:1`                |
-| <0.1% | 7.08 KiB |       8 | `<module>`            | `/venv/lib/python3.11/site-packages/click/utils.py:1`                      |
-| <0.1% | 6.48 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/util.py:1`                    |
-| <0.1% | 6.24 KiB |       5 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                |
-| <0.1% | 5.97 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                   |
-| <0.1% |  5.8 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/click/_compat.py:1`                    |
-| <0.1% | 3.82 KiB |       1 | `Specifier`           | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`           |
-| <0.1% | 3.72 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`                 |
-| <0.1% | 3.56 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                  |
-| <0.1% | 3.37 KiB |       5 | `handle_parse_result` | `/venv/lib/python3.11/site-packages/click/core.py:2663`                    |
-| <0.1% | 3.19 KiB |       1 | `<module>`            | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                   |
-| <0.1% | 3.19 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`                |
-| <0.1% | 3.04 KiB |       2 | `new_func`            | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                |
-| <0.1% | 2.81 KiB |       3 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1` |
-| <0.1% | 2.76 KiB |       2 | `<module>`            | `/venv/lib/python3.11/site-packages/click/types.py:1`                      |
+|     % |     Size | Allocations | Function              | Location                                                                   |
+| ----: | -------: | ----------: | --------------------- | -------------------------------------------------------------------------- |
+|  1.8% | 1.01 MiB |          11 | `<module>`            | `/venv/lib/python3.11/site-packages/click/parser.py:1`                     |
+|  0.1% | 44.3 KiB |          31 | `__init__`            | `/venv/lib/python3.11/site-packages/click/core.py:2883`                    |
+| <0.1% |   25 KiB |          22 | `<module>`            | `/venv/lib/python3.11/site-packages/click/core.py:1`                       |
+| <0.1% |   15 KiB |          18 | `<module>`            | `/venv/lib/python3.11/site-packages/mypy_extensions.py:1`                  |
+| <0.1% | 13.4 KiB |          15 | `<module>`            | `/venv/lib/python3.11/site-packages/click/exceptions.py:1`                 |
+| <0.1% | 9.61 KiB |           9 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/version.py:1`                |
+| <0.1% | 7.08 KiB |           8 | `<module>`            | `/venv/lib/python3.11/site-packages/click/utils.py:1`                      |
+| <0.1% | 6.48 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/util.py:1`                    |
+| <0.1% | 6.24 KiB |           5 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                |
+| <0.1% | 5.97 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                   |
+| <0.1% |  5.8 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/click/_compat.py:1`                    |
+| <0.1% | 3.82 KiB |           1 | `Specifier`           | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`           |
+| <0.1% | 3.72 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`                 |
+| <0.1% | 3.56 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                  |
+| <0.1% | 3.37 KiB |           5 | `handle_parse_result` | `/venv/lib/python3.11/site-packages/click/core.py:2663`                    |
+| <0.1% | 3.19 KiB |           1 | `<module>`            | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                   |
+| <0.1% | 3.19 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`                |
+| <0.1% | 3.04 KiB |           2 | `new_func`            | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                |
+| <0.1% | 2.81 KiB |           3 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1` |
+| <0.1% | 2.76 KiB |           2 | `<module>`            | `/venv/lib/python3.11/site-packages/click/types.py:1`                      |
 
 #### Lines
 
@@ -1592,451 +1592,451 @@ Lines ranked by contribution to each function's self size.
 
 ##### `mark` (`black/brackets.py:70`)
 
-|      % |     Size | Samples | Location                |
-| -----: | -------: | ------: | ----------------------- |
-| 100.0% | 17.2 MiB |  20,788 | `black/brackets.py:112` |
-|  <0.1% | 1.49 KiB |       1 | `black/brackets.py:114` |
+|      % |     Size | Allocations | Location                |
+| -----: | -------: | ----------: | ----------------------- |
+| 100.0% | 17.2 MiB |      20,788 | `black/brackets.py:112` |
+|  <0.1% | 1.49 KiB |           1 | `black/brackets.py:114` |
 
 ##### `update_sibling_maps` (`blib2to3/pytree.py:369`)
 
-|     % |     Size | Samples | Location                 |
-| ----: | -------: | ------: | ------------------------ |
-| 50.0% | 3.07 MiB |      96 | `blib2to3/pytree.py:377` |
-| 33.7% | 2.07 MiB |      95 | `blib2to3/pytree.py:376` |
-| 16.3% |    1 MiB |       1 | `blib2to3/pytree.py:370` |
-|  0.1% | 4.99 KiB |       9 | `blib2to3/pytree.py:379` |
+|     % |     Size | Allocations | Location                 |
+| ----: | -------: | ----------: | ------------------------ |
+| 50.0% | 3.07 MiB |          96 | `blib2to3/pytree.py:377` |
+| 33.7% | 2.07 MiB |          95 | `blib2to3/pytree.py:376` |
+| 16.3% |    1 MiB |           1 | `blib2to3/pytree.py:370` |
+|  0.1% | 4.99 KiB |           9 | `blib2to3/pytree.py:379` |
 
 ##### `changed` (`blib2to3/pytree.py:171`)
 
-|     % |  Size | Samples | Location                 |
-| ----: | ----: | ------: | ------------------------ |
-| 83.3% | 5 MiB |       5 | `blib2to3/pytree.py:176` |
-| 16.7% | 1 MiB |       1 | `blib2to3/pytree.py:175` |
+|     % |  Size | Allocations | Location                 |
+| ----: | ----: | ----------: | ------------------------ |
+| 83.3% | 5 MiB |           5 | `blib2to3/pytree.py:176` |
+| 16.7% | 1 MiB |           1 | `blib2to3/pytree.py:175` |
 
 ##### `__new__` (`blib2to3/pytree.py:81`)
 
-|      % |  Size | Samples | Location                |
-| -----: | ----: | ------: | ----------------------- |
-| 100.0% | 6 MiB |       6 | `blib2to3/pytree.py:84` |
+|      % |  Size | Allocations | Location                |
+| -----: | ----: | ----------: | ----------------------- |
+| 100.0% | 6 MiB |           6 | `blib2to3/pytree.py:84` |
 
 ##### `parse` (`/usr/lib/python3.11/ast.py:33`)
 
-|      % |     Size | Samples | Location                        |
-| -----: | -------: | ------: | ------------------------------- |
-| 100.0% | 3.01 MiB |       4 | `/usr/lib/python3.11/ast.py:50` |
+|      % |     Size | Allocations | Location                        |
+| -----: | -------: | ----------: | ------------------------------- |
+| 100.0% | 3.01 MiB |           4 | `/usr/lib/python3.11/ast.py:50` |
 
 ##### `generate_comments` (`black/comments.py:52`)
 
-|      % |  Size | Samples | Location               |
-| -----: | ----: | ------: | ---------------------- |
-| 100.0% | 3 MiB |       3 | `black/comments.py:76` |
+|      % |  Size | Allocations | Location               |
+| -----: | ----: | ----------: | ---------------------- |
+| 100.0% | 3 MiB |           3 | `black/comments.py:76` |
 
 ##### `push` (`blib2to3/pgen2/parse.py:386`)
 
-|      % |  Size | Samples | Location                      |
-| -----: | ----: | ------: | ----------------------------- |
-| 100.0% | 3 MiB |       3 | `blib2to3/pgen2/parse.py:394` |
+|      % |  Size | Allocations | Location                      |
+| -----: | ----: | ----------: | ----------------------------- |
+| 100.0% | 3 MiB |           3 | `blib2to3/pgen2/parse.py:394` |
 
 ##### `prefix` (`blib2to3/pytree.py:480`)
 
-|      % |  Size | Samples | Location                 |
-| -----: | ----: | ------: | ------------------------ |
-| 100.0% | 2 MiB |       2 | `blib2to3/pytree.py:482` |
+|      % |  Size | Allocations | Location                 |
+| -----: | ----: | ----------: | ------------------------ |
+| 100.0% | 2 MiB |           2 | `blib2to3/pytree.py:482` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`)
 
-|     % |     Size | Samples | Location                                                 |
-| ----: | -------: | ------: | -------------------------------------------------------- |
-| 99.4% |    1 MiB |       3 | `/venv/lib/python3.11/site-packages/click/parser.py:185` |
-|  0.2% | 2.29 KiB |       3 | `/venv/lib/python3.11/site-packages/click/parser.py:224` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:127` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:216` |
-|  0.1% |    768 B |       1 | `/venv/lib/python3.11/site-packages/click/parser.py:51`  |
+|     % |     Size | Allocations | Location                                                 |
+| ----: | -------: | ----------: | -------------------------------------------------------- |
+| 99.4% |    1 MiB |           3 | `/venv/lib/python3.11/site-packages/click/parser.py:185` |
+|  0.2% | 2.29 KiB |           3 | `/venv/lib/python3.11/site-packages/click/parser.py:224` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:127` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:216` |
+|  0.1% |    768 B |           1 | `/venv/lib/python3.11/site-packages/click/parser.py:51`  |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|     % |     Size | Samples | Location             |
-| ----: | -------: | ------: | -------------------- |
-| 99.7% |    1 MiB |       1 | `black/nodes.py:181` |
-|  0.3% | 2.68 KiB |       3 | `black/nodes.py:183` |
-|  0.1% |    690 B |       1 | `black/nodes.py:185` |
+|     % |     Size | Allocations | Location             |
+| ----: | -------: | ----------: | -------------------- |
+| 99.7% |    1 MiB |           1 | `black/nodes.py:181` |
+|  0.3% | 2.68 KiB |           3 | `black/nodes.py:183` |
+|  0.1% |    690 B |           1 | `black/nodes.py:185` |
 
 ##### `__init__` (`blib2to3/pytree.py:248`)
 
-|      % |  Size | Samples | Location                 |
-| -----: | ----: | ------: | ------------------------ |
-| 100.0% | 1 MiB |       5 | `blib2to3/pytree.py:266` |
+|      % |  Size | Allocations | Location                 |
+| -----: | ----: | ----------: | ------------------------ |
+| 100.0% | 1 MiB |           5 | `blib2to3/pytree.py:266` |
 
 ##### `_create_fn` (`/usr/lib/python3.11/dataclasses.py:413`)
 
-|      % |  Size | Samples | Location                                 |
-| -----: | ----: | ------: | ---------------------------------------- |
-| 100.0% | 1 MiB |       3 | `/usr/lib/python3.11/dataclasses.py:433` |
+|      % |  Size | Allocations | Location                                 |
+| -----: | ----: | ----------: | ---------------------------------------- |
+| 100.0% | 1 MiB |           3 | `/usr/lib/python3.11/dataclasses.py:433` |
 
 ##### `_stringify_ast` (`black/parsing.py:174`)
 
-|      % |  Size | Samples | Location               |
-| -----: | ----: | ------: | ---------------------- |
-| 100.0% | 1 MiB |       1 | `black/parsing.py:197` |
+|      % |  Size | Allocations | Location               |
+| -----: | ----: | ----------: | ---------------------- |
+| 100.0% | 1 MiB |           1 | `black/parsing.py:197` |
 
 ##### `debug` (`/usr/lib/python3.11/logging/__init__.py:1467`)
 
-|      % |  Size | Samples | Location                                       |
-| -----: | ----: | ------: | ---------------------------------------------- |
-| 100.0% | 1 MiB |       1 | `/usr/lib/python3.11/logging/__init__.py:1476` |
+|      % |  Size | Allocations | Location                                       |
+| -----: | ----: | ----------: | ---------------------------------------------- |
+| 100.0% | 1 MiB |           1 | `/usr/lib/python3.11/logging/__init__.py:1476` |
 
 ##### `generate_tokens` (`blib2to3/pgen2/tokenize.py:565`)
 
-|      % |  Size | Samples | Location                         |
-| -----: | ----: | ------: | -------------------------------- |
-| 100.0% | 1 MiB |       1 | `blib2to3/pgen2/tokenize.py:972` |
+|      % |  Size | Allocations | Location                         |
+| -----: | ----: | ----------: | -------------------------------- |
+| 100.0% | 1 MiB |           1 | `blib2to3/pgen2/tokenize.py:972` |
 
 ##### `__getitem__` (`/usr/lib/python3.11/re/_parser.py:162`)
 
-|      % |  Size | Samples | Location                                |
-| -----: | ----: | ------: | --------------------------------------- |
-| 100.0% | 1 MiB |       1 | `/usr/lib/python3.11/re/_parser.py:164` |
+|      % |  Size | Allocations | Location                                |
+| -----: | ----: | ----------: | --------------------------------------- |
+| 100.0% | 1 MiB |           1 | `/usr/lib/python3.11/re/_parser.py:164` |
 
 ##### `_compile_bytecode` (`<frozen importlib._bootstrap_external>:727`)
 
-|      % |    Size | Samples | Location                                     |
-| -----: | ------: | ------: | -------------------------------------------- |
-| 100.0% | 560 KiB |     606 | `<frozen importlib._bootstrap_external>:729` |
+|      % |    Size | Allocations | Location                                     |
+| -----: | ------: | ----------: | -------------------------------------------- |
+| 100.0% | 560 KiB |         606 | `<frozen importlib._bootstrap_external>:729` |
 
 ##### `transform_line` (`black/linegen.py:601`)
 
-|     % |     Size | Samples | Location               |
-| ----: | -------: | ------: | ---------------------- |
-| 96.4% | 73.7 KiB |       3 | `black/linegen.py:679` |
-|  1.8% | 1.39 KiB |       1 | `black/linegen.py:635` |
-|  1.2% |    910 B |       1 | `black/linegen.py:714` |
-|  0.7% |    518 B |       1 | `black/linegen.py:631` |
+|     % |     Size | Allocations | Location               |
+| ----: | -------: | ----------: | ---------------------- |
+| 96.4% | 73.7 KiB |           3 | `black/linegen.py:679` |
+|  1.8% | 1.39 KiB |           1 | `black/linegen.py:635` |
+|  1.2% |    910 B |           1 | `black/linegen.py:714` |
+|  0.7% |    518 B |           1 | `black/linegen.py:631` |
 
 ##### `__new__` (`<frozen abc>:105`)
 
-|      % |     Size | Samples | Location           |
-| -----: | -------: | ------: | ------------------ |
-| 100.0% | 75.7 KiB |      79 | `<frozen abc>:106` |
+|      % |     Size | Allocations | Location           |
+| -----: | -------: | ----------: | ------------------ |
+| 100.0% | 75.7 KiB |          79 | `<frozen abc>:106` |
 
 ##### `normalize_string_prefix` (`black/strings.py:143`)
 
-|      % |     Size | Samples | Location               |
-| -----: | -------: | ------: | ---------------------- |
-| 100.0% | 57.2 KiB |      65 | `black/strings.py:158` |
+|      % |     Size | Allocations | Location               |
+| -----: | -------: | ----------: | ---------------------- |
+| 100.0% | 57.2 KiB |          65 | `black/strings.py:158` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|     % |   Size | Samples | Location                                                |
-| ----: | -----: | ------: | ------------------------------------------------------- |
-| 97.1% | 43 KiB |      29 | `/venv/lib/python3.11/site-packages/click/core.py:3023` |
-|  1.6% |  704 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2905` |
-|  1.4% |  614 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2907` |
+|     % |   Size | Allocations | Location                                                |
+| ----: | -----: | ----------: | ------------------------------------------------------- |
+| 97.1% | 43 KiB |          29 | `/venv/lib/python3.11/site-packages/click/core.py:3023` |
+|  1.6% |  704 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2905` |
+|  1.4% |  614 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2907` |
 
 ##### `copy` (`blib2to3/pgen2/grammar.py:131`)
 
-|     % |     Size | Samples | Location                        |
-| ----: | -------: | ------: | ------------------------------- |
-| 88.2% | 36.6 KiB |      12 | `blib2to3/pgen2/grammar.py:145` |
-|  7.6% | 3.16 KiB |       2 | `blib2to3/pgen2/grammar.py:146` |
-|  4.2% | 1.75 KiB |       2 | `blib2to3/pgen2/grammar.py:147` |
+|     % |     Size | Allocations | Location                        |
+| ----: | -------: | ----------: | ------------------------------- |
+| 88.2% | 36.6 KiB |          12 | `blib2to3/pgen2/grammar.py:145` |
+|  7.6% | 3.16 KiB |           2 | `blib2to3/pgen2/grammar.py:146` |
+|  4.2% | 1.75 KiB |           2 | `blib2to3/pgen2/grammar.py:147` |
 
 ##### `classify` (`blib2to3/pgen2/parse.py:336`)
 
-|      % |   Size | Samples | Location                      |
-| -----: | -----: | ------: | ----------------------------- |
-| 100.0% | 32 KiB |       1 | `blib2to3/pgen2/parse.py:343` |
+|      % |   Size | Allocations | Location                      |
+| -----: | -----: | ----------: | ----------------------------- |
+| 100.0% | 32 KiB |           1 | `blib2to3/pgen2/parse.py:343` |
 
 ##### `make_first` (`blib2to3/pgen2/pgen.py:74`)
 
-|      % |     Size | Samples | Location                    |
-| -----: | -------: | ------: | --------------------------- |
-| 100.0% | 25.3 KiB |      40 | `blib2to3/pgen2/pgen.py:81` |
+|      % |     Size | Allocations | Location                    |
+| -----: | -------: | ----------: | --------------------------- |
+| 100.0% | 25.3 KiB |          40 | `blib2to3/pgen2/pgen.py:81` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 30.4% |  7.6 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:204`  |
-| 19.2% | 4.79 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:956`  |
-| 15.7% | 3.92 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:1587` |
-|  9.5% | 2.37 KiB |       3 | `/venv/lib/python3.11/site-packages/click/core.py:2057` |
-|  6.8% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/core.py:1580` |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 30.4% |  7.6 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:204`  |
+| 19.2% | 4.79 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:956`  |
+| 15.7% | 3.92 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:1587` |
+|  9.5% | 2.37 KiB |           3 | `/venv/lib/python3.11/site-packages/click/core.py:2057` |
+|  6.8% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/core.py:1580` |
 
 ##### `__new__` (`/usr/lib/python3.11/enum.py:488`)
 
-|      % |     Size | Samples | Location                          |
-| -----: | -------: | ------: | --------------------------------- |
-| 100.0% | 24.1 KiB |      27 | `/usr/lib/python3.11/enum.py:554` |
+|      % |     Size | Allocations | Location                          |
+| -----: | -------: | ----------: | --------------------------------- |
+| 100.0% | 24.1 KiB |          27 | `/usr/lib/python3.11/enum.py:554` |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|      % |     Size | Samples | Location                                  |
-| -----: | -------: | ------: | ----------------------------------------- |
-| 100.0% | 22.6 KiB |      12 | `/usr/lib/python3.11/re/_compiler.py:759` |
+|      % |     Size | Allocations | Location                                  |
+| -----: | -------: | ----------: | ----------------------------------------- |
+| 100.0% | 22.6 KiB |          12 | `/usr/lib/python3.11/re/_compiler.py:759` |
 
 ##### `<module>` (`blib2to3/pgen2/tokenize.py:1`)
 
-|     % |     Size | Samples | Location                         |
-| ----: | -------: | ------: | -------------------------------- |
-| 15.4% | 3.19 KiB |       1 | `blib2to3/pgen2/tokenize.py:170` |
-| 15.4% | 3.19 KiB |       1 | `blib2to3/pgen2/tokenize.py:208` |
-| 14.7% | 3.04 KiB |       3 | `blib2to3/pgen2/tokenize.py:490` |
-|  9.7% |    2 KiB |       1 | `blib2to3/pgen2/tokenize.py:229` |
-|  9.7% |    2 KiB |       1 | `blib2to3/pgen2/tokenize.py:234` |
+|     % |     Size | Allocations | Location                         |
+| ----: | -------: | ----------: | -------------------------------- |
+| 15.4% | 3.19 KiB |           1 | `blib2to3/pgen2/tokenize.py:170` |
+| 15.4% | 3.19 KiB |           1 | `blib2to3/pgen2/tokenize.py:208` |
+| 14.7% | 3.04 KiB |           3 | `blib2to3/pgen2/tokenize.py:490` |
+|  9.7% |    2 KiB |           1 | `blib2to3/pgen2/tokenize.py:229` |
+|  9.7% |    2 KiB |           1 | `blib2to3/pgen2/tokenize.py:234` |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/_parser.py:1`)
 
-|     % |  Size | Samples | Location                                    |
-| ----: | ----: | ------: | ------------------------------------------- |
-| 20.2% | 4 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:37` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:38` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:27` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:36` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:22` |
+|     % |  Size | Allocations | Location                                    |
+| ----: | ----: | ----------: | ------------------------------------------- |
+| 20.2% | 4 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:37` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:38` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:27` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:36` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:22` |
 
 ##### `convert_one_fmt_off_pair` (`black/comments.py:177`)
 
-|      % |     Size | Samples | Location                |
-| -----: | -------: | ------: | ----------------------- |
-| 100.0% | 18.6 KiB |       2 | `black/comments.py:186` |
+|      % |     Size | Allocations | Location                |
+| -----: | -------: | ----------: | ----------------------- |
+| 100.0% | 18.6 KiB |           2 | `black/comments.py:186` |
 
 ##### `__new__` (`/usr/lib/python3.11/typing.py:2891`)
 
-|      % |     Size | Samples | Location                             |
-| -----: | -------: | ------: | ------------------------------------ |
-| 100.0% | 17.4 KiB |      21 | `/usr/lib/python3.11/typing.py:2909` |
+|      % |     Size | Allocations | Location                             |
+| -----: | -------: | ----------: | ------------------------------------ |
+| 100.0% | 17.4 KiB |          21 | `/usr/lib/python3.11/typing.py:2909` |
 
 ##### `<module>` (`blib2to3/pytree.py:1`)
 
-|     % |     Size | Samples | Location                 |
-| ----: | -------: | ------: | ------------------------ |
-| 16.3% | 2.44 KiB |       3 | `blib2to3/pytree.py:64`  |
-| 11.3% | 1.69 KiB |       2 | `blib2to3/pytree.py:382` |
-| 11.3% | 1.69 KiB |       2 | `blib2to3/pytree.py:242` |
-| 11.3% | 1.69 KiB |       2 | `blib2to3/pytree.py:509` |
-| 11.3% | 1.69 KiB |       2 | `blib2to3/pytree.py:600` |
+|     % |     Size | Allocations | Location                 |
+| ----: | -------: | ----------: | ------------------------ |
+| 16.3% | 2.44 KiB |           3 | `blib2to3/pytree.py:64`  |
+| 11.3% | 1.69 KiB |           2 | `blib2to3/pytree.py:382` |
+| 11.3% | 1.69 KiB |           2 | `blib2to3/pytree.py:242` |
+| 11.3% | 1.69 KiB |           2 | `blib2to3/pytree.py:509` |
+| 11.3% | 1.69 KiB |           2 | `blib2to3/pytree.py:600` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/mypy_extensions.py:1`)
 
-|     % |     Size | Samples | Location                                                    |
-| ----: | -------: | ------: | ----------------------------------------------------------- |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:191` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:167` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:175` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:154` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:212` |
+|     % |     Size | Allocations | Location                                                    |
+| ----: | -------: | ----------: | ----------------------------------------------------------- |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:191` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:167` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:175` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:154` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:212` |
 
 ##### `make_grammar` (`blib2to3/pgen2/pgen.py:49`)
 
-|     % |     Size | Samples | Location                    |
-| ----: | -------: | ------: | --------------------------- |
-| 31.8% | 4.52 KiB |       1 | `blib2to3/pgen2/pgen.py:70` |
-| 31.8% | 4.52 KiB |       1 | `blib2to3/pgen2/pgen.py:58` |
-| 22.5% | 3.19 KiB |       1 | `blib2to3/pgen2/pgen.py:57` |
-|  7.1% |    1 KiB |       1 | `blib2to3/pgen2/pgen.py:69` |
-|  6.8% |    986 B |       1 | `blib2to3/pgen2/pgen.py:65` |
+|     % |     Size | Allocations | Location                    |
+| ----: | -------: | ----------: | --------------------------- |
+| 31.8% | 4.52 KiB |           1 | `blib2to3/pgen2/pgen.py:70` |
+| 31.8% | 4.52 KiB |           1 | `blib2to3/pgen2/pgen.py:58` |
+| 22.5% | 3.19 KiB |           1 | `blib2to3/pgen2/pgen.py:57` |
+|  7.1% |    1 KiB |           1 | `blib2to3/pgen2/pgen.py:69` |
+|  6.8% |    986 B |           1 | `blib2to3/pgen2/pgen.py:65` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/exceptions.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 18.4% | 2.45 KiB |       3 | `/venv/lib/python3.11/site-packages/click/exceptions.py:114` |
-| 11.5% | 1.53 KiB |       2 | `/venv/lib/python3.11/site-packages/click/exceptions.py:366` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:68`  |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:362` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:342` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 18.4% | 2.45 KiB |           3 | `/venv/lib/python3.11/site-packages/click/exceptions.py:114` |
+| 11.5% | 1.53 KiB |           2 | `/venv/lib/python3.11/site-packages/click/exceptions.py:366` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:68`  |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:362` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:342` |
 
 ##### `inner` (`/usr/lib/python3.11/typing.py:338`)
 
-|      % |   Size | Samples | Location                            |
-| -----: | -----: | ------: | ----------------------------------- |
-| 100.0% | 12 KiB |       3 | `/usr/lib/python3.11/typing.py:341` |
+|      % |   Size | Allocations | Location                            |
+| -----: | -----: | ----------: | ----------------------------------- |
+| 100.0% | 12 KiB |           3 | `/usr/lib/python3.11/typing.py:341` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/version.py:1`)
 
-|     % |     Size | Samples | Location                                                      |
-| ----: | -------: | ------: | ------------------------------------------------------------- |
-| 38.2% | 3.68 KiB |       3 | `/venv/lib/python3.11/site-packages/packaging/version.py:340` |
-| 15.5% | 1.49 KiB |       2 | `/venv/lib/python3.11/site-packages/packaging/version.py:124` |
-| 15.4% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:285` |
-| 11.3% | 1.09 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:228` |
-|  9.8% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:134` |
+|     % |     Size | Allocations | Location                                                      |
+| ----: | -------: | ----------: | ------------------------------------------------------------- |
+| 38.2% | 3.68 KiB |           3 | `/venv/lib/python3.11/site-packages/packaging/version.py:340` |
+| 15.5% | 1.49 KiB |           2 | `/venv/lib/python3.11/site-packages/packaging/version.py:124` |
+| 15.4% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:285` |
+| 11.3% | 1.09 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:228` |
+|  9.8% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:134` |
 
 ##### `_fill_cache` (`<frozen importlib._bootstrap_external>:1655`)
 
-|      % |  Size | Samples | Location                                      |
-| -----: | ----: | ------: | --------------------------------------------- |
-| 100.0% | 8 KiB |       4 | `<frozen importlib._bootstrap_external>:1667` |
+|      % |  Size | Allocations | Location                                      |
+| -----: | ----: | ----------: | --------------------------------------------- |
+| 100.0% | 8 KiB |           4 | `<frozen importlib._bootstrap_external>:1667` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|      % |     Size | Samples | Location                                |
-| -----: | -------: | ------: | --------------------------------------- |
-| 100.0% | 7.97 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:455` |
+|      % |     Size | Allocations | Location                                |
+| -----: | -------: | ----------: | --------------------------------------- |
+| 100.0% | 7.97 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:455` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/utils.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 44.8% | 3.17 KiB |       3 | `/venv/lib/python3.11/site-packages/click/utils.py:522` |
-| 31.4% | 2.22 KiB |       3 | `/venv/lib/python3.11/site-packages/click/utils.py:207` |
-| 23.8% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/utils.py:113` |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 44.8% | 3.17 KiB |           3 | `/venv/lib/python3.11/site-packages/click/utils.py:522` |
+| 31.4% | 2.22 KiB |           3 | `/venv/lib/python3.11/site-packages/click/utils.py:207` |
+| 23.8% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/utils.py:113` |
 
 ##### `__setattr__` (`/usr/lib/python3.11/enum.py:831`)
 
-|      % |     Size | Samples | Location                          |
-| -----: | -------: | ------: | --------------------------------- |
-| 100.0% | 6.73 KiB |       8 | `/usr/lib/python3.11/enum.py:842` |
+|      % |     Size | Allocations | Location                          |
+| -----: | -------: | ----------: | --------------------------------- |
+| 100.0% | 6.73 KiB |           8 | `/usr/lib/python3.11/enum.py:842` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/util.py:1`)
 
-|     % |     Size | Samples | Location                                                  |
-| ----: | -------: | ------: | --------------------------------------------------------- |
-| 22.9% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:254` |
-| 16.9% | 1.09 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:765` |
-| 16.3% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:710` |
-| 15.1% |   1000 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:741` |
-| 14.5% |    960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:604` |
+|     % |     Size | Allocations | Location                                                  |
+| ----: | -------: | ----------: | --------------------------------------------------------- |
+| 22.9% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:254` |
+| 16.9% | 1.09 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:765` |
+| 16.3% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:710` |
+| 15.1% |   1000 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:741` |
+| 14.5% |    960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:604` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|     % |     Size | Samples | Location                                                      |
-| ----: | -------: | ------: | ------------------------------------------------------------- |
-| 23.8% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:681` |
-| 23.0% | 1.43 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:44`  |
-| 19.4% | 1.21 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:63`  |
-| 16.9% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:236` |
-| 16.9% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:179` |
+|     % |     Size | Allocations | Location                                                      |
+| ----: | -------: | ----------: | ------------------------------------------------------------- |
+| 23.8% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:681` |
+| 23.0% | 1.43 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:44`  |
+| 19.4% | 1.21 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:63`  |
+| 16.9% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:236` |
+| 16.9% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:179` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|     % |     Size | Samples | Location                                                   |
-| ----: | -------: | ------: | ---------------------------------------------------------- |
-| 28.0% | 1.67 KiB |       2 | `/venv/lib/python3.11/site-packages/packaging/tags.py:118` |
-| 24.9% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:322` |
-| 15.7% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:93`  |
-| 15.7% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:101` |
-| 15.7% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:110` |
+|     % |     Size | Allocations | Location                                                   |
+| ----: | -------: | ----------: | ---------------------------------------------------------- |
+| 28.0% | 1.67 KiB |           2 | `/venv/lib/python3.11/site-packages/packaging/tags.py:118` |
+| 24.9% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:322` |
+| 15.7% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:93`  |
+| 15.7% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:101` |
+| 15.7% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:110` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/_compat.py:1`)
 
-|     % |     Size | Samples | Location                                                  |
-| ----: | -------: | ------: | --------------------------------------------------------- |
-| 29.1% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/_compat.py:82`  |
-| 29.1% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/_compat.py:452` |
-| 25.6% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/click/_compat.py:344` |
-| 16.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/_compat.py:56`  |
+|     % |     Size | Allocations | Location                                                  |
+| ----: | -------: | ----------: | --------------------------------------------------------- |
+| 29.1% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/_compat.py:82`  |
+| 29.1% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/_compat.py:452` |
+| 25.6% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/click/_compat.py:344` |
+| 16.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/_compat.py:56`  |
 
 ##### `namedtuple` (`/usr/lib/python3.11/collections/__init__.py:348`)
 
-|      % |     Size | Samples | Location                                          |
-| -----: | -------: | ------: | ------------------------------------------------- |
-| 100.0% | 5.63 KiB |       6 | `/usr/lib/python3.11/collections/__init__.py:501` |
+|      % |     Size | Allocations | Location                                          |
+| -----: | -------: | ----------: | ------------------------------------------------- |
+| 100.0% | 5.63 KiB |           6 | `/usr/lib/python3.11/collections/__init__.py:501` |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|     % |     Size | Samples | Location                                |
-| ----: | -------: | ------: | --------------------------------------- |
-| 43.4% | 2.43 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:539` |
-| 33.9% |  1.9 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:568` |
-| 22.7% | 1.28 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:838` |
+|     % |     Size | Allocations | Location                                |
+| ----: | -------: | ----------: | --------------------------------------- |
+| 43.4% | 2.43 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:539` |
+| 33.9% |  1.9 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:568` |
+| 22.7% | 1.28 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:838` |
 
 ##### `_code` (`/usr/lib/python3.11/re/_compiler.py:571`)
 
-|     % |     Size | Samples | Location                                  |
-| ----: | -------: | ------: | ----------------------------------------- |
-| 81.6% | 4.34 KiB |       1 | `/usr/lib/python3.11/re/_compiler.py:580` |
-| 18.4% |   1002 B |       1 | `/usr/lib/python3.11/re/_compiler.py:577` |
+|     % |     Size | Allocations | Location                                  |
+| ----: | -------: | ----------: | ----------------------------------------- |
+| 81.6% | 4.34 KiB |           1 | `/usr/lib/python3.11/re/_compiler.py:580` |
+| 18.4% |   1002 B |           1 | `/usr/lib/python3.11/re/_compiler.py:577` |
 
 ##### `<module>` (`/usr/lib/python3.11/pkgutil.py:1`)
 
-|     % |     Size | Samples | Location                             |
-| ----: | -------: | ------: | ------------------------------------ |
-| 35.7% | 1.69 KiB |       2 | `/usr/lib/python3.11/pkgutil.py:194` |
-| 35.7% | 1.69 KiB |       2 | `/usr/lib/python3.11/pkgutil.py:269` |
-| 15.9% |    768 B |       1 | `/usr/lib/python3.11/pkgutil.py:137` |
-| 12.8% |    620 B |       1 | `/usr/lib/python3.11/pkgutil.py:184` |
+|     % |     Size | Allocations | Location                             |
+| ----: | -------: | ----------: | ------------------------------------ |
+| 35.7% | 1.69 KiB |           2 | `/usr/lib/python3.11/pkgutil.py:194` |
+| 35.7% | 1.69 KiB |           2 | `/usr/lib/python3.11/pkgutil.py:269` |
+| 15.9% |    768 B |           1 | `/usr/lib/python3.11/pkgutil.py:137` |
+| 12.8% |    620 B |           1 | `/usr/lib/python3.11/pkgutil.py:184` |
 
 ##### `Specifier` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`)
 
-|      % |     Size | Samples | Location                                                         |
-| -----: | -------: | ------: | ---------------------------------------------------------------- |
-| 100.0% | 3.82 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:340` |
+|      % |     Size | Allocations | Location                                                         |
+| -----: | -------: | ----------: | ---------------------------------------------------------------- |
+| 100.0% | 3.82 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:340` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 46.4% | 1.73 KiB |       2 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:29`  |
-| 27.3% | 1.02 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:90`  |
-| 26.3% |   1000 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:245` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 46.4% | 1.73 KiB |           2 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:29`  |
+| 27.3% | 1.02 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:90`  |
+| 26.3% |   1000 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:245` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|     % |  Size | Samples | Location                                                   |
-| ----: | ----: | ------: | ---------------------------------------------------------- |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:62` |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:46` |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:54` |
-| 21.1% | 768 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:27` |
+|     % |  Size | Allocations | Location                                                   |
+| ----: | ----: | ----------: | ---------------------------------------------------------- |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:62` |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:46` |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:54` |
+| 21.1% | 768 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:27` |
 
 ##### `handle_parse_result` (`/venv/lib/python3.11/site-packages/click/core.py:2663`)
 
-|     % |    Size | Samples | Location                                                |
-| ----: | ------: | ------: | ------------------------------------------------------- |
-| 38.5% | 1.3 KiB |       2 | `/venv/lib/python3.11/site-packages/click/core.py:2686` |
-| 22.3% |   768 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2740` |
-| 22.3% |   768 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2739` |
-| 17.0% |   586 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2711` |
+|     % |    Size | Allocations | Location                                                |
+| ----: | ------: | ----------: | ------------------------------------------------------- |
+| 38.5% | 1.3 KiB |           2 | `/venv/lib/python3.11/site-packages/click/core.py:2686` |
+| 22.3% |   768 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2740` |
+| 22.3% |   768 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2739` |
+| 17.0% |   586 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2711` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|      % |     Size | Samples | Location                                                  |
-| -----: | -------: | ------: | --------------------------------------------------------- |
-| 100.0% | 3.19 KiB |       1 | `/venv/lib/python3.11/site-packages/click/__init__.py:74` |
+|      % |     Size | Allocations | Location                                                  |
+| -----: | -------: | ----------: | --------------------------------------------------------- |
+| 100.0% | 3.19 KiB |           1 | `/venv/lib/python3.11/site-packages/click/__init__.py:74` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 76.5% | 2.44 KiB |       3 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:55` |
-| 23.5% |    768 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:14` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 76.5% | 2.44 KiB |           3 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:55` |
+| 23.5% |    768 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:14` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Location                                                    |
-| -----: | -------: | ------: | ----------------------------------------------------------- |
-| 100.0% | 3.04 KiB |       2 | `/venv/lib/python3.11/site-packages/click/decorators.py:34` |
+|      % |     Size | Allocations | Location                                                    |
+| -----: | -------: | ----------: | ----------------------------------------------------------- |
+| 100.0% | 3.04 KiB |           2 | `/venv/lib/python3.11/site-packages/click/decorators.py:34` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|      % |     Size | Samples | Location                                  |
-| -----: | -------: | ------: | ----------------------------------------- |
-| 100.0% | 2.85 KiB |       1 | `/usr/lib/python3.11/dataclasses.py:1210` |
+|      % |     Size | Allocations | Location                                  |
+| -----: | -------: | ----------: | ----------------------------------------- |
+| 100.0% | 2.85 KiB |           1 | `/usr/lib/python3.11/dataclasses.py:1210` |
 
 ##### `_process_class` (`/usr/lib/python3.11/dataclasses.py:884`)
 
-|     % |     Size | Samples | Location                                  |
-| ----: | -------: | ------: | ----------------------------------------- |
-| 41.3% | 1.18 KiB |       1 | `/usr/lib/python3.11/dataclasses.py:958`  |
-| 21.0% |    612 B |       1 | `/usr/lib/python3.11/dataclasses.py:1027` |
-| 19.9% |    580 B |       1 | `/usr/lib/python3.11/dataclasses.py:1096` |
-| 17.8% |    518 B |       1 | `/usr/lib/python3.11/dataclasses.py:947`  |
+|     % |     Size | Allocations | Location                                  |
+| ----: | -------: | ----------: | ----------------------------------------- |
+| 41.3% | 1.18 KiB |           1 | `/usr/lib/python3.11/dataclasses.py:958`  |
+| 21.0% |    612 B |           1 | `/usr/lib/python3.11/dataclasses.py:1027` |
+| 19.9% |    580 B |           1 | `/usr/lib/python3.11/dataclasses.py:1096` |
+| 17.8% |    518 B |           1 | `/usr/lib/python3.11/dataclasses.py:947`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1`)
 
-|     % |  Size | Samples | Location                                                                     |
-| ----: | ----: | ------: | ---------------------------------------------------------------------------- |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:22`  |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:205` |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:197` |
+|     % |  Size | Allocations | Location                                                                     |
+| ----: | ----: | ----------: | ---------------------------------------------------------------------------- |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:22`  |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:205` |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:197` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 53.7% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/click/types.py:464` |
-| 46.3% | 1.28 KiB |       1 | `/venv/lib/python3.11/site-packages/click/types.py:37`  |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 53.7% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/click/types.py:464` |
+| 46.3% | 1.28 KiB |           1 | `/venv/lib/python3.11/site-packages/click/types.py:37`  |
 
 #### Callers
 
@@ -2044,484 +2044,484 @@ Callers ranked by contribution to each function's self size. Inlining can make c
 
 ##### `mark` (`black/brackets.py:70`)
 
-|      % |     Size | Samples | Caller   | Location            |
-| -----: | -------: | ------: | -------- | ------------------- |
-| 100.0% | 17.2 MiB |  20,789 | `append` | `black/lines.py:63` |
+|      % |     Size | Allocations | Caller   | Location            |
+| -----: | -------: | ----------: | -------- | ------------------- |
+| 100.0% | 17.2 MiB |      20,789 | `append` | `black/lines.py:63` |
 
 ##### `update_sibling_maps` (`blib2to3/pytree.py:369`)
 
-|      % |     Size | Samples | Caller         | Location                 |
-| -----: | -------: | ------: | -------------- | ------------------------ |
-| 100.0% | 6.14 MiB |     201 | `prev_sibling` | `blib2to3/pytree.py:207` |
+|      % |     Size | Allocations | Caller         | Location                 |
+| -----: | -------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 6.14 MiB |         201 | `prev_sibling` | `blib2to3/pytree.py:207` |
 
 ##### `changed` (`blib2to3/pytree.py:171`)
 
-|     % |  Size | Samples | Caller    | Location                 |
-| ----: | ----: | ------: | --------- | ------------------------ |
-| 83.3% | 5 MiB |       5 | `changed` | `blib2to3/pytree.py:171` |
-| 16.7% | 1 MiB |       1 | `prefix`  | `blib2to3/pytree.py:480` |
+|     % |  Size | Allocations | Caller    | Location                 |
+| ----: | ----: | ----------: | --------- | ------------------------ |
+| 83.3% | 5 MiB |           5 | `changed` | `blib2to3/pytree.py:171` |
+| 16.7% | 1 MiB |           1 | `prefix`  | `blib2to3/pytree.py:480` |
 
 ##### `__new__` (`blib2to3/pytree.py:81`)
 
-|      % |  Size | Samples | Caller    | Location                 |
-| -----: | ----: | ------: | --------- | ------------------------ |
-| 100.0% | 6 MiB |       6 | `convert` | `blib2to3/pytree.py:486` |
+|      % |  Size | Allocations | Caller    | Location                 |
+| -----: | ----: | ----------: | --------- | ------------------------ |
+| 100.0% | 6 MiB |           6 | `convert` | `blib2to3/pytree.py:486` |
 
 ##### `parse` (`/usr/lib/python3.11/ast.py:33`)
 
-|      % |     Size | Samples | Caller                  | Location               |
-| -----: | -------: | ------: | ----------------------- | ---------------------- |
-| 100.0% | 3.01 MiB |       4 | `_parse_single_version` | `black/parsing.py:117` |
+|      % |     Size | Allocations | Caller                  | Location               |
+| -----: | -------: | ----------: | ----------------------- | ---------------------- |
+| 100.0% | 3.01 MiB |           4 | `_parse_single_version` | `black/parsing.py:117` |
 
 ##### `generate_comments` (`black/comments.py:52`)
 
-|      % |  Size | Samples | Caller          | Location               |
-| -----: | ----: | ------: | --------------- | ---------------------- |
-| 100.0% | 3 MiB |       3 | `visit_default` | `black/linegen.py:134` |
+|      % |  Size | Allocations | Caller          | Location               |
+| -----: | ----: | ----------: | --------------- | ---------------------- |
+| 100.0% | 3 MiB |           3 | `visit_default` | `black/linegen.py:134` |
 
 ##### `push` (`blib2to3/pgen2/parse.py:386`)
 
-|      % |  Size | Samples | Caller      | Location                      |
-| -----: | ----: | ------: | ----------- | ----------------------------- |
-| 100.0% | 3 MiB |       3 | `_addtoken` | `blib2to3/pgen2/parse.py:290` |
+|      % |  Size | Allocations | Caller      | Location                      |
+| -----: | ----: | ----------: | ----------- | ----------------------------- |
+| 100.0% | 3 MiB |           3 | `_addtoken` | `blib2to3/pgen2/parse.py:290` |
 
 ##### `prefix` (`blib2to3/pytree.py:480`)
 
-|      % |  Size | Samples | Caller   | Location            |
-| -----: | ----: | ------: | -------- | ------------------- |
-| 100.0% | 2 MiB |       2 | `append` | `black/lines.py:63` |
+|      % |  Size | Allocations | Caller   | Location            |
+| -----: | ----: | ----------: | -------- | ------------------- |
+| 100.0% | 2 MiB |           2 | `append` | `black/lines.py:63` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 1.01 MiB |      11 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 1.01 MiB |          11 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|     % |     Size | Samples | Caller             | Location                 |
-| ----: | -------: | ------: | ------------------ | ------------------------ |
-| 99.7% |    1 MiB |       1 | `visit_stmt`       | `black/linegen.py:199`   |
-|  0.3% | 2.68 KiB |       3 | `visit_default`    | `black/nodes.py:187`     |
-|  0.1% |    690 B |       1 | `_format_str_once` | `black/__init__.py:1236` |
+|     % |     Size | Allocations | Caller             | Location                 |
+| ----: | -------: | ----------: | ------------------ | ------------------------ |
+| 99.7% |    1 MiB |           1 | `visit_stmt`       | `black/linegen.py:199`   |
+|  0.3% | 2.68 KiB |           3 | `visit_default`    | `black/nodes.py:187`     |
+|  0.1% |    690 B |           1 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `__init__` (`blib2to3/pytree.py:248`)
 
-|      % |  Size | Samples | Caller    | Location                 |
-| -----: | ----: | ------: | --------- | ------------------------ |
-| 100.0% | 1 MiB |       5 | `convert` | `blib2to3/pytree.py:486` |
+|      % |  Size | Allocations | Caller    | Location                 |
+| -----: | ----: | ----------: | --------- | ------------------------ |
+| 100.0% | 1 MiB |           5 | `convert` | `blib2to3/pytree.py:486` |
 
 ##### `_create_fn` (`/usr/lib/python3.11/dataclasses.py:413`)
 
-|     % |  Size | Samples | Caller     | Location                                 |
-| ----: | ----: | ------: | ---------- | ---------------------------------------- |
-| 99.9% | 1 MiB |       1 | `_init_fn` | `/usr/lib/python3.11/dataclasses.py:528` |
-| <0.1% | 341 B |       1 | `_cmp_fn`  | `/usr/lib/python3.11/dataclasses.py:624` |
-| <0.1% | 336 B |       1 | `_repr_fn` | `/usr/lib/python3.11/dataclasses.py:588` |
+|     % |  Size | Allocations | Caller     | Location                                 |
+| ----: | ----: | ----------: | ---------- | ---------------------------------------- |
+| 99.9% | 1 MiB |           1 | `_init_fn` | `/usr/lib/python3.11/dataclasses.py:528` |
+| <0.1% | 341 B |           1 | `_cmp_fn`  | `/usr/lib/python3.11/dataclasses.py:624` |
+| <0.1% | 336 B |           1 | `_repr_fn` | `/usr/lib/python3.11/dataclasses.py:588` |
 
 ##### `_stringify_ast` (`black/parsing.py:174`)
 
-|      % |  Size | Samples | Caller                           | Location               |
-| -----: | ----: | ------: | -------------------------------- | ---------------------- |
-| 100.0% | 1 MiB |       1 | `_stringify_ast_with_new_parent` | `black/parsing.py:166` |
+|      % |  Size | Allocations | Caller                           | Location               |
+| -----: | ----: | ----------: | -------------------------------- | ---------------------- |
+| 100.0% | 1 MiB |           1 | `_stringify_ast_with_new_parent` | `black/parsing.py:166` |
 
 ##### `debug` (`/usr/lib/python3.11/logging/__init__.py:1467`)
 
-|      % |  Size | Samples | Caller         | Location                       |
-| -----: | ----: | ------: | -------------- | ------------------------------ |
-| 100.0% | 1 MiB |       1 | `parse_tokens` | `blib2to3/pgen2/driver.py:114` |
+|      % |  Size | Allocations | Caller         | Location                       |
+| -----: | ----: | ----------: | -------------- | ------------------------------ |
+| 100.0% | 1 MiB |           1 | `parse_tokens` | `blib2to3/pgen2/driver.py:114` |
 
 ##### `generate_tokens` (`blib2to3/pgen2/tokenize.py:565`)
 
-|      % |  Size | Samples | Caller     | Location                      |
-| -----: | ----: | ------: | ---------- | ----------------------------- |
-| 100.0% | 1 MiB |       1 | `__next__` | `blib2to3/pgen2/driver.py:80` |
+|      % |  Size | Allocations | Caller     | Location                      |
+| -----: | ----: | ----------: | ---------- | ----------------------------- |
+| 100.0% | 1 MiB |           1 | `__next__` | `blib2to3/pgen2/driver.py:80` |
 
 ##### `__getitem__` (`/usr/lib/python3.11/re/_parser.py:162`)
 
-|      % |  Size | Samples | Caller   | Location                                |
-| -----: | ----: | ------: | -------- | --------------------------------------- |
-| 100.0% | 1 MiB |       1 | `_parse` | `/usr/lib/python3.11/re/_parser.py:507` |
+|      % |  Size | Allocations | Caller   | Location                                |
+| -----: | ----: | ----------: | -------- | --------------------------------------- |
+| 100.0% | 1 MiB |           1 | `_parse` | `/usr/lib/python3.11/re/_parser.py:507` |
 
 ##### `_compile_bytecode` (`<frozen importlib._bootstrap_external>:727`)
 
-|      % |    Size | Samples | Caller     | Location                                      |
-| -----: | ------: | ------: | ---------- | --------------------------------------------- |
-| 100.0% | 560 KiB |     606 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
+|      % |    Size | Allocations | Caller     | Location                                      |
+| -----: | ------: | ----------: | ---------- | --------------------------------------------- |
+| 100.0% | 560 KiB |         606 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `transform_line` (`black/linegen.py:601`)
 
-|      % |     Size | Samples | Caller             | Location                 |
-| -----: | -------: | ------: | ------------------ | ------------------------ |
-| 100.0% | 76.5 KiB |       6 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |     Size | Allocations | Caller             | Location                 |
+| -----: | -------: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 76.5 KiB |           6 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `__new__` (`<frozen abc>:105`)
 
-|     % |     Size | Samples | Caller     | Location                                                       |
-| ----: | -------: | ------: | ---------- | -------------------------------------------------------------- |
-| 50.5% | 38.2 KiB |      45 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`          |
-| 23.1% | 17.5 KiB |      18 | `<module>` | `black/trans.py:1`                                             |
-| 18.3% | 13.9 KiB |       9 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`           |
-|  8.0% | 6.07 KiB |       7 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
+|     % |     Size | Allocations | Caller     | Location                                                       |
+| ----: | -------: | ----------: | ---------- | -------------------------------------------------------------- |
+| 50.5% | 38.2 KiB |          45 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`          |
+| 23.1% | 17.5 KiB |          18 | `<module>` | `black/trans.py:1`                                             |
+| 18.3% | 13.9 KiB |           9 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`           |
+|  8.0% | 6.07 KiB |           7 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
 
 ##### `normalize_string_prefix` (`black/strings.py:143`)
 
-|      % |     Size | Samples | Caller         | Location               |
-| -----: | -------: | ------: | -------------- | ---------------------- |
-| 100.0% | 57.2 KiB |      65 | `visit_STRING` | `black/linegen.py:413` |
+|      % |     Size | Allocations | Caller         | Location               |
+| -----: | -------: | ----------: | -------------- | ---------------------- |
+| 100.0% | 57.2 KiB |          65 | `visit_STRING` | `black/linegen.py:413` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|      % |     Size | Samples | Caller      | Location                                                     |
-| -----: | -------: | ------: | ----------- | ------------------------------------------------------------ |
-| 100.0% | 44.3 KiB |      31 | `decorator` | `/venv/lib/python3.11/site-packages/click/decorators.py:373` |
+|      % |     Size | Allocations | Caller      | Location                                                     |
+| -----: | -------: | ----------: | ----------- | ------------------------------------------------------------ |
+| 100.0% | 44.3 KiB |          31 | `decorator` | `/venv/lib/python3.11/site-packages/click/decorators.py:373` |
 
 ##### `copy` (`blib2to3/pgen2/grammar.py:131`)
 
-|      % |     Size | Samples | Caller       | Location                 |
-| -----: | -------: | ------: | ------------ | ------------------------ |
-| 100.0% | 41.5 KiB |      16 | `initialize` | `blib2to3/pygram.py:165` |
+|      % |     Size | Allocations | Caller       | Location                 |
+| -----: | -------: | ----------: | ------------ | ------------------------ |
+| 100.0% | 41.5 KiB |          16 | `initialize` | `blib2to3/pygram.py:165` |
 
 ##### `classify` (`blib2to3/pgen2/parse.py:336`)
 
-|      % |   Size | Samples | Caller     | Location                      |
-| -----: | -----: | ------: | ---------- | ----------------------------- |
-| 100.0% | 32 KiB |       1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
+|      % |   Size | Allocations | Caller     | Location                      |
+| -----: | -----: | ----------: | ---------- | ----------------------------- |
+| 100.0% | 32 KiB |           1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
 
 ##### `make_first` (`blib2to3/pgen2/pgen.py:74`)
 
-|      % |     Size | Samples | Caller         | Location                    |
-| -----: | -------: | ------: | -------------- | --------------------------- |
-| 100.0% | 25.3 KiB |      40 | `make_grammar` | `blib2to3/pgen2/pgen.py:49` |
+|      % |     Size | Allocations | Caller         | Location                    |
+| -----: | -------: | ----------: | -------------- | --------------------------- |
+| 100.0% | 25.3 KiB |          40 | `make_grammar` | `blib2to3/pgen2/pgen.py:49` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 25 KiB |      22 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 25 KiB |          22 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__new__` (`/usr/lib/python3.11/enum.py:488`)
 
-|     % |     Size | Samples | Caller     | Location                                                     |
-| ----: | -------: | ------: | ---------- | ------------------------------------------------------------ |
-| 31.7% | 7.64 KiB |       9 | `<module>` | `black/mode.py:1`                                            |
-| 16.2% | 3.89 KiB |       4 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/_elffile.py:1` |
-| 13.7% |  3.3 KiB |       3 | `<module>` | `/venv/lib/python3.11/site-packages/click/_utils.py:1`       |
-| 10.1% | 2.44 KiB |       3 | `<module>` | `black/__init__.py:1`                                        |
-|  7.2% | 1.74 KiB |       2 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`         |
+|     % |     Size | Allocations | Caller     | Location                                                     |
+| ----: | -------: | ----------: | ---------- | ------------------------------------------------------------ |
+| 31.7% | 7.64 KiB |           9 | `<module>` | `black/mode.py:1`                                            |
+| 16.2% | 3.89 KiB |           4 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/_elffile.py:1` |
+| 13.7% |  3.3 KiB |           3 | `<module>` | `/venv/lib/python3.11/site-packages/click/_utils.py:1`       |
+| 10.1% | 2.44 KiB |           3 | `<module>` | `black/__init__.py:1`                                        |
+|  7.2% | 1.74 KiB |           2 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`         |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|      % |     Size | Samples | Caller     | Location                                 |
-| -----: | -------: | ------: | ---------- | ---------------------------------------- |
-| 100.0% | 22.6 KiB |      12 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
+|      % |     Size | Allocations | Caller     | Location                                 |
+| -----: | -------: | ----------: | ---------- | ---------------------------------------- |
+| 100.0% | 22.6 KiB |          12 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
 
 ##### `<module>` (`blib2to3/pgen2/tokenize.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 20.7 KiB |      14 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 20.7 KiB |          14 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/_parser.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 19.8 KiB |      12 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 19.8 KiB |          12 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `convert_one_fmt_off_pair` (`black/comments.py:177`)
 
-|      % |     Size | Samples | Caller              | Location                |
-| -----: | -------: | ------: | ------------------- | ----------------------- |
-| 100.0% | 18.6 KiB |       2 | `normalize_fmt_off` | `black/comments.py:168` |
+|      % |     Size | Allocations | Caller              | Location                |
+| -----: | -------: | ----------: | ------------------- | ----------------------- |
+| 100.0% | 18.6 KiB |           2 | `normalize_fmt_off` | `black/comments.py:168` |
 
 ##### `__new__` (`/usr/lib/python3.11/typing.py:2891`)
 
-|     % |     Size | Samples | Caller     | Location                                                    |
-| ----: | -------: | ------: | ---------- | ----------------------------------------------------------- |
-| 90.3% | 15.7 KiB |      19 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`       |
-|  9.7% | 1.69 KiB |       2 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/version.py:1` |
+|     % |     Size | Allocations | Caller     | Location                                                    |
+| ----: | -------: | ----------: | ---------- | ----------------------------------------------------------- |
+| 90.3% | 15.7 KiB |          19 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`       |
+|  9.7% | 1.69 KiB |           2 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/version.py:1` |
 
 ##### `<module>` (`blib2to3/pytree.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 15 KiB |      18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 15 KiB |          18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/mypy_extensions.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 15 KiB |      18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 15 KiB |          18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `make_grammar` (`blib2to3/pgen2/pgen.py:49`)
 
-|      % |     Size | Samples | Caller             | Location                     |
-| -----: | -------: | ------: | ------------------ | ---------------------------- |
-| 100.0% | 14.2 KiB |       5 | `generate_grammar` | `blib2to3/pgen2/pgen.py:426` |
+|      % |     Size | Allocations | Caller             | Location                     |
+| -----: | -------: | ----------: | ------------------ | ---------------------------- |
+| 100.0% | 14.2 KiB |           5 | `generate_grammar` | `blib2to3/pgen2/pgen.py:426` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/exceptions.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 13.4 KiB |      15 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 13.4 KiB |          15 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `inner` (`/usr/lib/python3.11/typing.py:338`)
 
-|     % |     Size | Samples | Caller        | Location                                              |
-| ----: | -------: | ------: | ------------- | ----------------------------------------------------- |
-| 75.3% | 9.02 KiB |       1 | `Line`        | `black/lines.py:49`                                   |
-| 17.9% | 2.15 KiB |       1 | `__getitem__` | `/usr/lib/python3.11/typing.py:467`                   |
-|  6.7% |    826 B |       1 | `<module>`    | `/venv/lib/python3.11/site-packages/click/types.py:1` |
+|     % |     Size | Allocations | Caller        | Location                                              |
+| ----: | -------: | ----------: | ------------- | ----------------------------------------------------- |
+| 75.3% | 9.02 KiB |           1 | `Line`        | `black/lines.py:49`                                   |
+| 17.9% | 2.15 KiB |           1 | `__getitem__` | `/usr/lib/python3.11/typing.py:467`                   |
+|  6.7% |    826 B |           1 | `<module>`    | `/venv/lib/python3.11/site-packages/click/types.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/version.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 9.61 KiB |       9 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 9.61 KiB |           9 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `_fill_cache` (`<frozen importlib._bootstrap_external>:1655`)
 
-|      % |  Size | Samples | Caller      | Location                                      |
-| -----: | ----: | ------: | ----------- | --------------------------------------------- |
-| 100.0% | 8 KiB |       4 | `find_spec` | `<frozen importlib._bootstrap_external>:1604` |
+|      % |  Size | Allocations | Caller      | Location                                      |
+| -----: | ----: | ----------: | ----------- | --------------------------------------------- |
+| 100.0% | 8 KiB |           4 | `find_spec` | `<frozen importlib._bootstrap_external>:1604` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|      % |     Size | Samples | Caller  | Location                                |
-| -----: | -------: | ------: | ------- | --------------------------------------- |
-| 100.0% | 7.97 KiB |       1 | `parse` | `/usr/lib/python3.11/re/_parser.py:970` |
+|      % |     Size | Allocations | Caller  | Location                                |
+| -----: | -------: | ----------: | ------- | --------------------------------------- |
+| 100.0% | 7.97 KiB |           1 | `parse` | `/usr/lib/python3.11/re/_parser.py:970` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/utils.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 7.08 KiB |       8 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 7.08 KiB |           8 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__setattr__` (`/usr/lib/python3.11/enum.py:831`)
 
-|     % |     Size | Samples | Caller         | Location                          |
-| ----: | -------: | ------: | -------------- | --------------------------------- |
-| 66.6% | 4.48 KiB |       5 | `__set_name__` | `/usr/lib/python3.11/enum.py:237` |
-| 33.4% | 2.25 KiB |       3 | `__new__`      | `/usr/lib/python3.11/enum.py:488` |
+|     % |     Size | Allocations | Caller         | Location                          |
+| ----: | -------: | ----------: | -------------- | --------------------------------- |
+| 66.6% | 4.48 KiB |           5 | `__set_name__` | `/usr/lib/python3.11/enum.py:237` |
+| 33.4% | 2.25 KiB |           3 | `__new__`      | `/usr/lib/python3.11/enum.py:488` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/util.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 6.48 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 6.48 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 6.24 KiB |       5 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 6.24 KiB |           5 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 5.97 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 5.97 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/_compat.py:1`)
 
-|      % |    Size | Samples | Caller                      | Location                            |
-| -----: | ------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 5.8 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |    Size | Allocations | Caller                      | Location                            |
+| -----: | ------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 5.8 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `namedtuple` (`/usr/lib/python3.11/collections/__init__.py:348`)
 
-|     % |     Size | Samples | Caller          | Location                             |
-| ----: | -------: | ------: | --------------- | ------------------------------------ |
-| 83.3% | 4.69 KiB |       5 | `_make_nmtuple` | `/usr/lib/python3.11/typing.py:2795` |
-| 16.7% |    960 B |       1 | `<module>`      | `/usr/lib/python3.11/pkgutil.py:1`   |
+|     % |     Size | Allocations | Caller          | Location                             |
+| ----: | -------: | ----------: | --------------- | ------------------------------------ |
+| 83.3% | 4.69 KiB |           5 | `_make_nmtuple` | `/usr/lib/python3.11/typing.py:2795` |
+| 16.7% |    960 B |           1 | `<module>`      | `/usr/lib/python3.11/pkgutil.py:1`   |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|      % |     Size | Samples | Caller       | Location                                |
-| -----: | -------: | ------: | ------------ | --------------------------------------- |
-| 100.0% | 5.61 KiB |       3 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
+|      % |     Size | Allocations | Caller       | Location                                |
+| -----: | -------: | ----------: | ------------ | --------------------------------------- |
+| 100.0% | 5.61 KiB |           3 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
 
 ##### `_code` (`/usr/lib/python3.11/re/_compiler.py:571`)
 
-|      % |     Size | Samples | Caller    | Location                                  |
-| -----: | -------: | ------: | --------- | ----------------------------------------- |
-| 100.0% | 5.32 KiB |       2 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
+|      % |     Size | Allocations | Caller    | Location                                  |
+| -----: | -------: | ----------: | --------- | ----------------------------------------- |
+| 100.0% | 5.32 KiB |           2 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
 
 ##### `<module>` (`/usr/lib/python3.11/pkgutil.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 4.73 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 4.73 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `Specifier` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`)
 
-|      % |     Size | Samples | Caller     | Location                                                       |
-| -----: | -------: | ------: | ---------- | -------------------------------------------------------------- |
-| 100.0% | 3.82 KiB |       1 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
+|      % |     Size | Allocations | Caller     | Location                                                       |
+| -----: | -------: | ----------: | ---------- | -------------------------------------------------------------- |
+| 100.0% | 3.82 KiB |           1 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.72 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.72 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.56 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.56 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `handle_parse_result` (`/venv/lib/python3.11/site-packages/click/core.py:2663`)
 
-|      % |     Size | Samples | Caller       | Location                                                |
-| -----: | -------: | ------: | ------------ | ------------------------------------------------------- |
-| 100.0% | 3.37 KiB |       5 | `parse_args` | `/venv/lib/python3.11/site-packages/click/core.py:1303` |
+|      % |     Size | Allocations | Caller       | Location                                                |
+| -----: | -------: | ----------: | ------------ | ------------------------------------------------------- |
+| 100.0% | 3.37 KiB |           5 | `parse_args` | `/venv/lib/python3.11/site-packages/click/core.py:1303` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.19 KiB |       1 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.19 KiB |           1 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.19 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.19 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Caller   | Location                                               |
-| -----: | -------: | ------: | -------- | ------------------------------------------------------ |
-| 100.0% | 3.04 KiB |       2 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
+|      % |     Size | Allocations | Caller   | Location                                               |
+| -----: | -------: | ----------: | -------- | ------------------------------------------------------ |
+| 100.0% | 3.04 KiB |           2 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|      % |     Size | Samples | Caller     | Location                                                   |
-| -----: | -------: | ------: | ---------- | ---------------------------------------------------------- |
-| 100.0% | 2.85 KiB |       1 | `<module>` | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1` |
+|      % |     Size | Allocations | Caller     | Location                                                   |
+| -----: | -------: | ----------: | ---------- | ---------------------------------------------------------- |
+| 100.0% | 2.85 KiB |           1 | `<module>` | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1` |
 
 ##### `_process_class` (`/usr/lib/python3.11/dataclasses.py:884`)
 
-|      % |     Size | Samples | Caller | Location                                  |
-| -----: | -------: | ------: | ------ | ----------------------------------------- |
-| 100.0% | 2.85 KiB |       4 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
+|      % |     Size | Allocations | Caller | Location                                  |
+| -----: | -------: | ----------: | ------ | ----------------------------------------- |
+| 100.0% | 2.85 KiB |           4 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.81 KiB |       3 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.81 KiB |           3 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.76 KiB |       2 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.76 KiB |           2 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ### Total size
 
 Functions ranked by total bytes never freed in the function and all its callees.
 
-|      % |     Size | Samples | Function               | Location                                                       |
-| -----: | -------: | ------: | ---------------------- | -------------------------------------------------------------- |
-| 100.0% | 55.9 MiB |  22,489 | `_run_tracker`         | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
-| 100.0% | 55.9 MiB |  22,488 | `run_module`           | `<frozen runpy>:201`                                           |
-|  92.3% | 51.6 MiB |  21,189 | `__call__`             | `/venv/lib/python3.11/site-packages/click/core.py:1567`        |
-|  92.3% | 51.6 MiB |  21,189 | `patched_main`         | `black/__init__.py:1594`                                       |
-|  92.3% | 51.6 MiB |  21,189 | `<module>`             | `black/__main__.py:1`                                          |
-|  92.3% | 51.6 MiB |  21,189 | `_run_code`            | `<frozen runpy>:65`                                            |
-|  92.3% | 51.6 MiB |  21,189 | `_run_module_code`     | `<frozen runpy>:91`                                            |
-|  92.3% | 51.6 MiB |  21,188 | `main`                 | `/venv/lib/python3.11/site-packages/click/core.py:1422`        |
-|  92.3% | 51.6 MiB |  21,169 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:1339`        |
-|  92.3% | 51.6 MiB |  21,167 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:853`         |
-|  92.3% | 51.6 MiB |  21,166 | `new_func`             | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
-|  92.3% | 51.6 MiB |  21,164 | `main`                 | `black/__init__.py:244`                                        |
-|  92.3% | 51.6 MiB |  21,159 | `reformat_one`         | `black/__init__.py:860`                                        |
-|  92.3% | 51.6 MiB |  21,152 | `format_file_in_place` | `black/__init__.py:917`                                        |
-|  92.3% | 51.6 MiB |  21,151 | `format_file_contents` | `black/__init__.py:1054`                                       |
-|  85.1% | 47.6 MiB |  21,143 | `_format_str_once`     | `black/__init__.py:1236`                                       |
-|  63.4% | 35.4 MiB |  21,086 | `visit`                | `black/nodes.py:163`                                           |
-|  63.4% | 35.4 MiB |  21,084 | `visit_default`        | `black/linegen.py:134`                                         |
-|  63.4% | 35.4 MiB |  21,084 | `visit_default`        | `black/nodes.py:187`                                           |
-|  62.9% | 35.2 MiB |  20,713 | `visit_stmt`           | `black/linegen.py:199`                                         |
+|      % |     Size | Allocations | Function               | Location                                                       |
+| -----: | -------: | ----------: | ---------------------- | -------------------------------------------------------------- |
+| 100.0% | 55.9 MiB |      22,489 | `_run_tracker`         | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
+| 100.0% | 55.9 MiB |      22,488 | `run_module`           | `<frozen runpy>:201`                                           |
+|  92.3% | 51.6 MiB |      21,189 | `__call__`             | `/venv/lib/python3.11/site-packages/click/core.py:1567`        |
+|  92.3% | 51.6 MiB |      21,189 | `patched_main`         | `black/__init__.py:1594`                                       |
+|  92.3% | 51.6 MiB |      21,189 | `<module>`             | `black/__main__.py:1`                                          |
+|  92.3% | 51.6 MiB |      21,189 | `_run_code`            | `<frozen runpy>:65`                                            |
+|  92.3% | 51.6 MiB |      21,189 | `_run_module_code`     | `<frozen runpy>:91`                                            |
+|  92.3% | 51.6 MiB |      21,188 | `main`                 | `/venv/lib/python3.11/site-packages/click/core.py:1422`        |
+|  92.3% | 51.6 MiB |      21,169 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:1339`        |
+|  92.3% | 51.6 MiB |      21,167 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:853`         |
+|  92.3% | 51.6 MiB |      21,166 | `new_func`             | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
+|  92.3% | 51.6 MiB |      21,164 | `main`                 | `black/__init__.py:244`                                        |
+|  92.3% | 51.6 MiB |      21,159 | `reformat_one`         | `black/__init__.py:860`                                        |
+|  92.3% | 51.6 MiB |      21,152 | `format_file_in_place` | `black/__init__.py:917`                                        |
+|  92.3% | 51.6 MiB |      21,151 | `format_file_contents` | `black/__init__.py:1054`                                       |
+|  85.1% | 47.6 MiB |      21,143 | `_format_str_once`     | `black/__init__.py:1236`                                       |
+|  63.4% | 35.4 MiB |      21,086 | `visit`                | `black/nodes.py:163`                                           |
+|  63.4% | 35.4 MiB |      21,084 | `visit_default`        | `black/linegen.py:134`                                         |
+|  63.4% | 35.4 MiB |      21,084 | `visit_default`        | `black/nodes.py:187`                                           |
+|  62.9% | 35.2 MiB |      20,713 | `visit_stmt`           | `black/linegen.py:199`                                         |
 
 #### Categories
 
 ##### Ours
 
-|     % |     Size | Samples | Function                          | Location                 |
-| ----: | -------: | ------: | --------------------------------- | ------------------------ |
-| 92.3% | 51.6 MiB |  21,189 | `patched_main`                    | `black/__init__.py:1594` |
-| 92.3% | 51.6 MiB |  21,189 | `<module>`                        | `black/__main__.py:1`    |
-| 92.3% | 51.6 MiB |  21,164 | `main`                            | `black/__init__.py:244`  |
-| 92.3% | 51.6 MiB |  21,159 | `reformat_one`                    | `black/__init__.py:860`  |
-| 92.3% | 51.6 MiB |  21,152 | `format_file_in_place`            | `black/__init__.py:917`  |
-| 92.3% | 51.6 MiB |  21,151 | `format_file_contents`            | `black/__init__.py:1054` |
-| 85.1% | 47.6 MiB |  21,143 | `_format_str_once`                | `black/__init__.py:1236` |
-| 63.4% | 35.4 MiB |  21,086 | `visit`                           | `black/nodes.py:163`     |
-| 63.4% | 35.4 MiB |  21,084 | `visit_default`                   | `black/linegen.py:134`   |
-| 63.4% | 35.4 MiB |  21,084 | `visit_default`                   | `black/nodes.py:187`     |
-| 62.9% | 35.2 MiB |  20,713 | `visit_stmt`                      | `black/linegen.py:199`   |
-| 58.7% | 32.8 MiB |  20,270 | `visit_funcdef`                   | `black/linegen.py:254`   |
-| 58.5% | 32.7 MiB |  20,144 | `visit_suite`                     | `black/linegen.py:288`   |
-| 55.6% | 31.1 MiB |      89 | `format_str`                      | `black/__init__.py:1189` |
-| 45.2% | 25.3 MiB |  20,890 | `append`                          | `black/lines.py:63`      |
-| 42.6% | 23.8 MiB |  13,402 | `visit_simple_stmt`               | `black/linegen.py:295`   |
-| 36.7% | 20.5 MiB |  21,062 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
-| 30.8% | 17.2 MiB |  20,789 | `mark`                            | `black/brackets.py:70`   |
-| 30.2% | 16.9 MiB |  10,808 | `visit_power`                     | `black/linegen.py:341`   |
-| 29.6% | 16.5 MiB |  21,055 | `assert_stable`                   | `black/__init__.py:1557` |
+|     % |     Size | Allocations | Function                          | Location                 |
+| ----: | -------: | ----------: | --------------------------------- | ------------------------ |
+| 92.3% | 51.6 MiB |      21,189 | `patched_main`                    | `black/__init__.py:1594` |
+| 92.3% | 51.6 MiB |      21,189 | `<module>`                        | `black/__main__.py:1`    |
+| 92.3% | 51.6 MiB |      21,164 | `main`                            | `black/__init__.py:244`  |
+| 92.3% | 51.6 MiB |      21,159 | `reformat_one`                    | `black/__init__.py:860`  |
+| 92.3% | 51.6 MiB |      21,152 | `format_file_in_place`            | `black/__init__.py:917`  |
+| 92.3% | 51.6 MiB |      21,151 | `format_file_contents`            | `black/__init__.py:1054` |
+| 85.1% | 47.6 MiB |      21,143 | `_format_str_once`                | `black/__init__.py:1236` |
+| 63.4% | 35.4 MiB |      21,086 | `visit`                           | `black/nodes.py:163`     |
+| 63.4% | 35.4 MiB |      21,084 | `visit_default`                   | `black/linegen.py:134`   |
+| 63.4% | 35.4 MiB |      21,084 | `visit_default`                   | `black/nodes.py:187`     |
+| 62.9% | 35.2 MiB |      20,713 | `visit_stmt`                      | `black/linegen.py:199`   |
+| 58.7% | 32.8 MiB |      20,270 | `visit_funcdef`                   | `black/linegen.py:254`   |
+| 58.5% | 32.7 MiB |      20,144 | `visit_suite`                     | `black/linegen.py:288`   |
+| 55.6% | 31.1 MiB |          89 | `format_str`                      | `black/__init__.py:1189` |
+| 45.2% | 25.3 MiB |      20,890 | `append`                          | `black/lines.py:63`      |
+| 42.6% | 23.8 MiB |      13,402 | `visit_simple_stmt`               | `black/linegen.py:295`   |
+| 36.7% | 20.5 MiB |      21,062 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+| 30.8% | 17.2 MiB |      20,789 | `mark`                            | `black/brackets.py:70`   |
+| 30.2% | 16.9 MiB |      10,808 | `visit_power`                     | `black/linegen.py:341`   |
+| 29.6% | 16.5 MiB |      21,055 | `assert_stable`                   | `black/__init__.py:1557` |
 
 ##### Standard library
 
-|      % |     Size | Samples | Function                    | Location                                     |
-| -----: | -------: | ------: | --------------------------- | -------------------------------------------- |
-| 100.0% | 55.9 MiB |  22,488 | `run_module`                | `<frozen runpy>:201`                         |
-|  92.3% | 51.6 MiB |  21,189 | `_run_code`                 | `<frozen runpy>:65`                          |
-|  92.3% | 51.6 MiB |  21,189 | `_run_module_code`          | `<frozen runpy>:91`                          |
-|   7.7% | 4.28 MiB |   1,298 | `_get_module_details`       | `<frozen runpy>:105`                         |
-|   7.6% | 4.28 MiB |   1,291 | `_find_and_load`            | `<frozen importlib._bootstrap>:1167`         |
-|   7.6% | 4.28 MiB |   1,289 | `_find_and_load_unlocked`   | `<frozen importlib._bootstrap>:1122`         |
-|   7.6% | 4.28 MiB |   1,288 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`          |
-|   7.6% | 4.27 MiB |   1,286 | `exec_module`               | `<frozen importlib._bootstrap_external>:934` |
-|   7.6% | 4.24 MiB |   1,256 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`          |
-|   5.4% | 3.01 MiB |       4 | `parse`                     | `/usr/lib/python3.11/ast.py:33`              |
-|   2.3% |  1.3 MiB |     318 | `_handle_fromlist`          | `<frozen importlib._bootstrap>:1209`         |
-|   1.9% | 1.05 MiB |      26 | `compile`                   | `/usr/lib/python3.11/re/__init__.py:225`     |
-|   1.9% | 1.05 MiB |      25 | `_compile`                  | `/usr/lib/python3.11/re/__init__.py:272`     |
-|   1.9% | 1.05 MiB |      24 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`    |
-|   1.8% | 1.01 MiB |       6 | `parse`                     | `/usr/lib/python3.11/re/_parser.py:970`      |
-|   1.8% | 1.01 MiB |      15 | `wrap`                      | `/usr/lib/python3.11/dataclasses.py:1209`    |
-|   1.8% | 1.01 MiB |       5 | `_parse_sub`                | `/usr/lib/python3.11/re/_parser.py:447`      |
-|   1.8% | 1.01 MiB |      14 | `_process_class`            | `/usr/lib/python3.11/dataclasses.py:884`     |
-|   1.8% | 1.01 MiB |      11 | `dataclass`                 | `/usr/lib/python3.11/dataclasses.py:1192`    |
-|   1.8% | 1.01 MiB |       4 | `_parse`                    | `/usr/lib/python3.11/re/_parser.py:507`      |
+|      % |     Size | Allocations | Function                    | Location                                     |
+| -----: | -------: | ----------: | --------------------------- | -------------------------------------------- |
+| 100.0% | 55.9 MiB |      22,488 | `run_module`                | `<frozen runpy>:201`                         |
+|  92.3% | 51.6 MiB |      21,189 | `_run_code`                 | `<frozen runpy>:65`                          |
+|  92.3% | 51.6 MiB |      21,189 | `_run_module_code`          | `<frozen runpy>:91`                          |
+|   7.7% | 4.28 MiB |       1,298 | `_get_module_details`       | `<frozen runpy>:105`                         |
+|   7.6% | 4.28 MiB |       1,291 | `_find_and_load`            | `<frozen importlib._bootstrap>:1167`         |
+|   7.6% | 4.28 MiB |       1,289 | `_find_and_load_unlocked`   | `<frozen importlib._bootstrap>:1122`         |
+|   7.6% | 4.28 MiB |       1,288 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`          |
+|   7.6% | 4.27 MiB |       1,286 | `exec_module`               | `<frozen importlib._bootstrap_external>:934` |
+|   7.6% | 4.24 MiB |       1,256 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`          |
+|   5.4% | 3.01 MiB |           4 | `parse`                     | `/usr/lib/python3.11/ast.py:33`              |
+|   2.3% |  1.3 MiB |         318 | `_handle_fromlist`          | `<frozen importlib._bootstrap>:1209`         |
+|   1.9% | 1.05 MiB |          26 | `compile`                   | `/usr/lib/python3.11/re/__init__.py:225`     |
+|   1.9% | 1.05 MiB |          25 | `_compile`                  | `/usr/lib/python3.11/re/__init__.py:272`     |
+|   1.9% | 1.05 MiB |          24 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`    |
+|   1.8% | 1.01 MiB |           6 | `parse`                     | `/usr/lib/python3.11/re/_parser.py:970`      |
+|   1.8% | 1.01 MiB |          15 | `wrap`                      | `/usr/lib/python3.11/dataclasses.py:1209`    |
+|   1.8% | 1.01 MiB |           5 | `_parse_sub`                | `/usr/lib/python3.11/re/_parser.py:447`      |
+|   1.8% | 1.01 MiB |          14 | `_process_class`            | `/usr/lib/python3.11/dataclasses.py:884`     |
+|   1.8% | 1.01 MiB |          11 | `dataclass`                 | `/usr/lib/python3.11/dataclasses.py:1192`    |
+|   1.8% | 1.01 MiB |           4 | `_parse`                    | `/usr/lib/python3.11/re/_parser.py:507`      |
 
 ##### Third-party
 
-|      % |     Size | Samples | Function       | Location                                                                         |
-| -----: | -------: | ------: | -------------- | -------------------------------------------------------------------------------- |
-| 100.0% | 55.9 MiB |  22,489 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40`                   |
-|  92.3% | 51.6 MiB |  21,189 | `__call__`     | `/venv/lib/python3.11/site-packages/click/core.py:1567`                          |
-|  92.3% | 51.6 MiB |  21,188 | `main`         | `/venv/lib/python3.11/site-packages/click/core.py:1422`                          |
-|  92.3% | 51.6 MiB |  21,169 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339`                          |
-|  92.3% | 51.6 MiB |  21,167 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:853`                           |
-|  92.3% | 51.6 MiB |  21,166 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                      |
-|   2.3% | 1.31 MiB |     304 | `<module>`     | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                         |
-|   2.2% | 1.23 MiB |     233 | `<module>`     | `/venv/lib/python3.11/site-packages/click/core.py:1`                             |
-|   1.8% | 1.02 MiB |      24 | `<module>`     | `/venv/lib/python3.11/site-packages/click/formatting.py:1`                       |
-|   1.8% | 1.01 MiB |      11 | `<module>`     | `/venv/lib/python3.11/site-packages/click/parser.py:1`                           |
-|   0.2% |  137 KiB |     140 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`                   |
-|   0.2% |  125 KiB |     127 | `<module>`     | `/venv/lib/python3.11/site-packages/click/types.py:1`                            |
-|   0.2% | 93.8 KiB |     119 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`                      |
-|   0.2% | 91.5 KiB |     115 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`                     |
-|   0.1% | 65.5 KiB |      84 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`                 |
-|   0.1% | 63.6 KiB |      71 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                        |
-|   0.1% | 47.3 KiB |      33 | `decorator`    | `/venv/lib/python3.11/site-packages/click/decorators.py:373`                     |
-|   0.1% | 46.9 KiB |      59 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1` |
-|   0.1% | 45.5 KiB |      32 | `__init__`     | `/venv/lib/python3.11/site-packages/click/core.py:2883`                          |
-|   0.1% | 40.8 KiB |      42 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                      |
+|      % |     Size | Allocations | Function       | Location                                                                         |
+| -----: | -------: | ----------: | -------------- | -------------------------------------------------------------------------------- |
+| 100.0% | 55.9 MiB |      22,489 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40`                   |
+|  92.3% | 51.6 MiB |      21,189 | `__call__`     | `/venv/lib/python3.11/site-packages/click/core.py:1567`                          |
+|  92.3% | 51.6 MiB |      21,188 | `main`         | `/venv/lib/python3.11/site-packages/click/core.py:1422`                          |
+|  92.3% | 51.6 MiB |      21,169 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339`                          |
+|  92.3% | 51.6 MiB |      21,167 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:853`                           |
+|  92.3% | 51.6 MiB |      21,166 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                      |
+|   2.3% | 1.31 MiB |         304 | `<module>`     | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                         |
+|   2.2% | 1.23 MiB |         233 | `<module>`     | `/venv/lib/python3.11/site-packages/click/core.py:1`                             |
+|   1.8% | 1.02 MiB |          24 | `<module>`     | `/venv/lib/python3.11/site-packages/click/formatting.py:1`                       |
+|   1.8% | 1.01 MiB |          11 | `<module>`     | `/venv/lib/python3.11/site-packages/click/parser.py:1`                           |
+|   0.2% |  137 KiB |         140 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`                   |
+|   0.2% |  125 KiB |         127 | `<module>`     | `/venv/lib/python3.11/site-packages/click/types.py:1`                            |
+|   0.2% | 93.8 KiB |         119 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`                      |
+|   0.2% | 91.5 KiB |         115 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`                     |
+|   0.1% | 65.5 KiB |          84 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`                 |
+|   0.1% | 63.6 KiB |          71 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                        |
+|   0.1% | 47.3 KiB |          33 | `decorator`    | `/venv/lib/python3.11/site-packages/click/decorators.py:373`                     |
+|   0.1% | 46.9 KiB |          59 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1` |
+|   0.1% | 45.5 KiB |          32 | `__init__`     | `/venv/lib/python3.11/site-packages/click/core.py:2883`                          |
+|   0.1% | 40.8 KiB |          42 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                      |
 
 #### Callees
 
@@ -2529,397 +2529,397 @@ Callees ranked by contribution to each function's total size. Inlining can make 
 
 ##### `_run_tracker` (`/venv/lib/python3.11/site-packages/memray/commands/run.py:40`)
 
-|      % |     Size | Samples | Callee       | Location             |
-| -----: | -------: | ------: | ------------ | -------------------- |
-| 100.0% | 55.9 MiB |  22,488 | `run_module` | `<frozen runpy>:201` |
+|      % |     Size | Allocations | Callee       | Location             |
+| -----: | -------: | ----------: | ------------ | -------------------- |
+| 100.0% | 55.9 MiB |      22,488 | `run_module` | `<frozen runpy>:201` |
 
 ##### `run_module` (`<frozen runpy>:201`)
 
-|     % |     Size | Samples | Callee                | Location             |
-| ----: | -------: | ------: | --------------------- | -------------------- |
-| 92.3% | 51.6 MiB |  21,189 | `_run_module_code`    | `<frozen runpy>:91`  |
-|  7.7% | 4.28 MiB |   1,298 | `_get_module_details` | `<frozen runpy>:105` |
+|     % |     Size | Allocations | Callee                | Location             |
+| ----: | -------: | ----------: | --------------------- | -------------------- |
+| 92.3% | 51.6 MiB |      21,189 | `_run_module_code`    | `<frozen runpy>:91`  |
+|  7.7% | 4.28 MiB |       1,298 | `_get_module_details` | `<frozen runpy>:105` |
 
 ##### `__call__` (`/venv/lib/python3.11/site-packages/click/core.py:1567`)
 
-|      % |     Size | Samples | Callee | Location                                                |
-| -----: | -------: | ------: | ------ | ------------------------------------------------------- |
-| 100.0% | 51.6 MiB |  21,188 | `main` | `/venv/lib/python3.11/site-packages/click/core.py:1422` |
+|      % |     Size | Allocations | Callee | Location                                                |
+| -----: | -------: | ----------: | ------ | ------------------------------------------------------- |
+| 100.0% | 51.6 MiB |      21,188 | `main` | `/venv/lib/python3.11/site-packages/click/core.py:1422` |
 
 ##### `patched_main` (`black/__init__.py:1594`)
 
-|      % |     Size | Samples | Callee     | Location                                                |
-| -----: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 100.0% | 51.6 MiB |  21,189 | `__call__` | `/venv/lib/python3.11/site-packages/click/core.py:1567` |
+|      % |     Size | Allocations | Callee     | Location                                                |
+| -----: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 100.0% | 51.6 MiB |      21,189 | `__call__` | `/venv/lib/python3.11/site-packages/click/core.py:1567` |
 
 ##### `<module>` (`black/__main__.py:1`)
 
-|      % |     Size | Samples | Callee         | Location                 |
-| -----: | -------: | ------: | -------------- | ------------------------ |
-| 100.0% | 51.6 MiB |  21,189 | `patched_main` | `black/__init__.py:1594` |
+|      % |     Size | Allocations | Callee         | Location                 |
+| -----: | -------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 51.6 MiB |      21,189 | `patched_main` | `black/__init__.py:1594` |
 
 ##### `_run_code` (`<frozen runpy>:65`)
 
-|      % |     Size | Samples | Callee     | Location              |
-| -----: | -------: | ------: | ---------- | --------------------- |
-| 100.0% | 51.6 MiB |  21,189 | `<module>` | `black/__main__.py:1` |
+|      % |     Size | Allocations | Callee     | Location              |
+| -----: | -------: | ----------: | ---------- | --------------------- |
+| 100.0% | 51.6 MiB |      21,189 | `<module>` | `black/__main__.py:1` |
 
 ##### `_run_module_code` (`<frozen runpy>:91`)
 
-|      % |     Size | Samples | Callee      | Location            |
-| -----: | -------: | ------: | ----------- | ------------------- |
-| 100.0% | 51.6 MiB |  21,189 | `_run_code` | `<frozen runpy>:65` |
+|      % |     Size | Allocations | Callee      | Location            |
+| -----: | -------: | ----------: | ----------- | ------------------- |
+| 100.0% | 51.6 MiB |      21,189 | `_run_code` | `<frozen runpy>:65` |
 
 ##### `main` (`/venv/lib/python3.11/site-packages/click/core.py:1422`)
 
-|      % |     Size | Samples | Callee         | Location                                                |
-| -----: | -------: | ------: | -------------- | ------------------------------------------------------- |
-| 100.0% | 51.6 MiB |  21,169 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339` |
-|  <0.1% | 13.6 KiB |      16 | `make_context` | `/venv/lib/python3.11/site-packages/click/core.py:1266` |
-|  <0.1% |    529 B |       2 | `__exit__`     | `/venv/lib/python3.11/site-packages/click/core.py:550`  |
+|      % |     Size | Allocations | Callee         | Location                                                |
+| -----: | -------: | ----------: | -------------- | ------------------------------------------------------- |
+| 100.0% | 51.6 MiB |      21,169 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339` |
+|  <0.1% | 13.6 KiB |          16 | `make_context` | `/venv/lib/python3.11/site-packages/click/core.py:1266` |
+|  <0.1% |    529 B |           2 | `__exit__`     | `/venv/lib/python3.11/site-packages/click/core.py:550`  |
 
 ##### `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:1339`)
 
-|      % |     Size | Samples | Callee   | Location                                               |
-| -----: | -------: | ------: | -------- | ------------------------------------------------------ |
-| 100.0% | 51.6 MiB |  21,167 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
+|      % |     Size | Allocations | Callee   | Location                                               |
+| -----: | -------: | ----------: | -------- | ------------------------------------------------------ |
+| 100.0% | 51.6 MiB |      21,167 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
 
 ##### `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`)
 
-|      % |     Size | Samples | Callee     | Location                                                    |
-| -----: | -------: | ------: | ---------- | ----------------------------------------------------------- |
-| 100.0% | 51.6 MiB |  21,166 | `new_func` | `/venv/lib/python3.11/site-packages/click/decorators.py:33` |
+|      % |     Size | Allocations | Callee     | Location                                                    |
+| -----: | -------: | ----------: | ---------- | ----------------------------------------------------------- |
+| 100.0% | 51.6 MiB |      21,166 | `new_func` | `/venv/lib/python3.11/site-packages/click/decorators.py:33` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Callee | Location                |
-| -----: | -------: | ------: | ------ | ----------------------- |
-| 100.0% | 51.6 MiB |  21,164 | `main` | `black/__init__.py:244` |
+|      % |     Size | Allocations | Callee | Location                |
+| -----: | -------: | ----------: | ------ | ----------------------- |
+| 100.0% | 51.6 MiB |      21,164 | `main` | `black/__init__.py:244` |
 
 ##### `main` (`black/__init__.py:244`)
 
-|      % |     Size | Samples | Callee         | Location                |
-| -----: | -------: | ------: | -------------- | ----------------------- |
-| 100.0% | 51.6 MiB |  21,159 | `reformat_one` | `black/__init__.py:860` |
-|  <0.1% | 2.06 KiB |       2 | `get_sources`  | `black/__init__.py:724` |
+|      % |     Size | Allocations | Callee         | Location                |
+| -----: | -------: | ----------: | -------------- | ----------------------- |
+| 100.0% | 51.6 MiB |      21,159 | `reformat_one` | `black/__init__.py:860` |
+|  <0.1% | 2.06 KiB |           2 | `get_sources`  | `black/__init__.py:724` |
 
 ##### `reformat_one` (`black/__init__.py:860`)
 
-|      % |     Size | Samples | Callee                 | Location                |
-| -----: | -------: | ------: | ---------------------- | ----------------------- |
-| 100.0% | 51.6 MiB |  21,152 | `format_file_in_place` | `black/__init__.py:917` |
-|  <0.1% | 1.92 KiB |       2 | `done`                 | `black/report.py:36`    |
-|  <0.1% | 1.13 KiB |       1 | `read`                 | `black/cache.py:60`     |
-|  <0.1% |     72 B |       2 | `write`                | `black/cache.py:132`    |
+|      % |     Size | Allocations | Callee                 | Location                |
+| -----: | -------: | ----------: | ---------------------- | ----------------------- |
+| 100.0% | 51.6 MiB |      21,152 | `format_file_in_place` | `black/__init__.py:917` |
+|  <0.1% | 1.92 KiB |           2 | `done`                 | `black/report.py:36`    |
+|  <0.1% | 1.13 KiB |           1 | `read`                 | `black/cache.py:60`     |
+|  <0.1% |     72 B |           2 | `write`                | `black/cache.py:132`    |
 
 ##### `format_file_in_place` (`black/__init__.py:917`)
 
-|      % |     Size | Samples | Callee                 | Location                 |
-| -----: | -------: | ------: | ---------------------- | ------------------------ |
-| 100.0% | 51.6 MiB |  21,151 | `format_file_contents` | `black/__init__.py:1054` |
-|  <0.1% |    552 B |       1 | `decode_bytes`         | `black/__init__.py:1290` |
+|      % |     Size | Allocations | Callee                 | Location                 |
+| -----: | -------: | ----------: | ---------------------- | ------------------------ |
+| 100.0% | 51.6 MiB |      21,151 | `format_file_contents` | `black/__init__.py:1054` |
+|  <0.1% |    552 B |           1 | `decode_bytes`         | `black/__init__.py:1290` |
 
 ##### `format_file_contents` (`black/__init__.py:1054`)
 
-|     % |     Size | Samples | Callee                            | Location                 |
-| ----: | -------: | ------: | --------------------------------- | ------------------------ |
-| 60.2% | 31.1 MiB |      89 | `format_str`                      | `black/__init__.py:1189` |
-| 39.8% | 20.5 MiB |  21,062 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+|     % |     Size | Allocations | Callee                            | Location                 |
+| ----: | -------: | ----------: | --------------------------------- | ------------------------ |
+| 60.2% | 31.1 MiB |          89 | `format_str`                      | `black/__init__.py:1189` |
+| 39.8% | 20.5 MiB |      21,062 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
 
 ##### `_format_str_once` (`black/__init__.py:1236`)
 
-|     % |     Size | Samples | Callee                   | Location                 |
-| ----: | -------: | ------: | ------------------------ | ------------------------ |
-| 74.5% | 35.4 MiB |  21,086 | `visit`                  | `black/nodes.py:163`     |
-| 25.3% |   12 MiB |      31 | `lib2to3_parse`          | `black/parsing.py:55`    |
-|  0.2% | 85.9 KiB |      15 | `transform_line`         | `black/linegen.py:601`   |
-| <0.1% | 19.9 KiB |       3 | `normalize_fmt_off`      | `black/comments.py:168`  |
-| <0.1% | 3.49 KiB |       1 | `detect_target_versions` | `black/__init__.py:1464` |
+|     % |     Size | Allocations | Callee                   | Location                 |
+| ----: | -------: | ----------: | ------------------------ | ------------------------ |
+| 74.5% | 35.4 MiB |      21,086 | `visit`                  | `black/nodes.py:163`     |
+| 25.3% |   12 MiB |          31 | `lib2to3_parse`          | `black/parsing.py:55`    |
+|  0.2% | 85.9 KiB |          15 | `transform_line`         | `black/linegen.py:601`   |
+| <0.1% | 19.9 KiB |           3 | `normalize_fmt_off`      | `black/comments.py:168`  |
+| <0.1% | 3.49 KiB |           1 | `detect_target_versions` | `black/__init__.py:1464` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|      % |     Size | Samples | Callee              | Location               |
-| -----: | -------: | ------: | ------------------- | ---------------------- |
-| 100.0% | 35.4 MiB |  21,084 | `visit_default`     | `black/linegen.py:134` |
-|  99.2% | 35.2 MiB |  20,713 | `visit_stmt`        | `black/linegen.py:199` |
-|  92.6% | 32.8 MiB |  20,270 | `visit_funcdef`     | `black/linegen.py:254` |
-|  92.4% | 32.7 MiB |  20,144 | `visit_suite`       | `black/linegen.py:288` |
-|  67.2% | 23.8 MiB |  13,402 | `visit_simple_stmt` | `black/linegen.py:295` |
+|      % |     Size | Allocations | Callee              | Location               |
+| -----: | -------: | ----------: | ------------------- | ---------------------- |
+| 100.0% | 35.4 MiB |      21,084 | `visit_default`     | `black/linegen.py:134` |
+|  99.2% | 35.2 MiB |      20,713 | `visit_stmt`        | `black/linegen.py:199` |
+|  92.6% | 32.8 MiB |      20,270 | `visit_funcdef`     | `black/linegen.py:254` |
+|  92.4% | 32.7 MiB |      20,144 | `visit_suite`       | `black/linegen.py:288` |
+|  67.2% | 23.8 MiB |      13,402 | `visit_simple_stmt` | `black/linegen.py:295` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|      % |     Size | Samples | Callee              | Location               |
-| -----: | -------: | ------: | ------------------- | ---------------------- |
-| 100.0% | 35.4 MiB |  21,084 | `visit_default`     | `black/nodes.py:187`   |
-|  71.3% | 25.3 MiB |  20,890 | `append`            | `black/lines.py:63`    |
-|  22.6% |    8 MiB |       8 | `generate_comments` | `black/comments.py:52` |
+|      % |     Size | Allocations | Callee              | Location               |
+| -----: | -------: | ----------: | ------------------- | ---------------------- |
+| 100.0% | 35.4 MiB |      21,084 | `visit_default`     | `black/nodes.py:187`   |
+|  71.3% | 25.3 MiB |      20,890 | `append`            | `black/lines.py:63`    |
+|  22.6% |    8 MiB |           8 | `generate_comments` | `black/comments.py:52` |
 
 ##### `visit_default` (`black/nodes.py:187`)
 
-|      % |     Size | Samples | Callee  | Location             |
-| -----: | -------: | ------: | ------- | -------------------- |
-| 100.0% | 35.4 MiB |  21,084 | `visit` | `black/nodes.py:163` |
+|      % |     Size | Allocations | Callee  | Location             |
+| -----: | -------: | ----------: | ------- | -------------------- |
+| 100.0% | 35.4 MiB |      21,084 | `visit` | `black/nodes.py:163` |
 
 ##### `visit_stmt` (`black/linegen.py:199`)
 
-|      % |     Size | Samples | Callee                       | Location                |
-| -----: | -------: | ------: | ---------------------------- | ----------------------- |
-| 100.0% | 35.2 MiB |  20,711 | `visit`                      | `black/nodes.py:163`    |
-|   2.8% |    1 MiB |       2 | `normalize_invisible_parens` | `black/linegen.py:1328` |
+|      % |     Size | Allocations | Callee                       | Location                |
+| -----: | -------: | ----------: | ---------------------------- | ----------------------- |
+| 100.0% | 35.2 MiB |      20,711 | `visit`                      | `black/nodes.py:163`    |
+|   2.8% |    1 MiB |           2 | `normalize_invisible_parens` | `black/linegen.py:1328` |
 
 ##### `visit_funcdef` (`black/linegen.py:254`)
 
-|      % |     Size | Samples | Callee  | Location             |
-| -----: | -------: | ------: | ------- | -------------------- |
-| 100.0% | 32.8 MiB |  20,270 | `visit` | `black/nodes.py:163` |
+|      % |     Size | Allocations | Callee  | Location             |
+| -----: | -------: | ----------: | ------- | -------------------- |
+| 100.0% | 32.8 MiB |      20,270 | `visit` | `black/nodes.py:163` |
 
 ##### `visit_suite` (`black/linegen.py:288`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 32.7 MiB |  20,144 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 32.7 MiB |      20,144 | `visit_default` | `black/linegen.py:134` |
 
 ##### `format_str` (`black/__init__.py:1189`)
 
-|      % |     Size | Samples | Callee             | Location                 |
-| -----: | -------: | ------: | ------------------ | ------------------------ |
-| 100.0% | 31.1 MiB |      88 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |     Size | Allocations | Callee             | Location                 |
+| -----: | -------: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 31.1 MiB |          88 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `append` (`black/lines.py:63`)
 
-|     % |     Size | Samples | Callee       | Location                 |
-| ----: | -------: | ------: | ------------ | ------------------------ |
-| 68.1% | 17.2 MiB |  20,789 | `mark`       | `black/brackets.py:70`   |
-| 23.9% | 6.05 MiB |      95 | `whitespace` | `black/nodes.py:194`     |
-|  7.9% |    2 MiB |       2 | `prefix`     | `blib2to3/pytree.py:480` |
+|     % |     Size | Allocations | Callee       | Location                 |
+| ----: | -------: | ----------: | ------------ | ------------------------ |
+| 68.1% | 17.2 MiB |      20,789 | `mark`       | `black/brackets.py:70`   |
+| 23.9% | 6.05 MiB |          95 | `whitespace` | `black/nodes.py:194`     |
+|  7.9% |    2 MiB |           2 | `prefix`     | `blib2to3/pytree.py:480` |
 
 ##### `visit_simple_stmt` (`black/linegen.py:295`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 23.8 MiB |  13,402 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 23.8 MiB |      13,402 | `visit_default` | `black/linegen.py:134` |
 
 ##### `check_stability_and_equivalence` (`black/__init__.py:1037`)
 
-|     % |     Size | Samples | Callee              | Location                 |
-| ----: | -------: | ------: | ------------------- | ------------------------ |
-| 80.5% | 16.5 MiB |  21,055 | `assert_stable`     | `black/__init__.py:1557` |
-| 19.5% | 4.01 MiB |       6 | `assert_equivalent` | `black/__init__.py:1524` |
+|     % |     Size | Allocations | Callee              | Location                 |
+| ----: | -------: | ----------: | ------------------- | ------------------------ |
+| 80.5% | 16.5 MiB |      21,055 | `assert_stable`     | `black/__init__.py:1557` |
+| 19.5% | 4.01 MiB |           6 | `assert_equivalent` | `black/__init__.py:1524` |
 
 ##### `visit_power` (`black/linegen.py:341`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 16.9 MiB |  10,807 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 16.9 MiB |      10,807 | `visit_default` | `black/linegen.py:134` |
 
 ##### `assert_stable` (`black/__init__.py:1557`)
 
-|      % |     Size | Samples | Callee             | Location                 |
-| -----: | -------: | ------: | ------------------ | ------------------------ |
-| 100.0% | 16.5 MiB |  21,055 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |     Size | Allocations | Callee             | Location                 |
+| -----: | -------: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 16.5 MiB |      21,055 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `_get_module_details` (`<frozen runpy>:105`)
 
-|     % |     Size | Samples | Callee                | Location                             |
-| ----: | -------: | ------: | --------------------- | ------------------------------------ |
-| 99.9% | 4.28 MiB |   1,291 | `_find_and_load`      | `<frozen importlib._bootstrap>:1167` |
-| 99.9% | 4.28 MiB |   1,291 | `_get_module_details` | `<frozen runpy>:105`                 |
-|  0.1% | 5.66 KiB |       6 | `find_spec`           | `<frozen importlib.util>:73`         |
+|     % |     Size | Allocations | Callee                | Location                             |
+| ----: | -------: | ----------: | --------------------- | ------------------------------------ |
+| 99.9% | 4.28 MiB |       1,291 | `_find_and_load`      | `<frozen importlib._bootstrap>:1167` |
+| 99.9% | 4.28 MiB |       1,291 | `_get_module_details` | `<frozen runpy>:105`                 |
+|  0.1% | 5.66 KiB |           6 | `find_spec`           | `<frozen importlib.util>:73`         |
 
 ##### `_find_and_load` (`<frozen importlib._bootstrap>:1167`)
 
-|      % |     Size | Samples | Callee                    | Location                             |
-| -----: | -------: | ------: | ------------------------- | ------------------------------------ |
-| 100.0% | 4.28 MiB |   1,289 | `_find_and_load_unlocked` | `<frozen importlib._bootstrap>:1122` |
-|  <0.1% |    560 B |       1 | `__enter__`               | `<frozen importlib._bootstrap>:169`  |
+|      % |     Size | Allocations | Callee                    | Location                             |
+| -----: | -------: | ----------: | ------------------------- | ------------------------------------ |
+| 100.0% | 4.28 MiB |       1,289 | `_find_and_load_unlocked` | `<frozen importlib._bootstrap>:1122` |
+|  <0.1% |    560 B |           1 | `__enter__`               | `<frozen importlib._bootstrap>:169`  |
 
 ##### `_find_and_load_unlocked` (`<frozen importlib._bootstrap>:1122`)
 
-|      % |     Size | Samples | Callee                      | Location                             |
-| -----: | -------: | ------: | --------------------------- | ------------------------------------ |
-| 100.0% | 4.28 MiB |   1,288 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`  |
-|   0.8% | 37.2 KiB |      47 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`  |
-|   0.2% | 7.48 KiB |       4 | `_find_spec`                | `<frozen importlib._bootstrap>:1056` |
+|      % |     Size | Allocations | Callee                      | Location                             |
+| -----: | -------: | ----------: | --------------------------- | ------------------------------------ |
+| 100.0% | 4.28 MiB |       1,288 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`  |
+|   0.8% | 37.2 KiB |          47 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`  |
+|   0.2% | 7.48 KiB |           4 | `_find_spec`                | `<frozen importlib._bootstrap>:1056` |
 
 ##### `_load_unlocked` (`<frozen importlib._bootstrap>:666`)
 
-|      % |     Size | Samples | Callee             | Location                                     |
-| -----: | -------: | ------: | ------------------ | -------------------------------------------- |
-| 100.0% | 4.27 MiB |   1,286 | `exec_module`      | `<frozen importlib._bootstrap_external>:934` |
-|  <0.1% | 1.83 KiB |       2 | `module_from_spec` | `<frozen importlib._bootstrap>:566`          |
+|      % |     Size | Allocations | Callee             | Location                                     |
+| -----: | -------: | ----------: | ------------------ | -------------------------------------------- |
+| 100.0% | 4.27 MiB |       1,286 | `exec_module`      | `<frozen importlib._bootstrap_external>:934` |
+|  <0.1% | 1.83 KiB |           2 | `module_from_spec` | `<frozen importlib._bootstrap>:566`          |
 
 ##### `exec_module` (`<frozen importlib._bootstrap_external>:934`)
 
-|     % |     Size | Samples | Callee                      | Location                                      |
-| ----: | -------: | ------: | --------------------------- | --------------------------------------------- |
-| 99.3% | 4.24 MiB |   1,256 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
-| 12.8% |  560 KiB |     606 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
+|     % |     Size | Allocations | Callee                      | Location                                      |
+| ----: | -------: | ----------: | --------------------------- | --------------------------------------------- |
+| 99.3% | 4.24 MiB |       1,256 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
+| 12.8% |  560 KiB |         606 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`)
 
-|      % |     Size | Samples | Callee           | Location                                                 |
-| -----: | -------: | ------: | ---------------- | -------------------------------------------------------- |
-| 100.0% | 4.24 MiB |   1,256 | `<module>`       | `black/__init__.py:1`                                    |
-|  54.2% |  2.3 MiB |     270 | `<module>`       | `black/comments.py:1`                                    |
-|  31.0% | 1.31 MiB |     329 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                     |
-|  30.8% | 1.31 MiB |     304 | `<module>`       | `/venv/lib/python3.11/site-packages/click/__init__.py:1` |
-|  30.3% | 1.29 MiB |     255 | `<module>`       | `black/nodes.py:1`                                       |
+|      % |     Size | Allocations | Callee           | Location                                                 |
+| -----: | -------: | ----------: | ---------------- | -------------------------------------------------------- |
+| 100.0% | 4.24 MiB |       1,256 | `<module>`       | `black/__init__.py:1`                                    |
+|  54.2% |  2.3 MiB |         270 | `<module>`       | `black/comments.py:1`                                    |
+|  31.0% | 1.31 MiB |         329 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                     |
+|  30.8% | 1.31 MiB |         304 | `<module>`       | `/venv/lib/python3.11/site-packages/click/__init__.py:1` |
+|  30.3% | 1.29 MiB |         255 | `<module>`       | `black/nodes.py:1`                                       |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|     % |    Size | Samples | Callee           | Location                             |
-| ----: | ------: | ------: | ---------------- | ------------------------------------ |
-| 99.8% | 1.3 MiB |     303 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |    Size | Allocations | Callee           | Location                             |
+| ----: | ------: | ----------: | ---------------- | ------------------------------------ |
+| 99.8% | 1.3 MiB |         303 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `_handle_fromlist` (`<frozen importlib._bootstrap>:1209`)
 
-|      % |    Size | Samples | Callee                      | Location                            |
-| -----: | ------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 1.3 MiB |     318 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |    Size | Allocations | Callee                      | Location                            |
+| -----: | ------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 1.3 MiB |         318 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|     % |     Size | Samples | Callee             | Location                                               |
-| ----: | -------: | ------: | ------------------ | ------------------------------------------------------ |
-| 85.5% | 1.05 MiB |      53 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167`                   |
-| 11.1% |  140 KiB |     145 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209`                   |
-|  1.1% | 13.9 KiB |       9 | `__new__`          | `<frozen abc>:105`                                     |
-|  0.2% | 2.49 KiB |       3 | `__new__`          | `/usr/lib/python3.11/enum.py:488`                      |
-|  0.1% |    768 B |       1 | `Context`          | `/venv/lib/python3.11/site-packages/click/core.py:204` |
+|     % |     Size | Allocations | Callee             | Location                                               |
+| ----: | -------: | ----------: | ------------------ | ------------------------------------------------------ |
+| 85.5% | 1.05 MiB |          53 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167`                   |
+| 11.1% |  140 KiB |         145 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209`                   |
+|  1.1% | 13.9 KiB |           9 | `__new__`          | `<frozen abc>:105`                                     |
+|  0.2% | 2.49 KiB |           3 | `__new__`          | `/usr/lib/python3.11/enum.py:488`                      |
+|  0.1% |    768 B |           1 | `Context`          | `/venv/lib/python3.11/site-packages/click/core.py:204` |
 
 ##### `compile` (`/usr/lib/python3.11/re/__init__.py:225`)
 
-|     % |     Size | Samples | Callee     | Location                                 |
-| ----: | -------: | ------: | ---------- | ---------------------------------------- |
-| 99.9% | 1.05 MiB |      25 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
+|     % |     Size | Allocations | Callee     | Location                                 |
+| ----: | -------: | ----------: | ---------- | ---------------------------------------- |
+| 99.9% | 1.05 MiB |          25 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
 
 ##### `_compile` (`/usr/lib/python3.11/re/__init__.py:272`)
 
-|     % |     Size | Samples | Callee    | Location                                  |
-| ----: | -------: | ------: | --------- | ----------------------------------------- |
-| 99.9% | 1.05 MiB |      24 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
-|  0.1% |    698 B |       1 | `__and__` | `/usr/lib/python3.11/enum.py:1504`        |
+|     % |     Size | Allocations | Callee    | Location                                  |
+| ----: | -------: | ----------: | --------- | ----------------------------------------- |
+| 99.9% | 1.05 MiB |          24 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
+|  0.1% |    698 B |           1 | `__and__` | `/usr/lib/python3.11/enum.py:1504`        |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|     % |     Size | Samples | Callee  | Location                                  |
-| ----: | -------: | ------: | ------- | ----------------------------------------- |
-| 97.0% | 1.01 MiB |       6 | `parse` | `/usr/lib/python3.11/re/_parser.py:970`   |
-|  0.9% |  9.5 KiB |       6 | `_code` | `/usr/lib/python3.11/re/_compiler.py:571` |
+|     % |     Size | Allocations | Callee  | Location                                  |
+| ----: | -------: | ----------: | ------- | ----------------------------------------- |
+| 97.0% | 1.01 MiB |           6 | `parse` | `/usr/lib/python3.11/re/_parser.py:970`   |
+|  0.9% |  9.5 KiB |           6 | `_code` | `/usr/lib/python3.11/re/_compiler.py:571` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 99.8% | 1.02 MiB |      22 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 99.8% | 1.02 MiB |          22 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `parse` (`/usr/lib/python3.11/re/_parser.py:970`)
 
-|     % |     Size | Samples | Callee       | Location                                |
-| ----: | -------: | ------: | ------------ | --------------------------------------- |
-| 99.9% | 1.01 MiB |       5 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
+|     % |     Size | Allocations | Callee       | Location                                |
+| ----: | -------: | ----------: | ------------ | --------------------------------------- |
+| 99.9% | 1.01 MiB |           5 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|     % |     Size | Samples | Callee           | Location                                 |
-| ----: | -------: | ------: | ---------------- | ---------------------------------------- |
-| 99.7% | 1.01 MiB |      14 | `_process_class` | `/usr/lib/python3.11/dataclasses.py:884` |
+|     % |     Size | Allocations | Callee           | Location                                 |
+| ----: | -------: | ----------: | ---------------- | ---------------------------------------- |
+| 99.7% | 1.01 MiB |          14 | `_process_class` | `/usr/lib/python3.11/dataclasses.py:884` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|     % |     Size | Samples | Callee   | Location                                |
-| ----: | -------: | ------: | -------- | --------------------------------------- |
-| 99.2% | 1.01 MiB |       4 | `_parse` | `/usr/lib/python3.11/re/_parser.py:507` |
+|     % |     Size | Allocations | Callee   | Location                                |
+| ----: | -------: | ----------: | -------- | --------------------------------------- |
+| 99.2% | 1.01 MiB |           4 | `_parse` | `/usr/lib/python3.11/re/_parser.py:507` |
 
 ##### `_process_class` (`/usr/lib/python3.11/dataclasses.py:884`)
 
-|     % |    Size | Samples | Callee               | Location                                 |
-| ----: | ------: | ------: | -------------------- | ---------------------------------------- |
-| 98.9% |   1 MiB |       1 | `_init_fn`           | `/usr/lib/python3.11/dataclasses.py:528` |
-|  0.6% | 6.5 KiB |       5 | `signature`          | `/usr/lib/python3.11/inspect.py:3277`    |
-|  0.1% | 1.5 KiB |       2 | `_set_new_attribute` | `/usr/lib/python3.11/dataclasses.py:827` |
-| <0.1% |   341 B |       1 | `_cmp_fn`            | `/usr/lib/python3.11/dataclasses.py:624` |
-| <0.1% |   336 B |       1 | `_repr_fn`           | `/usr/lib/python3.11/dataclasses.py:588` |
+|     % |    Size | Allocations | Callee               | Location                                 |
+| ----: | ------: | ----------: | -------------------- | ---------------------------------------- |
+| 98.9% |   1 MiB |           1 | `_init_fn`           | `/usr/lib/python3.11/dataclasses.py:528` |
+|  0.6% | 6.5 KiB |           5 | `signature`          | `/usr/lib/python3.11/inspect.py:3277`    |
+|  0.1% | 1.5 KiB |           2 | `_set_new_attribute` | `/usr/lib/python3.11/dataclasses.py:827` |
+| <0.1% |   341 B |           1 | `_cmp_fn`            | `/usr/lib/python3.11/dataclasses.py:624` |
+| <0.1% |   336 B |           1 | `_repr_fn`           | `/usr/lib/python3.11/dataclasses.py:588` |
 
 ##### `dataclass` (`/usr/lib/python3.11/dataclasses.py:1192`)
 
-|      % |     Size | Samples | Callee | Location                                  |
-| -----: | -------: | ------: | ------ | ----------------------------------------- |
-| 100.0% | 1.01 MiB |      11 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
+|      % |     Size | Allocations | Callee | Location                                  |
+| -----: | -------: | ----------: | ------ | ----------------------------------------- |
+| 100.0% | 1.01 MiB |          11 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|     % |  Size | Samples | Callee        | Location                                |
-| ----: | ----: | ------: | ------------- | --------------------------------------- |
-| 99.6% | 1 MiB |       2 | `_parse_sub`  | `/usr/lib/python3.11/re/_parser.py:447` |
-| 99.5% | 1 MiB |       1 | `__getitem__` | `/usr/lib/python3.11/re/_parser.py:162` |
+|     % |  Size | Allocations | Callee        | Location                                |
+| ----: | ----: | ----------: | ------------- | --------------------------------------- |
+| 99.6% | 1 MiB |           2 | `_parse_sub`  | `/usr/lib/python3.11/re/_parser.py:447` |
+| 99.5% | 1 MiB |           1 | `__getitem__` | `/usr/lib/python3.11/re/_parser.py:162` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                                                         |
-| ----: | -------: | ------: | ---------------- | ---------------------------------------------------------------- |
-| 87.6% |  120 KiB |     129 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                             |
-|  6.2% |  8.5 KiB |       2 | `Specifier`      | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220` |
-|  4.4% | 6.07 KiB |       7 | `__new__`        | `<frozen abc>:105`                                               |
+|     % |     Size | Allocations | Callee           | Location                                                         |
+| ----: | -------: | ----------: | ---------------- | ---------------------------------------------------------------- |
+| 87.6% |  120 KiB |         129 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                             |
+|  6.2% |  8.5 KiB |           2 | `Specifier`      | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220` |
+|  4.4% | 6.07 KiB |           7 | `__new__`        | `<frozen abc>:105`                                               |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 53.0% | 66.2 KiB |      58 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
-| 30.6% | 38.2 KiB |      45 | `__new__`        | `<frozen abc>:105`                   |
-| 12.6% | 15.7 KiB |      19 | `__new__`        | `/usr/lib/python3.11/typing.py:2891` |
-|  1.1% | 1.42 KiB |       2 | `inner`          | `/usr/lib/python3.11/typing.py:338`  |
-|  0.4% |    542 B |       1 | `__init__`       | `/usr/lib/python3.11/typing.py:992`  |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 53.0% | 66.2 KiB |          58 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+| 30.6% | 38.2 KiB |          45 | `__new__`        | `<frozen abc>:105`                   |
+| 12.6% | 15.7 KiB |          19 | `__new__`        | `/usr/lib/python3.11/typing.py:2891` |
+|  1.1% | 1.42 KiB |           2 | `inner`          | `/usr/lib/python3.11/typing.py:338`  |
+|  0.4% |    542 B |           1 | `__init__`       | `/usr/lib/python3.11/typing.py:992`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 99.2% | 93.1 KiB |     118 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 99.2% | 93.1 KiB |         118 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`)
 
-|     % |   Size | Samples | Callee           | Location                             |
-| ----: | -----: | ------: | ---------------- | ------------------------------------ |
-| 97.3% | 89 KiB |     112 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |   Size | Allocations | Callee           | Location                             |
+| ----: | -----: | ----------: | ---------------- | ------------------------------------ |
+| 97.3% | 89 KiB |         112 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 98.9% | 64.8 KiB |      83 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 98.9% | 64.8 KiB |          83 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|     % |   Size | Samples | Callee           | Location                             |
-| ----: | -----: | ------: | ---------------- | ------------------------------------ |
-| 94.4% | 60 KiB |      67 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |   Size | Allocations | Callee           | Location                             |
+| ----: | -----: | ----------: | ---------------- | ------------------------------------ |
+| 94.4% | 60 KiB |          67 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `decorator` (`/venv/lib/python3.11/site-packages/click/decorators.py:373`)
 
-|     % |     Size | Samples | Callee     | Location                                                |
-| ----: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 96.2% | 45.5 KiB |      32 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2883` |
+|     % |     Size | Allocations | Callee     | Location                                                |
+| ----: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 96.2% | 45.5 KiB |          32 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2883` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 94.8% | 44.5 KiB |      56 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 94.8% | 44.5 KiB |          56 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|    % |     Size | Samples | Callee     | Location                                                |
-| ---: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 2.6% | 1.17 KiB |       1 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2237` |
+|    % |     Size | Allocations | Callee     | Location                                                |
+| ---: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 2.6% | 1.17 KiB |           1 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2237` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 80.6% | 32.9 KiB |      35 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
-|  4.1% | 1.69 KiB |       2 | `__new__`        | `/usr/lib/python3.11/enum.py:488`    |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 80.6% | 32.9 KiB |          35 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|  4.1% | 1.69 KiB |           2 | `__new__`        | `/usr/lib/python3.11/enum.py:488`    |
 
 ## Hottest call stacks
 
@@ -2927,25 +2927,25 @@ Call stacks ranked by bytes never freed in their leaf frame.
 
 Common call stack: `run_module` (`<frozen runpy>:201`) ← `_run_tracker` (`/venv/lib/python3.11/site-packages/memray/commands/run.py:40`)
 
-|    % |     Size | Samples | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| ---: | -------: | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 8.9% |    5 MiB |       5 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `shift` (`blib2to3/pgen2/parse.py:373`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| 5.4% | 3.01 MiB |       4 | `parse` (`/usr/lib/python3.11/ast.py:33`) ← `_parse_single_version` (`black/parsing.py:117`) ← `parse_ast` (129) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| 5.4% |    3 MiB |       3 | `push` (`blib2to3/pgen2/parse.py:386`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| 3.6% |    2 MiB |       2 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| 1.8% | 1.01 MiB |      11 | `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| 1.8% |    1 MiB |       1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `assert_stable` (1557) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| 1.8% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| 1.8% |    1 MiB |       1 | `_create_fn` (`/usr/lib/python3.11/dataclasses.py:413`) ← `_init_fn` (528) ← `_process_class` (884) ← `wrap` (1209) ← `dataclass` (1192) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| 1.8% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| 1.8% |    1 MiB |       1 | `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| 1.8% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
-| 1.8% |    1 MiB |       1 | `_stringify_ast` (`black/parsing.py:174`) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| 1.8% |    1 MiB |       1 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| 1.8% |    1 MiB |       1 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| 1.8% |    1 MiB |       1 | `prefix` (`blib2to3/pytree.py:480`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| 1.8% |    1 MiB |       1 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| 1.8% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `preceding_leaf` (`black/nodes.py:441`) ← `whitespace` (194) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| 1.8% |    1 MiB |       1 | `__init__` (`blib2to3/pytree.py:248`) ← `convert` (486) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| 1.8% |    1 MiB |       1 | `prefix` (`blib2to3/pytree.py:480`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| 1.8% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                       |
+|    % |     Size | Allocations | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ---: | -------: | ----------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 8.9% |    5 MiB |           5 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `shift` (`blib2to3/pgen2/parse.py:373`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| 5.4% | 3.01 MiB |           4 | `parse` (`/usr/lib/python3.11/ast.py:33`) ← `_parse_single_version` (`black/parsing.py:117`) ← `parse_ast` (129) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| 5.4% |    3 MiB |           3 | `push` (`blib2to3/pgen2/parse.py:386`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| 3.6% |    2 MiB |           2 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| 1.8% | 1.01 MiB |          11 | `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| 1.8% |    1 MiB |           1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `assert_stable` (1557) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| 1.8% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| 1.8% |    1 MiB |           1 | `_create_fn` (`/usr/lib/python3.11/dataclasses.py:413`) ← `_init_fn` (528) ← `_process_class` (884) ← `wrap` (1209) ← `dataclass` (1192) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| 1.8% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| 1.8% |    1 MiB |           1 | `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| 1.8% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
+| 1.8% |    1 MiB |           1 | `_stringify_ast` (`black/parsing.py:174`) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `_stringify_ast_with_new_parent` (166) ← `_stringify_ast` (174) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| 1.8% |    1 MiB |           1 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| 1.8% |    1 MiB |           1 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| 1.8% |    1 MiB |           1 | `prefix` (`blib2to3/pytree.py:480`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| 1.8% |    1 MiB |           1 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| 1.8% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `preceding_leaf` (`black/nodes.py:441`) ← `whitespace` (194) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| 1.8% |    1 MiB |           1 | `__init__` (`blib2to3/pytree.py:248`) ← `convert` (486) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| 1.8% |    1 MiB |           1 | `prefix` (`blib2to3/pytree.py:480`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| 1.8% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                       |

--- a/examples/output/python.memray.aggregated.diff.memray.bin.md
+++ b/examples/output/python.memray.aggregated.diff.memray.bin.md
@@ -1,12 +1,12 @@
 # Peak memory profile diff
 
-Held 78.6 MiB over 22,694 samples (3.55 KiB per sample).
+Held 78.6 MiB over 22,694 allocations (3.55 KiB per allocation).
 
-| Category         | Change | Delta |     % |     Size | Samples |
-| ---------------- | -----: | ----: | ----: | -------: | ------: |
-| Ours             |   0.0% |   0 B | 81.6% | 64.2 MiB |  21,445 |
-| Standard library |   0.0% |   0 B | 16.7% | 13.2 MiB |   1,015 |
-| Third-party      |   0.0% |   0 B |  1.6% | 1.27 MiB |     234 |
+| Category         | Change | Delta |     % |     Size | Allocations |
+| ---------------- | -----: | ----: | ----: | -------: | ----------: |
+| Ours             |   0.0% |   0 B | 81.6% | 64.2 MiB |      21,445 |
+| Standard library |   0.0% |   0 B | 16.7% | 13.2 MiB |       1,015 |
+| Third-party      |   0.0% |   0 B |  1.6% | 1.27 MiB |         234 |
 
 ## Hottest functions
 
@@ -18,7 +18,7 @@ Functions with the largest increase in bytes held at peak memory directly in the
 
 ##### Ours
 
-|    Change |  Delta |             % |                Size |         Samples | Function              | Location                 |
+|    Change |  Delta |             % |                Size |     Allocations | Function              | Location                 |
 | --------: | -----: | ------------: | ------------------: | --------------: | --------------------- | ------------------------ |
 |   +200.0% | +2 MiB |   1.3% → 3.8% |       1 MiB → 3 MiB |           1 → 3 | `prefix`              | `blib2to3/pytree.py:480` |
 |    +32.8% | +1 MiB |   3.9% → 5.1% | 3.05 MiB → 4.05 MiB |         59 → 60 | `_stringify_ast`      | `black/parsing.py:174`   |
@@ -34,13 +34,13 @@ Functions with the largest decrease in bytes held at peak memory directly in the
 
 ##### Ours
 
-|  Change |  Delta |            % |          Size | Samples | Function                         | Location                |
-| ------: | -----: | -----------: | ------------: | ------: | -------------------------------- | ----------------------- |
-|  -75.0% | -3 MiB |  5.1% → 1.3% | 4 MiB → 1 MiB |   4 → 1 | `__init__`                       | `<string>:2`            |
-| -100.0% | -2 MiB | 2.5% → <0.1% | 2 MiB → 702 B |   3 → 1 | `visit_default`                  | `black/linegen.py:134`  |
-|  -33.3% | -1 MiB |  3.8% → 2.5% | 3 MiB → 2 MiB |   3 → 2 | `_stringify_ast_with_new_parent` | `black/parsing.py:166`  |
-| removed | -1 MiB |  1.3% → 0.0% |   1 MiB → 0 B |   1 → 0 | `__str__`                        | `black/lines.py:490`    |
-|  -14.3% | -1 MiB |  8.9% → 7.6% | 7 MiB → 6 MiB |   7 → 6 | `__new__`                        | `blib2to3/pytree.py:81` |
+|  Change |  Delta |            % |          Size | Allocations | Function                         | Location                |
+| ------: | -----: | -----------: | ------------: | ----------: | -------------------------------- | ----------------------- |
+|  -75.0% | -3 MiB |  5.1% → 1.3% | 4 MiB → 1 MiB |       4 → 1 | `__init__`                       | `<string>:2`            |
+| -100.0% | -2 MiB | 2.5% → <0.1% | 2 MiB → 702 B |       3 → 1 | `visit_default`                  | `black/linegen.py:134`  |
+|  -33.3% | -1 MiB |  3.8% → 2.5% | 3 MiB → 2 MiB |       3 → 2 | `_stringify_ast_with_new_parent` | `black/parsing.py:166`  |
+| removed | -1 MiB |  1.3% → 0.0% |   1 MiB → 0 B |       1 → 0 | `__str__`                        | `black/lines.py:490`    |
+|  -14.3% | -1 MiB |  8.9% → 7.6% | 7 MiB → 6 MiB |       7 → 6 | `__new__`                        | `blib2to3/pytree.py:81` |
 
 ### Total size
 
@@ -50,7 +50,7 @@ Functions with the largest increase in total bytes held at peak memory in the fu
 
 ##### Ours
 
-|   Change |  Delta |             % |                Size |         Samples | Function                    | Location                 |
+|   Change |  Delta |             % |                Size |     Allocations | Function                    | Location                 |
 | -------: | -----: | ------------: | ------------------: | --------------: | --------------------------- | ------------------------ |
 |   +16.5% | +4 MiB | 30.9% → 36.0% | 24.3 MiB → 28.3 MiB | 20,889 → 20,893 | `append`                    | `black/lines.py:63`      |
 |    +8.2% | +3 MiB | 46.4% → 50.2% | 36.4 MiB → 39.4 MiB | 21,085 → 21,088 | `visit_default`             | `black/linegen.py:134`   |
@@ -77,32 +77,32 @@ Functions with the largest decrease in total bytes held at peak memory in the fu
 
 ##### Ours
 
-|  Change |  Delta |            % |                Size |   Samples | Function                            | Location                 |
-| ------: | -----: | -----------: | ------------------: | --------: | ----------------------------------- | ------------------------ |
-|  -75.0% | -3 MiB |  5.1% → 1.3% |       4 MiB → 1 MiB |     4 → 1 | `__init__`                          | `<string>:2`             |
-|  -99.6% | -3 MiB | 3.8% → <0.1% | 3.01 MiB → 12.2 KiB |   15 → 12 | `transform_line`                    | `black/linegen.py:601`   |
-|  -66.7% | -2 MiB |  3.8% → 1.3% |       3 MiB → 1 MiB |     3 → 1 | `line`                              | `black/linegen.py:109`   |
-|  -99.6% | -2 MiB | 2.6% → <0.1% |  2.01 MiB → 8.6 KiB |    10 → 8 | `run_transformer`                   | `black/linegen.py:1755`  |
-| removed | -2 MiB |  2.5% → 0.0% |         2 MiB → 0 B |     2 → 0 | `visit_INDENT`                      | `black/linegen.py:179`   |
-|  -92.9% | -1 MiB |  1.4% → 0.1% |   1.08 MiB → 78 KiB | 105 → 104 | `visit_test`                        | `black/linegen.py:160`   |
-| removed | -1 MiB |  1.3% → 0.0% |         1 MiB → 0 B |     1 → 0 | `__str__`                           | `black/lines.py:490`     |
-| removed | -1 MiB |  1.3% → 0.0% |         1 MiB → 0 B |     1 → 0 | `line_to_string`                    | `black/lines.py:1073`    |
-|  -14.3% | -1 MiB |  8.9% → 7.6% |       7 MiB → 6 MiB |     7 → 6 | `__new__`                           | `blib2to3/pytree.py:81`  |
-|  -99.9% | -1 MiB | 1.3% → <0.1% |       1 MiB → 802 B |     2 → 1 | `_hugging_power_ops_line_to_string` | `black/linegen.py:590`   |
-|  -99.9% | -1 MiB | 1.3% → <0.1% |    1 MiB → 1.39 KiB |     2 → 1 | `split_wrapper`                     | `black/linegen.py:1162`  |
-| removed | -1 MiB |  1.3% → 0.0% |         1 MiB → 0 B |     1 → 0 | `clone`                             | `blib2to3/pytree.py:452` |
-| removed | -1 MiB |  1.3% → 0.0% |         1 MiB → 0 B |     1 → 0 | `hug_power_op`                      | `black/trans.py:85`      |
-| removed | -1 MiB |  1.3% → 0.0% |         1 MiB → 0 B |     1 → 0 | `delimiter_split`                   | `black/linegen.py:1203`  |
+|  Change |  Delta |            % |                Size | Allocations | Function                            | Location                 |
+| ------: | -----: | -----------: | ------------------: | ----------: | ----------------------------------- | ------------------------ |
+|  -75.0% | -3 MiB |  5.1% → 1.3% |       4 MiB → 1 MiB |       4 → 1 | `__init__`                          | `<string>:2`             |
+|  -99.6% | -3 MiB | 3.8% → <0.1% | 3.01 MiB → 12.2 KiB |     15 → 12 | `transform_line`                    | `black/linegen.py:601`   |
+|  -66.7% | -2 MiB |  3.8% → 1.3% |       3 MiB → 1 MiB |       3 → 1 | `line`                              | `black/linegen.py:109`   |
+|  -99.6% | -2 MiB | 2.6% → <0.1% |  2.01 MiB → 8.6 KiB |      10 → 8 | `run_transformer`                   | `black/linegen.py:1755`  |
+| removed | -2 MiB |  2.5% → 0.0% |         2 MiB → 0 B |       2 → 0 | `visit_INDENT`                      | `black/linegen.py:179`   |
+|  -92.9% | -1 MiB |  1.4% → 0.1% |   1.08 MiB → 78 KiB |   105 → 104 | `visit_test`                        | `black/linegen.py:160`   |
+| removed | -1 MiB |  1.3% → 0.0% |         1 MiB → 0 B |       1 → 0 | `__str__`                           | `black/lines.py:490`     |
+| removed | -1 MiB |  1.3% → 0.0% |         1 MiB → 0 B |       1 → 0 | `line_to_string`                    | `black/lines.py:1073`    |
+|  -14.3% | -1 MiB |  8.9% → 7.6% |       7 MiB → 6 MiB |       7 → 6 | `__new__`                           | `blib2to3/pytree.py:81`  |
+|  -99.9% | -1 MiB | 1.3% → <0.1% |       1 MiB → 802 B |       2 → 1 | `_hugging_power_ops_line_to_string` | `black/linegen.py:590`   |
+|  -99.9% | -1 MiB | 1.3% → <0.1% |    1 MiB → 1.39 KiB |       2 → 1 | `split_wrapper`                     | `black/linegen.py:1162`  |
+| removed | -1 MiB |  1.3% → 0.0% |         1 MiB → 0 B |       1 → 0 | `clone`                             | `blib2to3/pytree.py:452` |
+| removed | -1 MiB |  1.3% → 0.0% |         1 MiB → 0 B |       1 → 0 | `hug_power_op`                      | `black/trans.py:85`      |
+| removed | -1 MiB |  1.3% → 0.0% |         1 MiB → 0 B |       1 → 0 | `delimiter_split`                   | `black/linegen.py:1203`  |
 
 # Leaked memory profile diff
 
-Leaked 55.9 MiB over 22,489 samples (2.55 KiB per sample).
+Leaked 55.9 MiB over 22,489 allocations (2.55 KiB per allocation).
 
-| Category         | Change | Delta |     % |     Size | Samples |
-| ---------------- | -----: | ----: | ----: | -------: | ------: |
-| Ours             |   0.0% |   0 B | 85.6% | 47.9 MiB |  21,383 |
-| Standard library |   0.0% |   0 B | 12.2% | 6.83 MiB |     876 |
-| Third-party      |   0.0% |   0 B |  2.2% | 1.23 MiB |     230 |
+| Category         | Change | Delta |     % |     Size | Allocations |
+| ---------------- | -----: | ----: | ----: | -------: | ----------: |
+| Ours             |   0.0% |   0 B | 85.6% | 47.9 MiB |      21,383 |
+| Standard library |   0.0% |   0 B | 12.2% | 6.83 MiB |         876 |
+| Third-party      |   0.0% |   0 B |  2.2% | 1.23 MiB |         230 |
 
 ## Hottest functions
 
@@ -114,7 +114,7 @@ Functions with the largest increase in bytes never freed directly in the functio
 
 ##### Ours
 
-|    Change |  Delta |             % |                Size |         Samples | Function              | Location                 |
+|    Change |  Delta |             % |                Size |     Allocations | Function              | Location                 |
 | --------: | -----: | ------------: | ------------------: | --------------: | --------------------- | ------------------------ |
 |   +200.0% | +2 MiB |   1.8% → 5.4% |       1 MiB → 3 MiB |           1 → 3 | `generate_comments`   | `black/comments.py:52`   |
 |     +6.2% | +1 MiB | 29.0% → 30.8% | 16.2 MiB → 17.2 MiB | 20,788 → 20,789 | `mark`                | `black/brackets.py:70`   |
@@ -130,14 +130,14 @@ Functions with the largest decrease in bytes never freed directly in the functio
 
 ##### Ours
 
-|  Change |  Delta |             % |                Size | Samples | Function                         | Location                 |
-| ------: | -----: | ------------: | ------------------: | ------: | -------------------------------- | ------------------------ |
-| -100.0% | -2 MiB |  3.6% → <0.1% |       2 MiB → 702 B |   3 → 1 | `visit_default`                  | `black/linegen.py:134`   |
-| removed | -2 MiB |   3.6% → 0.0% |         2 MiB → 0 B |   2 → 0 | `__init__`                       | `<string>:2`             |
-|  -49.9% | -1 MiB |   3.6% → 1.8% |       2 MiB → 1 MiB |   6 → 5 | `__init__`                       | `blib2to3/pytree.py:248` |
-|  -93.0% | -1 MiB |   1.9% → 0.1% | 1.07 MiB → 76.5 KiB |   7 → 6 | `transform_line`                 | `black/linegen.py:601`   |
-| removed | -1 MiB |   1.8% → 0.0% |         1 MiB → 0 B |   1 → 0 | `_stringify_ast_with_new_parent` | `black/parsing.py:166`   |
-|  -14.3% | -1 MiB | 12.5% → 10.7% |       7 MiB → 6 MiB |   7 → 6 | `__new__`                        | `blib2to3/pytree.py:81`  |
+|  Change |  Delta |             % |                Size | Allocations | Function                         | Location                 |
+| ------: | -----: | ------------: | ------------------: | ----------: | -------------------------------- | ------------------------ |
+| -100.0% | -2 MiB |  3.6% → <0.1% |       2 MiB → 702 B |       3 → 1 | `visit_default`                  | `black/linegen.py:134`   |
+| removed | -2 MiB |   3.6% → 0.0% |         2 MiB → 0 B |       2 → 0 | `__init__`                       | `<string>:2`             |
+|  -49.9% | -1 MiB |   3.6% → 1.8% |       2 MiB → 1 MiB |       6 → 5 | `__init__`                       | `blib2to3/pytree.py:248` |
+|  -93.0% | -1 MiB |   1.9% → 0.1% | 1.07 MiB → 76.5 KiB |       7 → 6 | `transform_line`                 | `black/linegen.py:601`   |
+| removed | -1 MiB |   1.8% → 0.0% |         1 MiB → 0 B |       1 → 0 | `_stringify_ast_with_new_parent` | `black/parsing.py:166`   |
+|  -14.3% | -1 MiB | 12.5% → 10.7% |       7 MiB → 6 MiB |       7 → 6 | `__new__`                        | `blib2to3/pytree.py:81`  |
 
 ### Total size
 
@@ -147,7 +147,7 @@ Functions with the largest increase in total bytes never freed in the function a
 
 ##### Ours
 
-|   Change |  Delta |             % |                Size |         Samples | Function                    | Location                 |
+|   Change |  Delta |             % |                Size |     Allocations | Function                    | Location                 |
 | -------: | -----: | ------------: | ------------------: | --------------: | --------------------------- | ------------------------ |
 |   +18.8% | +4 MiB | 38.1% → 45.2% | 21.3 MiB → 25.3 MiB | 20,886 → 20,890 | `append`                    | `black/lines.py:63`      |
 |   +14.8% | +4 MiB | 48.4% → 55.6% | 27.1 MiB → 31.1 MiB |         85 → 89 | `format_str`                | `black/__init__.py:1189` |
@@ -175,7 +175,7 @@ Functions with the largest decrease in total bytes never freed in the function a
 
 ##### Ours
 
-|  Change |  Delta |             % |                Size |         Samples | Function                            | Location                 |
+|  Change |  Delta |             % |                Size |     Allocations | Function                            | Location                 |
 | ------: | -----: | ------------: | ------------------: | --------------: | ----------------------------------- | ------------------------ |
 |  -19.5% | -4 MiB | 36.7% → 29.6% | 20.5 MiB → 16.5 MiB | 21,059 → 21,055 | `assert_stable`                     | `black/__init__.py:1557` |
 |  -16.3% | -4 MiB | 43.9% → 36.7% | 24.5 MiB → 20.5 MiB | 21,066 → 21,062 | `check_stability_and_equivalence`   | `black/__init__.py:1037` |

--- a/examples/output/python.memray.base.memray.bin.md
+++ b/examples/output/python.memray.base.memray.bin.md
@@ -1,12 +1,12 @@
 # Peak memory profile
 
-Held 72.4 MiB over 23,696 samples (3.13 KiB per sample).
+Held 72.4 MiB over 23,696 allocations (3.13 KiB per allocation).
 
-| Category         |     % |     Size | Samples |
-| ---------------- | ----: | -------: | ------: |
-| Ours             | 71.8% |   52 MiB |  21,382 |
-| Standard library | 26.4% | 19.1 MiB |   2,080 |
-| Third-party      |  1.8% | 1.27 MiB |     234 |
+| Category         |     % |     Size | Allocations |
+| ---------------- | ----: | -------: | ----------: |
+| Ours             | 71.8% |   52 MiB |      21,382 |
+| Standard library | 26.4% | 19.1 MiB |       2,080 |
+| Third-party      |  1.8% | 1.27 MiB |         234 |
 
 ## Hottest functions
 
@@ -14,105 +14,105 @@ Held 72.4 MiB over 23,696 samples (3.13 KiB per sample).
 
 Functions ranked by bytes held at peak memory directly in the function body, excluding callees.
 
-|     % |     Size | Samples | Function                               | Location                                               |
-| ----: | -------: | ------: | -------------------------------------- | ------------------------------------------------------ |
-| 25.2% | 18.2 MiB |  20,790 | `mark`                                 | `black/brackets.py:70`                                 |
-| 22.0% |   16 MiB |   1,014 | `parse`                                | `/usr/lib/python3.11/ast.py:33`                        |
-|  8.3% |    6 MiB |       6 | `changed`                              | `blib2to3/pytree.py:171`                               |
-|  6.9% |    5 MiB |       5 | `__new__`                              | `blib2to3/pytree.py:81`                                |
-|  4.1% |    3 MiB |       8 | `transform_line`                       | `black/linegen.py:601`                                 |
-|  4.1% |    3 MiB |       4 | `visit_default`                        | `black/linegen.py:134`                                 |
-|  4.1% |    3 MiB |       3 | `generate_comments`                    | `black/comments.py:52`                                 |
-|  3.1% | 2.27 MiB |     352 | `_call_with_frames_removed`            | `<frozen importlib._bootstrap>:233`                    |
-|  3.0% | 2.14 MiB |     197 | `update_sibling_maps`                  | `blib2to3/pytree.py:369`                               |
-|  2.8% |    2 MiB |       2 | `convert`                              | `blib2to3/pytree.py:486`                               |
-|  2.8% |    2 MiB |       2 | `push`                                 | `blib2to3/pgen2/parse.py:386`                          |
-|  1.4% | 1.01 MiB |       6 | `make_grammar`                         | `blib2to3/pgen2/pgen.py:49`                            |
-|  1.4% | 1.01 MiB |      11 | `<module>`                             | `/venv/lib/python3.11/site-packages/click/parser.py:1` |
-|  1.4% |    1 MiB |       5 | `visit`                                | `black/nodes.py:163`                                   |
-|  1.4% |    1 MiB |       2 | `maybe_empty_lines`                    | `black/lines.py:560`                                   |
-|  1.4% |    1 MiB |       1 | `_addtoken`                            | `blib2to3/pgen2/parse.py:290`                          |
-|  1.4% |    1 MiB |       1 | `contains_uncollapsable_type_comments` | `black/lines.py:276`                                   |
-|  1.4% |    1 MiB |       1 | `__init__`                             | `<string>:2`                                           |
-|  1.4% |    1 MiB |       1 | `__init__`                             | `blib2to3/pytree.py:400`                               |
-|  0.4% |  311 KiB |     341 | `_compile_bytecode`                    | `<frozen importlib._bootstrap_external>:727`           |
+|     % |     Size | Allocations | Function                               | Location                                               |
+| ----: | -------: | ----------: | -------------------------------------- | ------------------------------------------------------ |
+| 25.2% | 18.2 MiB |      20,790 | `mark`                                 | `black/brackets.py:70`                                 |
+| 22.0% |   16 MiB |       1,014 | `parse`                                | `/usr/lib/python3.11/ast.py:33`                        |
+|  8.3% |    6 MiB |           6 | `changed`                              | `blib2to3/pytree.py:171`                               |
+|  6.9% |    5 MiB |           5 | `__new__`                              | `blib2to3/pytree.py:81`                                |
+|  4.1% |    3 MiB |           8 | `transform_line`                       | `black/linegen.py:601`                                 |
+|  4.1% |    3 MiB |           4 | `visit_default`                        | `black/linegen.py:134`                                 |
+|  4.1% |    3 MiB |           3 | `generate_comments`                    | `black/comments.py:52`                                 |
+|  3.1% | 2.27 MiB |         352 | `_call_with_frames_removed`            | `<frozen importlib._bootstrap>:233`                    |
+|  3.0% | 2.14 MiB |         197 | `update_sibling_maps`                  | `blib2to3/pytree.py:369`                               |
+|  2.8% |    2 MiB |           2 | `convert`                              | `blib2to3/pytree.py:486`                               |
+|  2.8% |    2 MiB |           2 | `push`                                 | `blib2to3/pgen2/parse.py:386`                          |
+|  1.4% | 1.01 MiB |           6 | `make_grammar`                         | `blib2to3/pgen2/pgen.py:49`                            |
+|  1.4% | 1.01 MiB |          11 | `<module>`                             | `/venv/lib/python3.11/site-packages/click/parser.py:1` |
+|  1.4% |    1 MiB |           5 | `visit`                                | `black/nodes.py:163`                                   |
+|  1.4% |    1 MiB |           2 | `maybe_empty_lines`                    | `black/lines.py:560`                                   |
+|  1.4% |    1 MiB |           1 | `_addtoken`                            | `blib2to3/pgen2/parse.py:290`                          |
+|  1.4% |    1 MiB |           1 | `contains_uncollapsable_type_comments` | `black/lines.py:276`                                   |
+|  1.4% |    1 MiB |           1 | `__init__`                             | `<string>:2`                                           |
+|  1.4% |    1 MiB |           1 | `__init__`                             | `blib2to3/pytree.py:400`                               |
+|  0.4% |  311 KiB |         341 | `_compile_bytecode`                    | `<frozen importlib._bootstrap_external>:727`           |
 
 #### Categories
 
 ##### Ours
 
-|     % |     Size | Samples | Function                               | Location                        |
-| ----: | -------: | ------: | -------------------------------------- | ------------------------------- |
-| 25.2% | 18.2 MiB |  20,790 | `mark`                                 | `black/brackets.py:70`          |
-|  8.3% |    6 MiB |       6 | `changed`                              | `blib2to3/pytree.py:171`        |
-|  6.9% |    5 MiB |       5 | `__new__`                              | `blib2to3/pytree.py:81`         |
-|  4.1% |    3 MiB |       8 | `transform_line`                       | `black/linegen.py:601`          |
-|  4.1% |    3 MiB |       4 | `visit_default`                        | `black/linegen.py:134`          |
-|  4.1% |    3 MiB |       3 | `generate_comments`                    | `black/comments.py:52`          |
-|  3.0% | 2.14 MiB |     197 | `update_sibling_maps`                  | `blib2to3/pytree.py:369`        |
-|  2.8% |    2 MiB |       2 | `convert`                              | `blib2to3/pytree.py:486`        |
-|  2.8% |    2 MiB |       2 | `push`                                 | `blib2to3/pgen2/parse.py:386`   |
-|  1.4% | 1.01 MiB |       6 | `make_grammar`                         | `blib2to3/pgen2/pgen.py:49`     |
-|  1.4% |    1 MiB |       5 | `visit`                                | `black/nodes.py:163`            |
-|  1.4% |    1 MiB |       2 | `maybe_empty_lines`                    | `black/lines.py:560`            |
-|  1.4% |    1 MiB |       1 | `_addtoken`                            | `blib2to3/pgen2/parse.py:290`   |
-|  1.4% |    1 MiB |       1 | `contains_uncollapsable_type_comments` | `black/lines.py:276`            |
-|  1.4% |    1 MiB |       1 | `__init__`                             | `<string>:2`                    |
-|  1.4% |    1 MiB |       1 | `__init__`                             | `blib2to3/pytree.py:400`        |
-|  0.3% |  225 KiB |       5 | `_format_str_once`                     | `black/__init__.py:1236`        |
-|  0.1% | 57.2 KiB |      65 | `normalize_string_prefix`              | `black/strings.py:143`          |
-|  0.1% | 41.5 KiB |      16 | `copy`                                 | `blib2to3/pgen2/grammar.py:131` |
-| <0.1% |   32 KiB |       1 | `classify`                             | `blib2to3/pgen2/parse.py:336`   |
+|     % |     Size | Allocations | Function                               | Location                        |
+| ----: | -------: | ----------: | -------------------------------------- | ------------------------------- |
+| 25.2% | 18.2 MiB |      20,790 | `mark`                                 | `black/brackets.py:70`          |
+|  8.3% |    6 MiB |           6 | `changed`                              | `blib2to3/pytree.py:171`        |
+|  6.9% |    5 MiB |           5 | `__new__`                              | `blib2to3/pytree.py:81`         |
+|  4.1% |    3 MiB |           8 | `transform_line`                       | `black/linegen.py:601`          |
+|  4.1% |    3 MiB |           4 | `visit_default`                        | `black/linegen.py:134`          |
+|  4.1% |    3 MiB |           3 | `generate_comments`                    | `black/comments.py:52`          |
+|  3.0% | 2.14 MiB |         197 | `update_sibling_maps`                  | `blib2to3/pytree.py:369`        |
+|  2.8% |    2 MiB |           2 | `convert`                              | `blib2to3/pytree.py:486`        |
+|  2.8% |    2 MiB |           2 | `push`                                 | `blib2to3/pgen2/parse.py:386`   |
+|  1.4% | 1.01 MiB |           6 | `make_grammar`                         | `blib2to3/pgen2/pgen.py:49`     |
+|  1.4% |    1 MiB |           5 | `visit`                                | `black/nodes.py:163`            |
+|  1.4% |    1 MiB |           2 | `maybe_empty_lines`                    | `black/lines.py:560`            |
+|  1.4% |    1 MiB |           1 | `_addtoken`                            | `blib2to3/pgen2/parse.py:290`   |
+|  1.4% |    1 MiB |           1 | `contains_uncollapsable_type_comments` | `black/lines.py:276`            |
+|  1.4% |    1 MiB |           1 | `__init__`                             | `<string>:2`                    |
+|  1.4% |    1 MiB |           1 | `__init__`                             | `blib2to3/pytree.py:400`        |
+|  0.3% |  225 KiB |           5 | `_format_str_once`                     | `black/__init__.py:1236`        |
+|  0.1% | 57.2 KiB |          65 | `normalize_string_prefix`              | `black/strings.py:143`          |
+|  0.1% | 41.5 KiB |          16 | `copy`                                 | `blib2to3/pgen2/grammar.py:131` |
+| <0.1% |   32 KiB |           1 | `classify`                             | `blib2to3/pgen2/parse.py:336`   |
 
 ##### Standard library
 
-|     % |     Size | Samples | Function                    | Location                                          |
-| ----: | -------: | ------: | --------------------------- | ------------------------------------------------- |
-| 22.0% |   16 MiB |   1,014 | `parse`                     | `/usr/lib/python3.11/ast.py:33`                   |
-|  3.1% | 2.27 MiB |     352 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`               |
-|  0.4% |  311 KiB |     341 | `_compile_bytecode`         | `<frozen importlib._bootstrap_external>:727`      |
-|  0.3% |  222 KiB |       1 | `decode`                    | `<frozen codecs>:319`                             |
-|  0.2% |  112 KiB |     108 | `_code_to_timestamp_pyc`    | `<frozen importlib._bootstrap_external>:740`      |
-|  0.1% | 75.7 KiB |      79 | `__new__`                   | `<frozen abc>:105`                                |
-| <0.1% | 24.1 KiB |      27 | `__new__`                   | `/usr/lib/python3.11/enum.py:488`                 |
-| <0.1% | 22.6 KiB |      12 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`         |
-| <0.1% | 19.8 KiB |      12 | `<module>`                  | `/usr/lib/python3.11/tomllib/_parser.py:1`        |
-| <0.1% | 17.4 KiB |      21 | `__new__`                   | `/usr/lib/python3.11/typing.py:2891`              |
-| <0.1% |   12 KiB |       3 | `inner`                     | `/usr/lib/python3.11/typing.py:338`               |
-| <0.1% |    8 KiB |       4 | `_fill_cache`               | `<frozen importlib._bootstrap_external>:1655`     |
-| <0.1% | 7.97 KiB |       1 | `_parse_sub`                | `/usr/lib/python3.11/re/_parser.py:447`           |
-| <0.1% | 6.73 KiB |       8 | `__setattr__`               | `/usr/lib/python3.11/enum.py:831`                 |
-| <0.1% | 5.63 KiB |       6 | `namedtuple`                | `/usr/lib/python3.11/collections/__init__.py:348` |
-| <0.1% | 5.61 KiB |       3 | `_parse`                    | `/usr/lib/python3.11/re/_parser.py:507`           |
-| <0.1% | 5.32 KiB |       2 | `_code`                     | `/usr/lib/python3.11/re/_compiler.py:571`         |
-| <0.1% | 4.73 KiB |       6 | `<module>`                  | `/usr/lib/python3.11/pkgutil.py:1`                |
-| <0.1% | 2.85 KiB |       1 | `wrap`                      | `/usr/lib/python3.11/dataclasses.py:1209`         |
-| <0.1% | 2.85 KiB |       4 | `_process_class`            | `/usr/lib/python3.11/dataclasses.py:884`          |
+|     % |     Size | Allocations | Function                    | Location                                          |
+| ----: | -------: | ----------: | --------------------------- | ------------------------------------------------- |
+| 22.0% |   16 MiB |       1,014 | `parse`                     | `/usr/lib/python3.11/ast.py:33`                   |
+|  3.1% | 2.27 MiB |         352 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`               |
+|  0.4% |  311 KiB |         341 | `_compile_bytecode`         | `<frozen importlib._bootstrap_external>:727`      |
+|  0.3% |  222 KiB |           1 | `decode`                    | `<frozen codecs>:319`                             |
+|  0.2% |  112 KiB |         108 | `_code_to_timestamp_pyc`    | `<frozen importlib._bootstrap_external>:740`      |
+|  0.1% | 75.7 KiB |          79 | `__new__`                   | `<frozen abc>:105`                                |
+| <0.1% | 24.1 KiB |          27 | `__new__`                   | `/usr/lib/python3.11/enum.py:488`                 |
+| <0.1% | 22.6 KiB |          12 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`         |
+| <0.1% | 19.8 KiB |          12 | `<module>`                  | `/usr/lib/python3.11/tomllib/_parser.py:1`        |
+| <0.1% | 17.4 KiB |          21 | `__new__`                   | `/usr/lib/python3.11/typing.py:2891`              |
+| <0.1% |   12 KiB |           3 | `inner`                     | `/usr/lib/python3.11/typing.py:338`               |
+| <0.1% |    8 KiB |           4 | `_fill_cache`               | `<frozen importlib._bootstrap_external>:1655`     |
+| <0.1% | 7.97 KiB |           1 | `_parse_sub`                | `/usr/lib/python3.11/re/_parser.py:447`           |
+| <0.1% | 6.73 KiB |           8 | `__setattr__`               | `/usr/lib/python3.11/enum.py:831`                 |
+| <0.1% | 5.63 KiB |           6 | `namedtuple`                | `/usr/lib/python3.11/collections/__init__.py:348` |
+| <0.1% | 5.61 KiB |           3 | `_parse`                    | `/usr/lib/python3.11/re/_parser.py:507`           |
+| <0.1% | 5.32 KiB |           2 | `_code`                     | `/usr/lib/python3.11/re/_compiler.py:571`         |
+| <0.1% | 4.73 KiB |           6 | `<module>`                  | `/usr/lib/python3.11/pkgutil.py:1`                |
+| <0.1% | 2.85 KiB |           1 | `wrap`                      | `/usr/lib/python3.11/dataclasses.py:1209`         |
+| <0.1% | 2.85 KiB |           4 | `_process_class`            | `/usr/lib/python3.11/dataclasses.py:884`          |
 
 ##### Third-party
 
-|     % |     Size | Samples | Function              | Location                                                                   |
-| ----: | -------: | ------: | --------------------- | -------------------------------------------------------------------------- |
-|  1.4% | 1.01 MiB |      11 | `<module>`            | `/venv/lib/python3.11/site-packages/click/parser.py:1`                     |
-|  0.1% | 44.3 KiB |      31 | `__init__`            | `/venv/lib/python3.11/site-packages/click/core.py:2883`                    |
-|  0.1% |   42 KiB |       7 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                   |
-| <0.1% |   25 KiB |      22 | `<module>`            | `/venv/lib/python3.11/site-packages/click/core.py:1`                       |
-| <0.1% |   15 KiB |      18 | `<module>`            | `/venv/lib/python3.11/site-packages/mypy_extensions.py:1`                  |
-| <0.1% | 13.4 KiB |      15 | `<module>`            | `/venv/lib/python3.11/site-packages/click/exceptions.py:1`                 |
-| <0.1% | 9.61 KiB |       9 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/version.py:1`                |
-| <0.1% | 7.08 KiB |       8 | `<module>`            | `/venv/lib/python3.11/site-packages/click/utils.py:1`                      |
-| <0.1% | 6.48 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/util.py:1`                    |
-| <0.1% | 6.24 KiB |       5 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                |
-| <0.1% |  5.8 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/click/_compat.py:1`                    |
-| <0.1% | 3.82 KiB |       1 | `Specifier`           | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`           |
-| <0.1% | 3.79 KiB |       3 | `new_func`            | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                |
-| <0.1% | 3.72 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`                 |
-| <0.1% | 3.56 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                  |
-| <0.1% | 3.37 KiB |       5 | `handle_parse_result` | `/venv/lib/python3.11/site-packages/click/core.py:2663`                    |
-| <0.1% | 3.19 KiB |       1 | `<module>`            | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                   |
-| <0.1% | 3.19 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`                |
-| <0.1% | 2.81 KiB |       3 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1` |
-| <0.1% | 2.76 KiB |       2 | `<module>`            | `/venv/lib/python3.11/site-packages/click/types.py:1`                      |
+|     % |     Size | Allocations | Function              | Location                                                                   |
+| ----: | -------: | ----------: | --------------------- | -------------------------------------------------------------------------- |
+|  1.4% | 1.01 MiB |          11 | `<module>`            | `/venv/lib/python3.11/site-packages/click/parser.py:1`                     |
+|  0.1% | 44.3 KiB |          31 | `__init__`            | `/venv/lib/python3.11/site-packages/click/core.py:2883`                    |
+|  0.1% |   42 KiB |           7 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                   |
+| <0.1% |   25 KiB |          22 | `<module>`            | `/venv/lib/python3.11/site-packages/click/core.py:1`                       |
+| <0.1% |   15 KiB |          18 | `<module>`            | `/venv/lib/python3.11/site-packages/mypy_extensions.py:1`                  |
+| <0.1% | 13.4 KiB |          15 | `<module>`            | `/venv/lib/python3.11/site-packages/click/exceptions.py:1`                 |
+| <0.1% | 9.61 KiB |           9 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/version.py:1`                |
+| <0.1% | 7.08 KiB |           8 | `<module>`            | `/venv/lib/python3.11/site-packages/click/utils.py:1`                      |
+| <0.1% | 6.48 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/util.py:1`                    |
+| <0.1% | 6.24 KiB |           5 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                |
+| <0.1% |  5.8 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/click/_compat.py:1`                    |
+| <0.1% | 3.82 KiB |           1 | `Specifier`           | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`           |
+| <0.1% | 3.79 KiB |           3 | `new_func`            | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                |
+| <0.1% | 3.72 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`                 |
+| <0.1% | 3.56 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                  |
+| <0.1% | 3.37 KiB |           5 | `handle_parse_result` | `/venv/lib/python3.11/site-packages/click/core.py:2663`                    |
+| <0.1% | 3.19 KiB |           1 | `<module>`            | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                   |
+| <0.1% | 3.19 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`                |
+| <0.1% | 2.81 KiB |           3 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1` |
+| <0.1% | 2.76 KiB |           2 | `<module>`            | `/venv/lib/python3.11/site-packages/click/types.py:1`                      |
 
 #### Lines
 
@@ -120,450 +120,450 @@ Lines ranked by contribution to each function's self size.
 
 ##### `mark` (`black/brackets.py:70`)
 
-|     % |     Size | Samples | Location                |
-| ----: | -------: | ------: | ----------------------- |
-| 94.5% | 17.2 MiB |  20,788 | `black/brackets.py:112` |
-|  5.5% |    1 MiB |       1 | `black/brackets.py:118` |
-| <0.1% | 1.49 KiB |       1 | `black/brackets.py:114` |
+|     % |     Size | Allocations | Location                |
+| ----: | -------: | ----------: | ----------------------- |
+| 94.5% | 17.2 MiB |      20,788 | `black/brackets.py:112` |
+|  5.5% |    1 MiB |           1 | `black/brackets.py:118` |
+| <0.1% | 1.49 KiB |           1 | `black/brackets.py:114` |
 
 ##### `parse` (`/usr/lib/python3.11/ast.py:33`)
 
-|      % |   Size | Samples | Location                        |
-| -----: | -----: | ------: | ------------------------------- |
-| 100.0% | 16 MiB |   1,014 | `/usr/lib/python3.11/ast.py:50` |
+|      % |   Size | Allocations | Location                        |
+| -----: | -----: | ----------: | ------------------------------- |
+| 100.0% | 16 MiB |       1,014 | `/usr/lib/python3.11/ast.py:50` |
 
 ##### `changed` (`blib2to3/pytree.py:171`)
 
-|     % |  Size | Samples | Location                 |
-| ----: | ----: | ------: | ------------------------ |
-| 66.7% | 4 MiB |       4 | `blib2to3/pytree.py:175` |
-| 33.3% | 2 MiB |       2 | `blib2to3/pytree.py:176` |
+|     % |  Size | Allocations | Location                 |
+| ----: | ----: | ----------: | ------------------------ |
+| 66.7% | 4 MiB |           4 | `blib2to3/pytree.py:175` |
+| 33.3% | 2 MiB |           2 | `blib2to3/pytree.py:176` |
 
 ##### `__new__` (`blib2to3/pytree.py:81`)
 
-|      % |  Size | Samples | Location                |
-| -----: | ----: | ------: | ----------------------- |
-| 100.0% | 5 MiB |       5 | `blib2to3/pytree.py:84` |
+|      % |  Size | Allocations | Location                |
+| -----: | ----: | ----------: | ----------------------- |
+| 100.0% | 5 MiB |           5 | `blib2to3/pytree.py:84` |
 
 ##### `transform_line` (`black/linegen.py:601`)
 
-|     % |     Size | Samples | Location               |
-| ----: | -------: | ------: | ---------------------- |
-| 33.3% |    1 MiB |       3 | `black/linegen.py:679` |
-| 33.3% |    1 MiB |       2 | `black/linegen.py:714` |
-| 33.3% |    1 MiB |       1 | `black/linegen.py:626` |
-| <0.1% | 1.39 KiB |       1 | `black/linegen.py:635` |
-| <0.1% |    518 B |       1 | `black/linegen.py:631` |
+|     % |     Size | Allocations | Location               |
+| ----: | -------: | ----------: | ---------------------- |
+| 33.3% |    1 MiB |           3 | `black/linegen.py:679` |
+| 33.3% |    1 MiB |           2 | `black/linegen.py:714` |
+| 33.3% |    1 MiB |           1 | `black/linegen.py:626` |
+| <0.1% | 1.39 KiB |           1 | `black/linegen.py:635` |
+| <0.1% |    518 B |           1 | `black/linegen.py:631` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|      % |  Size | Samples | Location               |
-| -----: | ----: | ------: | ---------------------- |
-| 100.0% | 3 MiB |       3 | `black/linegen.py:158` |
-|  <0.1% | 702 B |       1 | `black/linegen.py:144` |
+|      % |  Size | Allocations | Location               |
+| -----: | ----: | ----------: | ---------------------- |
+| 100.0% | 3 MiB |           3 | `black/linegen.py:158` |
+|  <0.1% | 702 B |           1 | `black/linegen.py:144` |
 
 ##### `generate_comments` (`black/comments.py:52`)
 
-|     % |  Size | Samples | Location               |
-| ----: | ----: | ------: | ---------------------- |
-| 66.7% | 2 MiB |       2 | `black/comments.py:76` |
-| 33.3% | 1 MiB |       1 | `black/comments.py:72` |
+|     % |  Size | Allocations | Location               |
+| ----: | ----: | ----------: | ---------------------- |
+| 66.7% | 2 MiB |           2 | `black/comments.py:76` |
+| 33.3% | 1 MiB |           1 | `black/comments.py:72` |
 
 ##### `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`)
 
-|      % |     Size | Samples | Location                            |
-| -----: | -------: | ------: | ----------------------------------- |
-| 100.0% | 2.27 MiB |     352 | `<frozen importlib._bootstrap>:241` |
+|      % |     Size | Allocations | Location                            |
+| -----: | -------: | ----------: | ----------------------------------- |
+| 100.0% | 2.27 MiB |         352 | `<frozen importlib._bootstrap>:241` |
 
 ##### `update_sibling_maps` (`blib2to3/pytree.py:369`)
 
-|     % |     Size | Samples | Location                 |
-| ----: | -------: | ------: | ------------------------ |
-| 96.6% | 2.07 MiB |      95 | `blib2to3/pytree.py:377` |
-|  3.2% | 70.3 KiB |      93 | `blib2to3/pytree.py:376` |
-|  0.2% | 4.99 KiB |       9 | `blib2to3/pytree.py:379` |
+|     % |     Size | Allocations | Location                 |
+| ----: | -------: | ----------: | ------------------------ |
+| 96.6% | 2.07 MiB |          95 | `blib2to3/pytree.py:377` |
+|  3.2% | 70.3 KiB |          93 | `blib2to3/pytree.py:376` |
+|  0.2% | 4.99 KiB |           9 | `blib2to3/pytree.py:379` |
 
 ##### `convert` (`blib2to3/pytree.py:486`)
 
-|      % |  Size | Samples | Location                 |
-| -----: | ----: | ------: | ------------------------ |
-| 100.0% | 2 MiB |       2 | `blib2to3/pytree.py:501` |
+|      % |  Size | Allocations | Location                 |
+| -----: | ----: | ----------: | ------------------------ |
+| 100.0% | 2 MiB |           2 | `blib2to3/pytree.py:501` |
 
 ##### `push` (`blib2to3/pgen2/parse.py:386`)
 
-|      % |  Size | Samples | Location                      |
-| -----: | ----: | ------: | ----------------------------- |
-| 100.0% | 2 MiB |       2 | `blib2to3/pgen2/parse.py:394` |
+|      % |  Size | Allocations | Location                      |
+| -----: | ----: | ----------: | ----------------------------- |
+| 100.0% | 2 MiB |           2 | `blib2to3/pgen2/parse.py:394` |
 
 ##### `make_grammar` (`blib2to3/pgen2/pgen.py:49`)
 
-|     % |     Size | Samples | Location                    |
-| ----: | -------: | ------: | --------------------------- |
-| 98.6% |    1 MiB |       1 | `blib2to3/pgen2/pgen.py:56` |
-|  0.4% | 4.52 KiB |       1 | `blib2to3/pgen2/pgen.py:70` |
-|  0.4% | 4.52 KiB |       1 | `blib2to3/pgen2/pgen.py:58` |
-|  0.3% | 3.19 KiB |       1 | `blib2to3/pgen2/pgen.py:57` |
-|  0.1% |    1 KiB |       1 | `blib2to3/pgen2/pgen.py:69` |
+|     % |     Size | Allocations | Location                    |
+| ----: | -------: | ----------: | --------------------------- |
+| 98.6% |    1 MiB |           1 | `blib2to3/pgen2/pgen.py:56` |
+|  0.4% | 4.52 KiB |           1 | `blib2to3/pgen2/pgen.py:70` |
+|  0.4% | 4.52 KiB |           1 | `blib2to3/pgen2/pgen.py:58` |
+|  0.3% | 3.19 KiB |           1 | `blib2to3/pgen2/pgen.py:57` |
+|  0.1% |    1 KiB |           1 | `blib2to3/pgen2/pgen.py:69` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`)
 
-|     % |     Size | Samples | Location                                                 |
-| ----: | -------: | ------: | -------------------------------------------------------- |
-| 99.2% |    1 MiB |       1 | `/venv/lib/python3.11/site-packages/click/parser.py:25`  |
-|  0.2% | 2.29 KiB |       3 | `/venv/lib/python3.11/site-packages/click/parser.py:224` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:185` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:127` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:216` |
+|     % |     Size | Allocations | Location                                                 |
+| ----: | -------: | ----------: | -------------------------------------------------------- |
+| 99.2% |    1 MiB |           1 | `/venv/lib/python3.11/site-packages/click/parser.py:25`  |
+|  0.2% | 2.29 KiB |           3 | `/venv/lib/python3.11/site-packages/click/parser.py:224` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:185` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:127` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:216` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|     % |     Size | Samples | Location             |
-| ----: | -------: | ------: | -------------------- |
-| 99.7% |    1 MiB |       2 | `black/nodes.py:185` |
-|  0.3% | 2.68 KiB |       3 | `black/nodes.py:183` |
+|     % |     Size | Allocations | Location             |
+| ----: | -------: | ----------: | -------------------- |
+| 99.7% |    1 MiB |           2 | `black/nodes.py:185` |
+|  0.3% | 2.68 KiB |           3 | `black/nodes.py:183` |
 
 ##### `maybe_empty_lines` (`black/lines.py:560`)
 
-|     % |     Size | Samples | Location             |
-| ----: | -------: | ------: | -------------------- |
-| 99.9% |    1 MiB |       1 | `black/lines.py:584` |
-|  0.1% | 1.11 KiB |       1 | `black/lines.py:571` |
+|     % |     Size | Allocations | Location             |
+| ----: | -------: | ----------: | -------------------- |
+| 99.9% |    1 MiB |           1 | `black/lines.py:584` |
+|  0.1% | 1.11 KiB |           1 | `black/lines.py:571` |
 
 ##### `_addtoken` (`blib2to3/pgen2/parse.py:290`)
 
-|      % |  Size | Samples | Location                      |
-| -----: | ----: | ------: | ----------------------------- |
-| 100.0% | 1 MiB |       1 | `blib2to3/pgen2/parse.py:315` |
+|      % |  Size | Allocations | Location                      |
+| -----: | ----: | ----------: | ----------------------------- |
+| 100.0% | 1 MiB |           1 | `blib2to3/pgen2/parse.py:315` |
 
 ##### `contains_uncollapsable_type_comments` (`black/lines.py:276`)
 
-|      % |  Size | Samples | Location             |
-| -----: | ----: | ------: | -------------------- |
-| 100.0% | 1 MiB |       1 | `black/lines.py:280` |
+|      % |  Size | Allocations | Location             |
+| -----: | ----: | ----------: | -------------------- |
+| 100.0% | 1 MiB |           1 | `black/lines.py:280` |
 
 ##### `__init__` (`<string>:2`)
 
-|      % |  Size | Samples | Location     |
-| -----: | ----: | ------: | ------------ |
-| 100.0% | 1 MiB |       1 | `<string>:7` |
+|      % |  Size | Allocations | Location     |
+| -----: | ----: | ----------: | ------------ |
+| 100.0% | 1 MiB |           1 | `<string>:7` |
 
 ##### `__init__` (`blib2to3/pytree.py:400`)
 
-|      % |  Size | Samples | Location                 |
-| -----: | ----: | ------: | ------------------------ |
-| 100.0% | 1 MiB |       1 | `blib2to3/pytree.py:425` |
+|      % |  Size | Allocations | Location                 |
+| -----: | ----: | ----------: | ------------------------ |
+| 100.0% | 1 MiB |           1 | `blib2to3/pytree.py:425` |
 
 ##### `_compile_bytecode` (`<frozen importlib._bootstrap_external>:727`)
 
-|      % |    Size | Samples | Location                                     |
-| -----: | ------: | ------: | -------------------------------------------- |
-| 100.0% | 311 KiB |     341 | `<frozen importlib._bootstrap_external>:729` |
+|      % |    Size | Allocations | Location                                     |
+| -----: | ------: | ----------: | -------------------------------------------- |
+| 100.0% | 311 KiB |         341 | `<frozen importlib._bootstrap_external>:729` |
 
 ##### `_format_str_once` (`black/__init__.py:1236`)
 
-|     % |     Size | Samples | Location                 |
-| ----: | -------: | ------: | ------------------------ |
-| 98.6% |  222 KiB |       1 | `black/__init__.py:1287` |
-|  0.5% | 1.07 KiB |       1 | `black/__init__.py:1271` |
-|  0.3% |    800 B |       1 | `black/__init__.py:1239` |
-|  0.3% |    644 B |       1 | `black/__init__.py:1269` |
-|  0.3% |    638 B |       1 | `black/__init__.py:1244` |
+|     % |     Size | Allocations | Location                 |
+| ----: | -------: | ----------: | ------------------------ |
+| 98.6% |  222 KiB |           1 | `black/__init__.py:1287` |
+|  0.5% | 1.07 KiB |           1 | `black/__init__.py:1271` |
+|  0.3% |    800 B |           1 | `black/__init__.py:1239` |
+|  0.3% |    644 B |           1 | `black/__init__.py:1269` |
+|  0.3% |    638 B |           1 | `black/__init__.py:1244` |
 
 ##### `decode` (`<frozen codecs>:319`)
 
-|      % |    Size | Samples | Location              |
-| -----: | ------: | ------: | --------------------- |
-| 100.0% | 222 KiB |       1 | `<frozen codecs>:322` |
+|      % |    Size | Allocations | Location              |
+| -----: | ------: | ----------: | --------------------- |
+| 100.0% | 222 KiB |           1 | `<frozen codecs>:322` |
 
 ##### `_code_to_timestamp_pyc` (`<frozen importlib._bootstrap_external>:740`)
 
-|      % |    Size | Samples | Location                                     |
-| -----: | ------: | ------: | -------------------------------------------- |
-| 100.0% | 112 KiB |     108 | `<frozen importlib._bootstrap_external>:746` |
+|      % |    Size | Allocations | Location                                     |
+| -----: | ------: | ----------: | -------------------------------------------- |
+| 100.0% | 112 KiB |         108 | `<frozen importlib._bootstrap_external>:746` |
 
 ##### `__new__` (`<frozen abc>:105`)
 
-|      % |     Size | Samples | Location           |
-| -----: | -------: | ------: | ------------------ |
-| 100.0% | 75.7 KiB |      79 | `<frozen abc>:106` |
+|      % |     Size | Allocations | Location           |
+| -----: | -------: | ----------: | ------------------ |
+| 100.0% | 75.7 KiB |          79 | `<frozen abc>:106` |
 
 ##### `normalize_string_prefix` (`black/strings.py:143`)
 
-|      % |     Size | Samples | Location               |
-| -----: | -------: | ------: | ---------------------- |
-| 100.0% | 57.2 KiB |      65 | `black/strings.py:158` |
+|      % |     Size | Allocations | Location               |
+| -----: | -------: | ----------: | ---------------------- |
+| 100.0% | 57.2 KiB |          65 | `black/strings.py:158` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|     % |   Size | Samples | Location                                                |
-| ----: | -----: | ------: | ------------------------------------------------------- |
-| 97.1% | 43 KiB |      29 | `/venv/lib/python3.11/site-packages/click/core.py:3023` |
-|  1.6% |  704 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2905` |
-|  1.4% |  614 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2907` |
+|     % |   Size | Allocations | Location                                                |
+| ----: | -----: | ----------: | ------------------------------------------------------- |
+| 97.1% | 43 KiB |          29 | `/venv/lib/python3.11/site-packages/click/core.py:3023` |
+|  1.6% |  704 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2905` |
+|  1.4% |  614 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2907` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|     % |     Size | Samples | Location                                                   |
-| ----: | -------: | ------: | ---------------------------------------------------------- |
-| 89.8% | 37.7 KiB |       3 | `/venv/lib/python3.11/site-packages/packaging/tags.py:118` |
-|  3.5% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:322` |
-|  2.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:110` |
-|  2.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:101` |
-|  2.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:93`  |
+|     % |     Size | Allocations | Location                                                   |
+| ----: | -------: | ----------: | ---------------------------------------------------------- |
+| 89.8% | 37.7 KiB |           3 | `/venv/lib/python3.11/site-packages/packaging/tags.py:118` |
+|  3.5% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:322` |
+|  2.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:110` |
+|  2.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:101` |
+|  2.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:93`  |
 
 ##### `copy` (`blib2to3/pgen2/grammar.py:131`)
 
-|     % |     Size | Samples | Location                        |
-| ----: | -------: | ------: | ------------------------------- |
-| 88.2% | 36.6 KiB |      12 | `blib2to3/pgen2/grammar.py:145` |
-|  7.6% | 3.16 KiB |       2 | `blib2to3/pgen2/grammar.py:146` |
-|  4.2% | 1.75 KiB |       2 | `blib2to3/pgen2/grammar.py:147` |
+|     % |     Size | Allocations | Location                        |
+| ----: | -------: | ----------: | ------------------------------- |
+| 88.2% | 36.6 KiB |          12 | `blib2to3/pgen2/grammar.py:145` |
+|  7.6% | 3.16 KiB |           2 | `blib2to3/pgen2/grammar.py:146` |
+|  4.2% | 1.75 KiB |           2 | `blib2to3/pgen2/grammar.py:147` |
 
 ##### `classify` (`blib2to3/pgen2/parse.py:336`)
 
-|      % |   Size | Samples | Location                      |
-| -----: | -----: | ------: | ----------------------------- |
-| 100.0% | 32 KiB |       1 | `blib2to3/pgen2/parse.py:343` |
+|      % |   Size | Allocations | Location                      |
+| -----: | -----: | ----------: | ----------------------------- |
+| 100.0% | 32 KiB |           1 | `blib2to3/pgen2/parse.py:343` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 30.4% |  7.6 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:204`  |
-| 19.2% | 4.79 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:956`  |
-| 15.7% | 3.92 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:1587` |
-|  9.5% | 2.37 KiB |       3 | `/venv/lib/python3.11/site-packages/click/core.py:2057` |
-|  6.8% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/core.py:2050` |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 30.4% |  7.6 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:204`  |
+| 19.2% | 4.79 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:956`  |
+| 15.7% | 3.92 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:1587` |
+|  9.5% | 2.37 KiB |           3 | `/venv/lib/python3.11/site-packages/click/core.py:2057` |
+|  6.8% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/core.py:2050` |
 
 ##### `__new__` (`/usr/lib/python3.11/enum.py:488`)
 
-|      % |     Size | Samples | Location                          |
-| -----: | -------: | ------: | --------------------------------- |
-| 100.0% | 24.1 KiB |      27 | `/usr/lib/python3.11/enum.py:554` |
+|      % |     Size | Allocations | Location                          |
+| -----: | -------: | ----------: | --------------------------------- |
+| 100.0% | 24.1 KiB |          27 | `/usr/lib/python3.11/enum.py:554` |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|      % |     Size | Samples | Location                                  |
-| -----: | -------: | ------: | ----------------------------------------- |
-| 100.0% | 22.6 KiB |      12 | `/usr/lib/python3.11/re/_compiler.py:759` |
+|      % |     Size | Allocations | Location                                  |
+| -----: | -------: | ----------: | ----------------------------------------- |
+| 100.0% | 22.6 KiB |          12 | `/usr/lib/python3.11/re/_compiler.py:759` |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/_parser.py:1`)
 
-|     % |  Size | Samples | Location                                    |
-| ----: | ----: | ------: | ------------------------------------------- |
-| 20.2% | 4 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:37` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:26` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:22` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:38` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:27` |
+|     % |  Size | Allocations | Location                                    |
+| ----: | ----: | ----------: | ------------------------------------------- |
+| 20.2% | 4 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:37` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:26` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:22` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:38` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:27` |
 
 ##### `__new__` (`/usr/lib/python3.11/typing.py:2891`)
 
-|      % |     Size | Samples | Location                             |
-| -----: | -------: | ------: | ------------------------------------ |
-| 100.0% | 17.4 KiB |      21 | `/usr/lib/python3.11/typing.py:2909` |
+|      % |     Size | Allocations | Location                             |
+| -----: | -------: | ----------: | ------------------------------------ |
+| 100.0% | 17.4 KiB |          21 | `/usr/lib/python3.11/typing.py:2909` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/mypy_extensions.py:1`)
 
-|     % |     Size | Samples | Location                                                    |
-| ----: | -------: | ------: | ----------------------------------------------------------- |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:198` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:167` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:212` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:191` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:154` |
+|     % |     Size | Allocations | Location                                                    |
+| ----: | -------: | ----------: | ----------------------------------------------------------- |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:198` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:167` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:212` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:191` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:154` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/exceptions.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 18.4% | 2.45 KiB |       3 | `/venv/lib/python3.11/site-packages/click/exceptions.py:114` |
-| 11.5% | 1.53 KiB |       2 | `/venv/lib/python3.11/site-packages/click/exceptions.py:366` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:304` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:268` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:232` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 18.4% | 2.45 KiB |           3 | `/venv/lib/python3.11/site-packages/click/exceptions.py:114` |
+| 11.5% | 1.53 KiB |           2 | `/venv/lib/python3.11/site-packages/click/exceptions.py:366` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:304` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:268` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:232` |
 
 ##### `inner` (`/usr/lib/python3.11/typing.py:338`)
 
-|      % |   Size | Samples | Location                            |
-| -----: | -----: | ------: | ----------------------------------- |
-| 100.0% | 12 KiB |       3 | `/usr/lib/python3.11/typing.py:341` |
+|      % |   Size | Allocations | Location                            |
+| -----: | -----: | ----------: | ----------------------------------- |
+| 100.0% | 12 KiB |           3 | `/usr/lib/python3.11/typing.py:341` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/version.py:1`)
 
-|     % |     Size | Samples | Location                                                      |
-| ----: | -------: | ------: | ------------------------------------------------------------- |
-| 38.2% | 3.68 KiB |       3 | `/venv/lib/python3.11/site-packages/packaging/version.py:340` |
-| 15.5% | 1.49 KiB |       2 | `/venv/lib/python3.11/site-packages/packaging/version.py:124` |
-| 15.4% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:285` |
-| 11.3% | 1.09 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:228` |
-|  9.8% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:134` |
+|     % |     Size | Allocations | Location                                                      |
+| ----: | -------: | ----------: | ------------------------------------------------------------- |
+| 38.2% | 3.68 KiB |           3 | `/venv/lib/python3.11/site-packages/packaging/version.py:340` |
+| 15.5% | 1.49 KiB |           2 | `/venv/lib/python3.11/site-packages/packaging/version.py:124` |
+| 15.4% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:285` |
+| 11.3% | 1.09 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:228` |
+|  9.8% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:134` |
 
 ##### `_fill_cache` (`<frozen importlib._bootstrap_external>:1655`)
 
-|      % |  Size | Samples | Location                                      |
-| -----: | ----: | ------: | --------------------------------------------- |
-| 100.0% | 8 KiB |       4 | `<frozen importlib._bootstrap_external>:1667` |
+|      % |  Size | Allocations | Location                                      |
+| -----: | ----: | ----------: | --------------------------------------------- |
+| 100.0% | 8 KiB |           4 | `<frozen importlib._bootstrap_external>:1667` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|      % |     Size | Samples | Location                                |
-| -----: | -------: | ------: | --------------------------------------- |
-| 100.0% | 7.97 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:455` |
+|      % |     Size | Allocations | Location                                |
+| -----: | -------: | ----------: | --------------------------------------- |
+| 100.0% | 7.97 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:455` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/utils.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 44.8% | 3.17 KiB |       3 | `/venv/lib/python3.11/site-packages/click/utils.py:522` |
-| 31.4% | 2.22 KiB |       3 | `/venv/lib/python3.11/site-packages/click/utils.py:207` |
-| 23.8% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/utils.py:113` |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 44.8% | 3.17 KiB |           3 | `/venv/lib/python3.11/site-packages/click/utils.py:522` |
+| 31.4% | 2.22 KiB |           3 | `/venv/lib/python3.11/site-packages/click/utils.py:207` |
+| 23.8% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/utils.py:113` |
 
 ##### `__setattr__` (`/usr/lib/python3.11/enum.py:831`)
 
-|      % |     Size | Samples | Location                          |
-| -----: | -------: | ------: | --------------------------------- |
-| 100.0% | 6.73 KiB |       8 | `/usr/lib/python3.11/enum.py:842` |
+|      % |     Size | Allocations | Location                          |
+| -----: | -------: | ----------: | --------------------------------- |
+| 100.0% | 6.73 KiB |           8 | `/usr/lib/python3.11/enum.py:842` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/util.py:1`)
 
-|     % |     Size | Samples | Location                                                  |
-| ----: | -------: | ------: | --------------------------------------------------------- |
-| 22.9% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:254` |
-| 16.9% | 1.09 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:765` |
-| 16.3% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:710` |
-| 15.1% |   1000 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:741` |
-| 14.5% |    960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:651` |
+|     % |     Size | Allocations | Location                                                  |
+| ----: | -------: | ----------: | --------------------------------------------------------- |
+| 22.9% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:254` |
+| 16.9% | 1.09 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:765` |
+| 16.3% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:710` |
+| 15.1% |   1000 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:741` |
+| 14.5% |    960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:651` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|     % |     Size | Samples | Location                                                      |
-| ----: | -------: | ------: | ------------------------------------------------------------- |
-| 23.8% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:681` |
-| 23.0% | 1.43 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:44`  |
-| 19.4% | 1.21 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:63`  |
-| 16.9% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:179` |
-| 16.9% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:236` |
+|     % |     Size | Allocations | Location                                                      |
+| ----: | -------: | ----------: | ------------------------------------------------------------- |
+| 23.8% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:681` |
+| 23.0% | 1.43 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:44`  |
+| 19.4% | 1.21 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:63`  |
+| 16.9% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:179` |
+| 16.9% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:236` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/_compat.py:1`)
 
-|     % |     Size | Samples | Location                                                  |
-| ----: | -------: | ------: | --------------------------------------------------------- |
-| 29.1% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/_compat.py:452` |
-| 29.1% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/_compat.py:82`  |
-| 25.6% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/click/_compat.py:344` |
-| 16.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/_compat.py:56`  |
+|     % |     Size | Allocations | Location                                                  |
+| ----: | -------: | ----------: | --------------------------------------------------------- |
+| 29.1% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/_compat.py:452` |
+| 29.1% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/_compat.py:82`  |
+| 25.6% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/click/_compat.py:344` |
+| 16.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/_compat.py:56`  |
 
 ##### `namedtuple` (`/usr/lib/python3.11/collections/__init__.py:348`)
 
-|      % |     Size | Samples | Location                                          |
-| -----: | -------: | ------: | ------------------------------------------------- |
-| 100.0% | 5.63 KiB |       6 | `/usr/lib/python3.11/collections/__init__.py:501` |
+|      % |     Size | Allocations | Location                                          |
+| -----: | -------: | ----------: | ------------------------------------------------- |
+| 100.0% | 5.63 KiB |           6 | `/usr/lib/python3.11/collections/__init__.py:501` |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|     % |     Size | Samples | Location                                |
-| ----: | -------: | ------: | --------------------------------------- |
-| 43.4% | 2.43 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:539` |
-| 33.9% |  1.9 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:568` |
-| 22.7% | 1.28 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:838` |
+|     % |     Size | Allocations | Location                                |
+| ----: | -------: | ----------: | --------------------------------------- |
+| 43.4% | 2.43 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:539` |
+| 33.9% |  1.9 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:568` |
+| 22.7% | 1.28 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:838` |
 
 ##### `_code` (`/usr/lib/python3.11/re/_compiler.py:571`)
 
-|     % |     Size | Samples | Location                                  |
-| ----: | -------: | ------: | ----------------------------------------- |
-| 81.6% | 4.34 KiB |       1 | `/usr/lib/python3.11/re/_compiler.py:580` |
-| 18.4% |   1002 B |       1 | `/usr/lib/python3.11/re/_compiler.py:577` |
+|     % |     Size | Allocations | Location                                  |
+| ----: | -------: | ----------: | ----------------------------------------- |
+| 81.6% | 4.34 KiB |           1 | `/usr/lib/python3.11/re/_compiler.py:580` |
+| 18.4% |   1002 B |           1 | `/usr/lib/python3.11/re/_compiler.py:577` |
 
 ##### `<module>` (`/usr/lib/python3.11/pkgutil.py:1`)
 
-|     % |     Size | Samples | Location                             |
-| ----: | -------: | ------: | ------------------------------------ |
-| 35.7% | 1.69 KiB |       2 | `/usr/lib/python3.11/pkgutil.py:269` |
-| 35.7% | 1.69 KiB |       2 | `/usr/lib/python3.11/pkgutil.py:194` |
-| 15.9% |    768 B |       1 | `/usr/lib/python3.11/pkgutil.py:137` |
-| 12.8% |    620 B |       1 | `/usr/lib/python3.11/pkgutil.py:184` |
+|     % |     Size | Allocations | Location                             |
+| ----: | -------: | ----------: | ------------------------------------ |
+| 35.7% | 1.69 KiB |           2 | `/usr/lib/python3.11/pkgutil.py:269` |
+| 35.7% | 1.69 KiB |           2 | `/usr/lib/python3.11/pkgutil.py:194` |
+| 15.9% |    768 B |           1 | `/usr/lib/python3.11/pkgutil.py:137` |
+| 12.8% |    620 B |           1 | `/usr/lib/python3.11/pkgutil.py:184` |
 
 ##### `Specifier` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`)
 
-|      % |     Size | Samples | Location                                                         |
-| -----: | -------: | ------: | ---------------------------------------------------------------- |
-| 100.0% | 3.82 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:340` |
+|      % |     Size | Allocations | Location                                                         |
+| -----: | -------: | ----------: | ---------------------------------------------------------------- |
+| 100.0% | 3.82 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:340` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Location                                                    |
-| -----: | -------: | ------: | ----------------------------------------------------------- |
-| 100.0% | 3.79 KiB |       3 | `/venv/lib/python3.11/site-packages/click/decorators.py:34` |
+|      % |     Size | Allocations | Location                                                    |
+| -----: | -------: | ----------: | ----------------------------------------------------------- |
+| 100.0% | 3.79 KiB |           3 | `/venv/lib/python3.11/site-packages/click/decorators.py:34` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 46.4% | 1.73 KiB |       2 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:29`  |
-| 27.3% | 1.02 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:90`  |
-| 26.3% |   1000 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:245` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 46.4% | 1.73 KiB |           2 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:29`  |
+| 27.3% | 1.02 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:90`  |
+| 26.3% |   1000 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:245` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|     % |  Size | Samples | Location                                                   |
-| ----: | ----: | ------: | ---------------------------------------------------------- |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:62` |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:46` |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:54` |
-| 21.1% | 768 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:27` |
+|     % |  Size | Allocations | Location                                                   |
+| ----: | ----: | ----------: | ---------------------------------------------------------- |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:62` |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:46` |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:54` |
+| 21.1% | 768 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:27` |
 
 ##### `handle_parse_result` (`/venv/lib/python3.11/site-packages/click/core.py:2663`)
 
-|     % |    Size | Samples | Location                                                |
-| ----: | ------: | ------: | ------------------------------------------------------- |
-| 38.5% | 1.3 KiB |       2 | `/venv/lib/python3.11/site-packages/click/core.py:2686` |
-| 22.3% |   768 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2739` |
-| 22.3% |   768 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2740` |
-| 17.0% |   586 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2711` |
+|     % |    Size | Allocations | Location                                                |
+| ----: | ------: | ----------: | ------------------------------------------------------- |
+| 38.5% | 1.3 KiB |           2 | `/venv/lib/python3.11/site-packages/click/core.py:2686` |
+| 22.3% |   768 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2739` |
+| 22.3% |   768 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2740` |
+| 17.0% |   586 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2711` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|      % |     Size | Samples | Location                                                  |
-| -----: | -------: | ------: | --------------------------------------------------------- |
-| 100.0% | 3.19 KiB |       1 | `/venv/lib/python3.11/site-packages/click/__init__.py:74` |
+|      % |     Size | Allocations | Location                                                  |
+| -----: | -------: | ----------: | --------------------------------------------------------- |
+| 100.0% | 3.19 KiB |           1 | `/venv/lib/python3.11/site-packages/click/__init__.py:74` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 76.5% | 2.44 KiB |       3 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:55` |
-| 23.5% |    768 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:14` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 76.5% | 2.44 KiB |           3 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:55` |
+| 23.5% |    768 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:14` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|      % |     Size | Samples | Location                                  |
-| -----: | -------: | ------: | ----------------------------------------- |
-| 100.0% | 2.85 KiB |       1 | `/usr/lib/python3.11/dataclasses.py:1210` |
+|      % |     Size | Allocations | Location                                  |
+| -----: | -------: | ----------: | ----------------------------------------- |
+| 100.0% | 2.85 KiB |           1 | `/usr/lib/python3.11/dataclasses.py:1210` |
 
 ##### `_process_class` (`/usr/lib/python3.11/dataclasses.py:884`)
 
-|     % |     Size | Samples | Location                                  |
-| ----: | -------: | ------: | ----------------------------------------- |
-| 41.3% | 1.18 KiB |       1 | `/usr/lib/python3.11/dataclasses.py:958`  |
-| 21.0% |    612 B |       1 | `/usr/lib/python3.11/dataclasses.py:1027` |
-| 19.9% |    580 B |       1 | `/usr/lib/python3.11/dataclasses.py:1096` |
-| 17.8% |    518 B |       1 | `/usr/lib/python3.11/dataclasses.py:947`  |
+|     % |     Size | Allocations | Location                                  |
+| ----: | -------: | ----------: | ----------------------------------------- |
+| 41.3% | 1.18 KiB |           1 | `/usr/lib/python3.11/dataclasses.py:958`  |
+| 21.0% |    612 B |           1 | `/usr/lib/python3.11/dataclasses.py:1027` |
+| 19.9% |    580 B |           1 | `/usr/lib/python3.11/dataclasses.py:1096` |
+| 17.8% |    518 B |           1 | `/usr/lib/python3.11/dataclasses.py:947`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1`)
 
-|     % |  Size | Samples | Location                                                                     |
-| ----: | ----: | ------: | ---------------------------------------------------------------------------- |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:22`  |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:205` |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:197` |
+|     % |  Size | Allocations | Location                                                                     |
+| ----: | ----: | ----------: | ---------------------------------------------------------------------------- |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:22`  |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:205` |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:197` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 53.7% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/click/types.py:464` |
-| 46.3% | 1.28 KiB |       1 | `/venv/lib/python3.11/site-packages/click/types.py:37`  |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 53.7% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/click/types.py:464` |
+| 46.3% | 1.28 KiB |           1 | `/venv/lib/python3.11/site-packages/click/types.py:37`  |
 
 #### Callers
 
@@ -571,483 +571,483 @@ Callers ranked by contribution to each function's self size. Inlining can make c
 
 ##### `mark` (`black/brackets.py:70`)
 
-|     % |     Size | Samples | Caller                           | Location                |
-| ----: | -------: | ------: | -------------------------------- | ----------------------- |
-| 94.5% | 17.2 MiB |  20,789 | `append`                         | `black/lines.py:63`     |
-|  5.5% |    1 MiB |       1 | `max_delimiter_priority_in_atom` | `black/brackets.py:328` |
+|     % |     Size | Allocations | Caller                           | Location                |
+| ----: | -------: | ----------: | -------------------------------- | ----------------------- |
+| 94.5% | 17.2 MiB |      20,789 | `append`                         | `black/lines.py:63`     |
+|  5.5% |    1 MiB |           1 | `max_delimiter_priority_in_atom` | `black/brackets.py:328` |
 
 ##### `parse` (`/usr/lib/python3.11/ast.py:33`)
 
-|      % |   Size | Samples | Caller                  | Location               |
-| -----: | -----: | ------: | ----------------------- | ---------------------- |
-| 100.0% | 16 MiB |   1,014 | `_parse_single_version` | `black/parsing.py:117` |
+|      % |   Size | Allocations | Caller                  | Location               |
+| -----: | -----: | ----------: | ----------------------- | ---------------------- |
+| 100.0% | 16 MiB |       1,014 | `_parse_single_version` | `black/parsing.py:117` |
 
 ##### `changed` (`blib2to3/pytree.py:171`)
 
-|     % |  Size | Samples | Caller    | Location                 |
-| ----: | ----: | ------: | --------- | ------------------------ |
-| 66.7% | 4 MiB |       4 | `changed` | `blib2to3/pytree.py:171` |
-| 33.3% | 2 MiB |       2 | `prefix`  | `blib2to3/pytree.py:480` |
+|     % |  Size | Allocations | Caller    | Location                 |
+| ----: | ----: | ----------: | --------- | ------------------------ |
+| 66.7% | 4 MiB |           4 | `changed` | `blib2to3/pytree.py:171` |
+| 33.3% | 2 MiB |           2 | `prefix`  | `blib2to3/pytree.py:480` |
 
 ##### `__new__` (`blib2to3/pytree.py:81`)
 
-|      % |  Size | Samples | Caller    | Location                 |
-| -----: | ----: | ------: | --------- | ------------------------ |
-| 100.0% | 5 MiB |       5 | `convert` | `blib2to3/pytree.py:486` |
+|      % |  Size | Allocations | Caller    | Location                 |
+| -----: | ----: | ----------: | --------- | ------------------------ |
+| 100.0% | 5 MiB |           5 | `convert` | `blib2to3/pytree.py:486` |
 
 ##### `transform_line` (`black/linegen.py:601`)
 
-|      % |  Size | Samples | Caller             | Location                 |
-| -----: | ----: | ------: | ------------------ | ------------------------ |
-| 100.0% | 3 MiB |       8 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |  Size | Allocations | Caller             | Location                 |
+| -----: | ----: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 3 MiB |           8 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|      % |  Size | Samples | Caller         | Location               |
-| -----: | ----: | ------: | -------------- | ---------------------- |
-| 100.0% | 3 MiB |       3 | `visit`        | `black/nodes.py:163`   |
-|  <0.1% | 702 B |       1 | `visit_STRING` | `black/linegen.py:413` |
+|      % |  Size | Allocations | Caller         | Location               |
+| -----: | ----: | ----------: | -------------- | ---------------------- |
+| 100.0% | 3 MiB |           3 | `visit`        | `black/nodes.py:163`   |
+|  <0.1% | 702 B |           1 | `visit_STRING` | `black/linegen.py:413` |
 
 ##### `generate_comments` (`black/comments.py:52`)
 
-|      % |  Size | Samples | Caller          | Location               |
-| -----: | ----: | ------: | --------------- | ---------------------- |
-| 100.0% | 3 MiB |       3 | `visit_default` | `black/linegen.py:134` |
+|      % |  Size | Allocations | Caller          | Location               |
+| -----: | ----: | ----------: | --------------- | ---------------------- |
+| 100.0% | 3 MiB |           3 | `visit_default` | `black/linegen.py:134` |
 
 ##### `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`)
 
-|      % |     Size | Samples | Caller           | Location                                     |
-| -----: | -------: | ------: | ---------------- | -------------------------------------------- |
-| 100.0% | 2.27 MiB |     352 | `source_to_code` | `<frozen importlib._bootstrap_external>:999` |
+|      % |     Size | Allocations | Caller           | Location                                     |
+| -----: | -------: | ----------: | ---------------- | -------------------------------------------- |
+| 100.0% | 2.27 MiB |         352 | `source_to_code` | `<frozen importlib._bootstrap_external>:999` |
 
 ##### `update_sibling_maps` (`blib2to3/pytree.py:369`)
 
-|      % |     Size | Samples | Caller         | Location                 |
-| -----: | -------: | ------: | -------------- | ------------------------ |
-| 100.0% | 2.14 MiB |     197 | `prev_sibling` | `blib2to3/pytree.py:207` |
+|      % |     Size | Allocations | Caller         | Location                 |
+| -----: | -------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 2.14 MiB |         197 | `prev_sibling` | `blib2to3/pytree.py:207` |
 
 ##### `convert` (`blib2to3/pytree.py:486`)
 
-|      % |  Size | Samples | Caller | Location                      |
-| -----: | ----: | ------: | ------ | ----------------------------- |
-| 100.0% | 2 MiB |       2 | `pop`  | `blib2to3/pgen2/parse.py:398` |
+|      % |  Size | Allocations | Caller | Location                      |
+| -----: | ----: | ----------: | ------ | ----------------------------- |
+| 100.0% | 2 MiB |           2 | `pop`  | `blib2to3/pgen2/parse.py:398` |
 
 ##### `push` (`blib2to3/pgen2/parse.py:386`)
 
-|      % |  Size | Samples | Caller      | Location                      |
-| -----: | ----: | ------: | ----------- | ----------------------------- |
-| 100.0% | 2 MiB |       2 | `_addtoken` | `blib2to3/pgen2/parse.py:290` |
+|      % |  Size | Allocations | Caller      | Location                      |
+| -----: | ----: | ----------: | ----------- | ----------------------------- |
+| 100.0% | 2 MiB |           2 | `_addtoken` | `blib2to3/pgen2/parse.py:290` |
 
 ##### `make_grammar` (`blib2to3/pgen2/pgen.py:49`)
 
-|      % |     Size | Samples | Caller             | Location                     |
-| -----: | -------: | ------: | ------------------ | ---------------------------- |
-| 100.0% | 1.01 MiB |       6 | `generate_grammar` | `blib2to3/pgen2/pgen.py:426` |
+|      % |     Size | Allocations | Caller             | Location                     |
+| -----: | -------: | ----------: | ------------------ | ---------------------------- |
+| 100.0% | 1.01 MiB |           6 | `generate_grammar` | `blib2to3/pgen2/pgen.py:426` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 1.01 MiB |      11 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 1.01 MiB |          11 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|     % |  Size | Samples | Caller             | Location                 |
-| ----: | ----: | ------: | ------------------ | ------------------------ |
-| 99.9% | 1 MiB |       4 | `visit_default`    | `black/nodes.py:187`     |
-|  0.1% | 690 B |       1 | `_format_str_once` | `black/__init__.py:1236` |
+|     % |  Size | Allocations | Caller             | Location                 |
+| ----: | ----: | ----------: | ------------------ | ------------------------ |
+| 99.9% | 1 MiB |           4 | `visit_default`    | `black/nodes.py:187`     |
+|  0.1% | 690 B |           1 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `maybe_empty_lines` (`black/lines.py:560`)
 
-|      % |  Size | Samples | Caller             | Location                 |
-| -----: | ----: | ------: | ------------------ | ------------------------ |
-| 100.0% | 1 MiB |       2 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |  Size | Allocations | Caller             | Location                 |
+| -----: | ----: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 1 MiB |           2 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `_addtoken` (`blib2to3/pgen2/parse.py:290`)
 
-|      % |  Size | Samples | Caller     | Location                      |
-| -----: | ----: | ------: | ---------- | ----------------------------- |
-| 100.0% | 1 MiB |       1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
+|      % |  Size | Allocations | Caller     | Location                      |
+| -----: | ----: | ----------: | ---------- | ----------------------------- |
+| 100.0% | 1 MiB |           1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
 
 ##### `contains_uncollapsable_type_comments` (`black/lines.py:276`)
 
-|      % |  Size | Samples | Caller           | Location               |
-| -----: | ----: | ------: | ---------------- | ---------------------- |
-| 100.0% | 1 MiB |       1 | `transform_line` | `black/linegen.py:601` |
+|      % |  Size | Allocations | Caller           | Location               |
+| -----: | ----: | ----------: | ---------------- | ---------------------- |
+| 100.0% | 1 MiB |           1 | `transform_line` | `black/linegen.py:601` |
 
 ##### `__init__` (`<string>:2`)
 
-|      % |  Size | Samples | Caller | Location               |
-| -----: | ----: | ------: | ------ | ---------------------- |
-| 100.0% | 1 MiB |       1 | `line` | `black/linegen.py:109` |
+|      % |  Size | Allocations | Caller | Location               |
+| -----: | ----: | ----------: | ------ | ---------------------- |
+| 100.0% | 1 MiB |           1 | `line` | `black/linegen.py:109` |
 
 ##### `__init__` (`blib2to3/pytree.py:400`)
 
-|      % |  Size | Samples | Caller    | Location                 |
-| -----: | ----: | ------: | --------- | ------------------------ |
-| 100.0% | 1 MiB |       1 | `convert` | `blib2to3/pytree.py:486` |
+|      % |  Size | Allocations | Caller    | Location                 |
+| -----: | ----: | ----------: | --------- | ------------------------ |
+| 100.0% | 1 MiB |           1 | `convert` | `blib2to3/pytree.py:486` |
 
 ##### `_compile_bytecode` (`<frozen importlib._bootstrap_external>:727`)
 
-|      % |    Size | Samples | Caller     | Location                                      |
-| -----: | ------: | ------: | ---------- | --------------------------------------------- |
-| 100.0% | 311 KiB |     341 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
+|      % |    Size | Allocations | Caller     | Location                                      |
+| -----: | ------: | ----------: | ---------- | --------------------------------------------- |
+| 100.0% | 311 KiB |         341 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `_format_str_once` (`black/__init__.py:1236`)
 
-|      % |    Size | Samples | Caller       | Location                 |
-| -----: | ------: | ------: | ------------ | ------------------------ |
-| 100.0% | 225 KiB |       5 | `format_str` | `black/__init__.py:1189` |
+|      % |    Size | Allocations | Caller       | Location                 |
+| -----: | ------: | ----------: | ------------ | ------------------------ |
+| 100.0% | 225 KiB |           5 | `format_str` | `black/__init__.py:1189` |
 
 ##### `decode` (`<frozen codecs>:319`)
 
-|      % |    Size | Samples | Caller         | Location                 |
-| -----: | ------: | ------: | -------------- | ------------------------ |
-| 100.0% | 222 KiB |       1 | `decode_bytes` | `black/__init__.py:1290` |
+|      % |    Size | Allocations | Caller         | Location                 |
+| -----: | ------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 222 KiB |           1 | `decode_bytes` | `black/__init__.py:1290` |
 
 ##### `_code_to_timestamp_pyc` (`<frozen importlib._bootstrap_external>:740`)
 
-|      % |    Size | Samples | Caller     | Location                                      |
-| -----: | ------: | ------: | ---------- | --------------------------------------------- |
-| 100.0% | 112 KiB |     108 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
+|      % |    Size | Allocations | Caller     | Location                                      |
+| -----: | ------: | ----------: | ---------- | --------------------------------------------- |
+| 100.0% | 112 KiB |         108 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `__new__` (`<frozen abc>:105`)
 
-|     % |     Size | Samples | Caller     | Location                                                       |
-| ----: | -------: | ------: | ---------- | -------------------------------------------------------------- |
-| 50.5% | 38.2 KiB |      45 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`          |
-| 23.1% | 17.5 KiB |      18 | `<module>` | `black/trans.py:1`                                             |
-| 18.3% | 13.9 KiB |       9 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`           |
-|  8.0% | 6.07 KiB |       7 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
+|     % |     Size | Allocations | Caller     | Location                                                       |
+| ----: | -------: | ----------: | ---------- | -------------------------------------------------------------- |
+| 50.5% | 38.2 KiB |          45 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`          |
+| 23.1% | 17.5 KiB |          18 | `<module>` | `black/trans.py:1`                                             |
+| 18.3% | 13.9 KiB |           9 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`           |
+|  8.0% | 6.07 KiB |           7 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
 
 ##### `normalize_string_prefix` (`black/strings.py:143`)
 
-|      % |     Size | Samples | Caller         | Location               |
-| -----: | -------: | ------: | -------------- | ---------------------- |
-| 100.0% | 57.2 KiB |      65 | `visit_STRING` | `black/linegen.py:413` |
+|      % |     Size | Allocations | Caller         | Location               |
+| -----: | -------: | ----------: | -------------- | ---------------------- |
+| 100.0% | 57.2 KiB |          65 | `visit_STRING` | `black/linegen.py:413` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|      % |     Size | Samples | Caller      | Location                                                     |
-| -----: | -------: | ------: | ----------- | ------------------------------------------------------------ |
-| 100.0% | 44.3 KiB |      31 | `decorator` | `/venv/lib/python3.11/site-packages/click/decorators.py:373` |
+|      % |     Size | Allocations | Caller      | Location                                                     |
+| -----: | -------: | ----------: | ----------- | ------------------------------------------------------------ |
+| 100.0% | 44.3 KiB |          31 | `decorator` | `/venv/lib/python3.11/site-packages/click/decorators.py:373` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 42 KiB |       7 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 42 KiB |           7 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `copy` (`blib2to3/pgen2/grammar.py:131`)
 
-|      % |     Size | Samples | Caller       | Location                 |
-| -----: | -------: | ------: | ------------ | ------------------------ |
-| 100.0% | 41.5 KiB |      16 | `initialize` | `blib2to3/pygram.py:165` |
+|      % |     Size | Allocations | Caller       | Location                 |
+| -----: | -------: | ----------: | ------------ | ------------------------ |
+| 100.0% | 41.5 KiB |          16 | `initialize` | `blib2to3/pygram.py:165` |
 
 ##### `classify` (`blib2to3/pgen2/parse.py:336`)
 
-|      % |   Size | Samples | Caller     | Location                      |
-| -----: | -----: | ------: | ---------- | ----------------------------- |
-| 100.0% | 32 KiB |       1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
+|      % |   Size | Allocations | Caller     | Location                      |
+| -----: | -----: | ----------: | ---------- | ----------------------------- |
+| 100.0% | 32 KiB |           1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 25 KiB |      22 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 25 KiB |          22 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__new__` (`/usr/lib/python3.11/enum.py:488`)
 
-|     % |     Size | Samples | Caller     | Location                                                     |
-| ----: | -------: | ------: | ---------- | ------------------------------------------------------------ |
-| 31.7% | 7.64 KiB |       9 | `<module>` | `black/mode.py:1`                                            |
-| 16.2% | 3.89 KiB |       4 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/_elffile.py:1` |
-| 13.7% |  3.3 KiB |       3 | `<module>` | `/venv/lib/python3.11/site-packages/click/_utils.py:1`       |
-| 10.1% | 2.44 KiB |       3 | `<module>` | `black/__init__.py:1`                                        |
-|  7.2% | 1.74 KiB |       2 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`         |
+|     % |     Size | Allocations | Caller     | Location                                                     |
+| ----: | -------: | ----------: | ---------- | ------------------------------------------------------------ |
+| 31.7% | 7.64 KiB |           9 | `<module>` | `black/mode.py:1`                                            |
+| 16.2% | 3.89 KiB |           4 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/_elffile.py:1` |
+| 13.7% |  3.3 KiB |           3 | `<module>` | `/venv/lib/python3.11/site-packages/click/_utils.py:1`       |
+| 10.1% | 2.44 KiB |           3 | `<module>` | `black/__init__.py:1`                                        |
+|  7.2% | 1.74 KiB |           2 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`         |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|      % |     Size | Samples | Caller     | Location                                 |
-| -----: | -------: | ------: | ---------- | ---------------------------------------- |
-| 100.0% | 22.6 KiB |      12 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
+|      % |     Size | Allocations | Caller     | Location                                 |
+| -----: | -------: | ----------: | ---------- | ---------------------------------------- |
+| 100.0% | 22.6 KiB |          12 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/_parser.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 19.8 KiB |      12 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 19.8 KiB |          12 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__new__` (`/usr/lib/python3.11/typing.py:2891`)
 
-|     % |     Size | Samples | Caller     | Location                                                    |
-| ----: | -------: | ------: | ---------- | ----------------------------------------------------------- |
-| 90.3% | 15.7 KiB |      19 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`       |
-|  9.7% | 1.69 KiB |       2 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/version.py:1` |
+|     % |     Size | Allocations | Caller     | Location                                                    |
+| ----: | -------: | ----------: | ---------- | ----------------------------------------------------------- |
+| 90.3% | 15.7 KiB |          19 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`       |
+|  9.7% | 1.69 KiB |           2 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/version.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/mypy_extensions.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 15 KiB |      18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 15 KiB |          18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/exceptions.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 13.4 KiB |      15 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 13.4 KiB |          15 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `inner` (`/usr/lib/python3.11/typing.py:338`)
 
-|     % |     Size | Samples | Caller        | Location                                              |
-| ----: | -------: | ------: | ------------- | ----------------------------------------------------- |
-| 75.3% | 9.02 KiB |       1 | `Line`        | `black/lines.py:49`                                   |
-| 17.9% | 2.15 KiB |       1 | `__getitem__` | `/usr/lib/python3.11/typing.py:467`                   |
-|  6.7% |    826 B |       1 | `<module>`    | `/venv/lib/python3.11/site-packages/click/types.py:1` |
+|     % |     Size | Allocations | Caller        | Location                                              |
+| ----: | -------: | ----------: | ------------- | ----------------------------------------------------- |
+| 75.3% | 9.02 KiB |           1 | `Line`        | `black/lines.py:49`                                   |
+| 17.9% | 2.15 KiB |           1 | `__getitem__` | `/usr/lib/python3.11/typing.py:467`                   |
+|  6.7% |    826 B |           1 | `<module>`    | `/venv/lib/python3.11/site-packages/click/types.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/version.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 9.61 KiB |       9 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 9.61 KiB |           9 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `_fill_cache` (`<frozen importlib._bootstrap_external>:1655`)
 
-|      % |  Size | Samples | Caller      | Location                                      |
-| -----: | ----: | ------: | ----------- | --------------------------------------------- |
-| 100.0% | 8 KiB |       4 | `find_spec` | `<frozen importlib._bootstrap_external>:1604` |
+|      % |  Size | Allocations | Caller      | Location                                      |
+| -----: | ----: | ----------: | ----------- | --------------------------------------------- |
+| 100.0% | 8 KiB |           4 | `find_spec` | `<frozen importlib._bootstrap_external>:1604` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|      % |     Size | Samples | Caller  | Location                                |
-| -----: | -------: | ------: | ------- | --------------------------------------- |
-| 100.0% | 7.97 KiB |       1 | `parse` | `/usr/lib/python3.11/re/_parser.py:970` |
+|      % |     Size | Allocations | Caller  | Location                                |
+| -----: | -------: | ----------: | ------- | --------------------------------------- |
+| 100.0% | 7.97 KiB |           1 | `parse` | `/usr/lib/python3.11/re/_parser.py:970` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/utils.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 7.08 KiB |       8 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 7.08 KiB |           8 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__setattr__` (`/usr/lib/python3.11/enum.py:831`)
 
-|     % |     Size | Samples | Caller         | Location                          |
-| ----: | -------: | ------: | -------------- | --------------------------------- |
-| 66.6% | 4.48 KiB |       5 | `__set_name__` | `/usr/lib/python3.11/enum.py:237` |
-| 33.4% | 2.25 KiB |       3 | `__new__`      | `/usr/lib/python3.11/enum.py:488` |
+|     % |     Size | Allocations | Caller         | Location                          |
+| ----: | -------: | ----------: | -------------- | --------------------------------- |
+| 66.6% | 4.48 KiB |           5 | `__set_name__` | `/usr/lib/python3.11/enum.py:237` |
+| 33.4% | 2.25 KiB |           3 | `__new__`      | `/usr/lib/python3.11/enum.py:488` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/util.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 6.48 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 6.48 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 6.24 KiB |       5 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 6.24 KiB |           5 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/_compat.py:1`)
 
-|      % |    Size | Samples | Caller                      | Location                            |
-| -----: | ------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 5.8 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |    Size | Allocations | Caller                      | Location                            |
+| -----: | ------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 5.8 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `namedtuple` (`/usr/lib/python3.11/collections/__init__.py:348`)
 
-|     % |     Size | Samples | Caller          | Location                             |
-| ----: | -------: | ------: | --------------- | ------------------------------------ |
-| 83.3% | 4.69 KiB |       5 | `_make_nmtuple` | `/usr/lib/python3.11/typing.py:2795` |
-| 16.7% |    960 B |       1 | `<module>`      | `/usr/lib/python3.11/pkgutil.py:1`   |
+|     % |     Size | Allocations | Caller          | Location                             |
+| ----: | -------: | ----------: | --------------- | ------------------------------------ |
+| 83.3% | 4.69 KiB |           5 | `_make_nmtuple` | `/usr/lib/python3.11/typing.py:2795` |
+| 16.7% |    960 B |           1 | `<module>`      | `/usr/lib/python3.11/pkgutil.py:1`   |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|      % |     Size | Samples | Caller       | Location                                |
-| -----: | -------: | ------: | ------------ | --------------------------------------- |
-| 100.0% | 5.61 KiB |       3 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
+|      % |     Size | Allocations | Caller       | Location                                |
+| -----: | -------: | ----------: | ------------ | --------------------------------------- |
+| 100.0% | 5.61 KiB |           3 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
 
 ##### `_code` (`/usr/lib/python3.11/re/_compiler.py:571`)
 
-|      % |     Size | Samples | Caller    | Location                                  |
-| -----: | -------: | ------: | --------- | ----------------------------------------- |
-| 100.0% | 5.32 KiB |       2 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
+|      % |     Size | Allocations | Caller    | Location                                  |
+| -----: | -------: | ----------: | --------- | ----------------------------------------- |
+| 100.0% | 5.32 KiB |           2 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
 
 ##### `<module>` (`/usr/lib/python3.11/pkgutil.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 4.73 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 4.73 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `Specifier` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`)
 
-|      % |     Size | Samples | Caller     | Location                                                       |
-| -----: | -------: | ------: | ---------- | -------------------------------------------------------------- |
-| 100.0% | 3.82 KiB |       1 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
+|      % |     Size | Allocations | Caller     | Location                                                       |
+| -----: | -------: | ----------: | ---------- | -------------------------------------------------------------- |
+| 100.0% | 3.82 KiB |           1 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Caller   | Location                                               |
-| -----: | -------: | ------: | -------- | ------------------------------------------------------ |
-| 100.0% | 3.79 KiB |       3 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
+|      % |     Size | Allocations | Caller   | Location                                               |
+| -----: | -------: | ----------: | -------- | ------------------------------------------------------ |
+| 100.0% | 3.79 KiB |           3 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.72 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.72 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.56 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.56 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `handle_parse_result` (`/venv/lib/python3.11/site-packages/click/core.py:2663`)
 
-|      % |     Size | Samples | Caller       | Location                                                |
-| -----: | -------: | ------: | ------------ | ------------------------------------------------------- |
-| 100.0% | 3.37 KiB |       5 | `parse_args` | `/venv/lib/python3.11/site-packages/click/core.py:1303` |
+|      % |     Size | Allocations | Caller       | Location                                                |
+| -----: | -------: | ----------: | ------------ | ------------------------------------------------------- |
+| 100.0% | 3.37 KiB |           5 | `parse_args` | `/venv/lib/python3.11/site-packages/click/core.py:1303` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.19 KiB |       1 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.19 KiB |           1 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.19 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.19 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|      % |     Size | Samples | Caller     | Location                                                   |
-| -----: | -------: | ------: | ---------- | ---------------------------------------------------------- |
-| 100.0% | 2.85 KiB |       1 | `<module>` | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1` |
+|      % |     Size | Allocations | Caller     | Location                                                   |
+| -----: | -------: | ----------: | ---------- | ---------------------------------------------------------- |
+| 100.0% | 2.85 KiB |           1 | `<module>` | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1` |
 
 ##### `_process_class` (`/usr/lib/python3.11/dataclasses.py:884`)
 
-|      % |     Size | Samples | Caller | Location                                  |
-| -----: | -------: | ------: | ------ | ----------------------------------------- |
-| 100.0% | 2.85 KiB |       4 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
+|      % |     Size | Allocations | Caller | Location                                  |
+| -----: | -------: | ----------: | ------ | ----------------------------------------- |
+| 100.0% | 2.85 KiB |           4 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.81 KiB |       3 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.81 KiB |           3 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.76 KiB |       2 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.76 KiB |           2 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ### Total size
 
 Functions ranked by total bytes held at peak memory in the function and all its callees.
 
-|      % |     Size | Samples | Function               | Location                                                       |
-| -----: | -------: | ------: | ---------------------- | -------------------------------------------------------------- |
-| 100.0% | 72.4 MiB |  23,696 | `_run_tracker`         | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
-| 100.0% | 72.4 MiB |  23,695 | `run_module`           | `<frozen runpy>:201`                                           |
-|  92.5% |   67 MiB |  22,200 | `__call__`             | `/venv/lib/python3.11/site-packages/click/core.py:1567`        |
-|  92.5% |   67 MiB |  22,200 | `patched_main`         | `black/__init__.py:1594`                                       |
-|  92.5% |   67 MiB |  22,200 | `<module>`             | `black/__main__.py:1`                                          |
-|  92.5% |   67 MiB |  22,200 | `_run_code`            | `<frozen runpy>:65`                                            |
-|  92.5% |   67 MiB |  22,200 | `_run_module_code`     | `<frozen runpy>:91`                                            |
-|  92.5% |   67 MiB |  22,199 | `main`                 | `/venv/lib/python3.11/site-packages/click/core.py:1422`        |
-|  92.4% | 66.9 MiB |  22,180 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:1339`        |
-|  92.4% | 66.9 MiB |  22,177 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:853`         |
-|  92.4% | 66.9 MiB |  22,175 | `new_func`             | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
-|  92.4% | 66.9 MiB |  22,172 | `main`                 | `black/__init__.py:244`                                        |
-|  92.4% | 66.9 MiB |  22,168 | `reformat_one`         | `black/__init__.py:860`                                        |
-|  92.4% | 66.9 MiB |  22,165 | `format_file_in_place` | `black/__init__.py:917`                                        |
-|  92.1% | 66.7 MiB |  22,162 | `format_file_contents` | `black/__init__.py:1054`                                       |
-|  70.1% | 50.8 MiB |  21,147 | `format_str`           | `black/__init__.py:1189`                                       |
-|  70.1% | 50.8 MiB |  21,146 | `_format_str_once`     | `black/__init__.py:1236`                                       |
-|  47.6% | 34.4 MiB |  21,085 | `visit`                | `black/nodes.py:163`                                           |
-|  47.6% | 34.4 MiB |  21,083 | `visit_default`        | `black/linegen.py:134`                                         |
-|  47.6% | 34.4 MiB |  21,083 | `visit_default`        | `black/nodes.py:187`                                           |
+|      % |     Size | Allocations | Function               | Location                                                       |
+| -----: | -------: | ----------: | ---------------------- | -------------------------------------------------------------- |
+| 100.0% | 72.4 MiB |      23,696 | `_run_tracker`         | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
+| 100.0% | 72.4 MiB |      23,695 | `run_module`           | `<frozen runpy>:201`                                           |
+|  92.5% |   67 MiB |      22,200 | `__call__`             | `/venv/lib/python3.11/site-packages/click/core.py:1567`        |
+|  92.5% |   67 MiB |      22,200 | `patched_main`         | `black/__init__.py:1594`                                       |
+|  92.5% |   67 MiB |      22,200 | `<module>`             | `black/__main__.py:1`                                          |
+|  92.5% |   67 MiB |      22,200 | `_run_code`            | `<frozen runpy>:65`                                            |
+|  92.5% |   67 MiB |      22,200 | `_run_module_code`     | `<frozen runpy>:91`                                            |
+|  92.5% |   67 MiB |      22,199 | `main`                 | `/venv/lib/python3.11/site-packages/click/core.py:1422`        |
+|  92.4% | 66.9 MiB |      22,180 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:1339`        |
+|  92.4% | 66.9 MiB |      22,177 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:853`         |
+|  92.4% | 66.9 MiB |      22,175 | `new_func`             | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
+|  92.4% | 66.9 MiB |      22,172 | `main`                 | `black/__init__.py:244`                                        |
+|  92.4% | 66.9 MiB |      22,168 | `reformat_one`         | `black/__init__.py:860`                                        |
+|  92.4% | 66.9 MiB |      22,165 | `format_file_in_place` | `black/__init__.py:917`                                        |
+|  92.1% | 66.7 MiB |      22,162 | `format_file_contents` | `black/__init__.py:1054`                                       |
+|  70.1% | 50.8 MiB |      21,147 | `format_str`           | `black/__init__.py:1189`                                       |
+|  70.1% | 50.8 MiB |      21,146 | `_format_str_once`     | `black/__init__.py:1236`                                       |
+|  47.6% | 34.4 MiB |      21,085 | `visit`                | `black/nodes.py:163`                                           |
+|  47.6% | 34.4 MiB |      21,083 | `visit_default`        | `black/linegen.py:134`                                         |
+|  47.6% | 34.4 MiB |      21,083 | `visit_default`        | `black/nodes.py:187`                                           |
 
 #### Categories
 
 ##### Ours
 
-|     % |     Size | Samples | Function                          | Location                 |
-| ----: | -------: | ------: | --------------------------------- | ------------------------ |
-| 92.5% |   67 MiB |  22,200 | `patched_main`                    | `black/__init__.py:1594` |
-| 92.5% |   67 MiB |  22,200 | `<module>`                        | `black/__main__.py:1`    |
-| 92.4% | 66.9 MiB |  22,172 | `main`                            | `black/__init__.py:244`  |
-| 92.4% | 66.9 MiB |  22,168 | `reformat_one`                    | `black/__init__.py:860`  |
-| 92.4% | 66.9 MiB |  22,165 | `format_file_in_place`            | `black/__init__.py:917`  |
-| 92.1% | 66.7 MiB |  22,162 | `format_file_contents`            | `black/__init__.py:1054` |
-| 70.1% | 50.8 MiB |  21,147 | `format_str`                      | `black/__init__.py:1189` |
-| 70.1% | 50.8 MiB |  21,146 | `_format_str_once`                | `black/__init__.py:1236` |
-| 47.6% | 34.4 MiB |  21,085 | `visit`                           | `black/nodes.py:163`     |
-| 47.6% | 34.4 MiB |  21,083 | `visit_default`                   | `black/linegen.py:134`   |
-| 47.6% | 34.4 MiB |  21,083 | `visit_default`                   | `black/nodes.py:187`     |
-| 47.2% | 34.2 MiB |  20,712 | `visit_stmt`                      | `black/linegen.py:199`   |
-| 46.7% | 33.8 MiB |  20,271 | `visit_funcdef`                   | `black/linegen.py:254`   |
-| 46.6% | 33.7 MiB |  20,145 | `visit_suite`                     | `black/linegen.py:288`   |
-| 32.9% | 23.8 MiB |  13,402 | `visit_simple_stmt`               | `black/linegen.py:295`   |
-| 26.6% | 19.3 MiB |  20,884 | `append`                          | `black/lines.py:63`      |
-| 25.2% | 18.2 MiB |  20,790 | `mark`                            | `black/brackets.py:70`   |
-| 23.3% | 16.9 MiB |  10,808 | `visit_power`                     | `black/linegen.py:341`   |
-| 22.0% |   16 MiB |   1,015 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
-| 22.0% |   16 MiB |   1,014 | `_parse_single_version`           | `black/parsing.py:117`   |
+|     % |     Size | Allocations | Function                          | Location                 |
+| ----: | -------: | ----------: | --------------------------------- | ------------------------ |
+| 92.5% |   67 MiB |      22,200 | `patched_main`                    | `black/__init__.py:1594` |
+| 92.5% |   67 MiB |      22,200 | `<module>`                        | `black/__main__.py:1`    |
+| 92.4% | 66.9 MiB |      22,172 | `main`                            | `black/__init__.py:244`  |
+| 92.4% | 66.9 MiB |      22,168 | `reformat_one`                    | `black/__init__.py:860`  |
+| 92.4% | 66.9 MiB |      22,165 | `format_file_in_place`            | `black/__init__.py:917`  |
+| 92.1% | 66.7 MiB |      22,162 | `format_file_contents`            | `black/__init__.py:1054` |
+| 70.1% | 50.8 MiB |      21,147 | `format_str`                      | `black/__init__.py:1189` |
+| 70.1% | 50.8 MiB |      21,146 | `_format_str_once`                | `black/__init__.py:1236` |
+| 47.6% | 34.4 MiB |      21,085 | `visit`                           | `black/nodes.py:163`     |
+| 47.6% | 34.4 MiB |      21,083 | `visit_default`                   | `black/linegen.py:134`   |
+| 47.6% | 34.4 MiB |      21,083 | `visit_default`                   | `black/nodes.py:187`     |
+| 47.2% | 34.2 MiB |      20,712 | `visit_stmt`                      | `black/linegen.py:199`   |
+| 46.7% | 33.8 MiB |      20,271 | `visit_funcdef`                   | `black/linegen.py:254`   |
+| 46.6% | 33.7 MiB |      20,145 | `visit_suite`                     | `black/linegen.py:288`   |
+| 32.9% | 23.8 MiB |      13,402 | `visit_simple_stmt`               | `black/linegen.py:295`   |
+| 26.6% | 19.3 MiB |      20,884 | `append`                          | `black/lines.py:63`      |
+| 25.2% | 18.2 MiB |      20,790 | `mark`                            | `black/brackets.py:70`   |
+| 23.3% | 16.9 MiB |      10,808 | `visit_power`                     | `black/linegen.py:341`   |
+| 22.0% |   16 MiB |       1,015 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+| 22.0% |   16 MiB |       1,014 | `_parse_single_version`           | `black/parsing.py:117`   |
 
 ##### Standard library
 
-|      % |     Size | Samples | Function                    | Location                                      |
-| -----: | -------: | ------: | --------------------------- | --------------------------------------------- |
-| 100.0% | 72.4 MiB |  23,695 | `run_module`                | `<frozen runpy>:201`                          |
-|  92.5% |   67 MiB |  22,200 | `_run_code`                 | `<frozen runpy>:65`                           |
-|  92.5% |   67 MiB |  22,200 | `_run_module_code`          | `<frozen runpy>:91`                           |
-|  22.0% |   16 MiB |   1,014 | `parse`                     | `/usr/lib/python3.11/ast.py:33`               |
-|   7.5% | 5.46 MiB |   1,494 | `_get_module_details`       | `<frozen runpy>:105`                          |
-|   7.5% | 5.45 MiB |   1,487 | `_find_and_load`            | `<frozen importlib._bootstrap>:1167`          |
-|   7.5% | 5.45 MiB |   1,485 | `_find_and_load_unlocked`   | `<frozen importlib._bootstrap>:1122`          |
-|   7.5% | 5.45 MiB |   1,484 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`           |
-|   7.5% | 5.45 MiB |   1,482 | `exec_module`               | `<frozen importlib._bootstrap_external>:934`  |
-|   7.5% | 5.43 MiB |   1,470 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
-|   3.7% | 2.69 MiB |     802 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
-|   3.1% | 2.27 MiB |     352 | `source_to_code`            | `<frozen importlib._bootstrap_external>:999`  |
-|   0.4% |  333 KiB |     341 | `_handle_fromlist`          | `<frozen importlib._bootstrap>:1209`          |
-|   0.4% |  311 KiB |     341 | `_compile_bytecode`         | `<frozen importlib._bootstrap_external>:727`  |
-|   0.3% |  222 KiB |       1 | `decode`                    | `<frozen codecs>:319`                         |
-|   0.2% |  112 KiB |     108 | `_code_to_timestamp_pyc`    | `<frozen importlib._bootstrap_external>:740`  |
-|   0.1% | 75.7 KiB |      79 | `__new__`                   | `<frozen abc>:105`                            |
-|   0.1% | 47.8 KiB |      25 | `compile`                   | `/usr/lib/python3.11/re/__init__.py:225`      |
-|   0.1% | 47.1 KiB |      24 | `_compile`                  | `/usr/lib/python3.11/re/__init__.py:272`      |
-|   0.1% | 46.5 KiB |      23 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`     |
+|      % |     Size | Allocations | Function                    | Location                                      |
+| -----: | -------: | ----------: | --------------------------- | --------------------------------------------- |
+| 100.0% | 72.4 MiB |      23,695 | `run_module`                | `<frozen runpy>:201`                          |
+|  92.5% |   67 MiB |      22,200 | `_run_code`                 | `<frozen runpy>:65`                           |
+|  92.5% |   67 MiB |      22,200 | `_run_module_code`          | `<frozen runpy>:91`                           |
+|  22.0% |   16 MiB |       1,014 | `parse`                     | `/usr/lib/python3.11/ast.py:33`               |
+|   7.5% | 5.46 MiB |       1,494 | `_get_module_details`       | `<frozen runpy>:105`                          |
+|   7.5% | 5.45 MiB |       1,487 | `_find_and_load`            | `<frozen importlib._bootstrap>:1167`          |
+|   7.5% | 5.45 MiB |       1,485 | `_find_and_load_unlocked`   | `<frozen importlib._bootstrap>:1122`          |
+|   7.5% | 5.45 MiB |       1,484 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`           |
+|   7.5% | 5.45 MiB |       1,482 | `exec_module`               | `<frozen importlib._bootstrap_external>:934`  |
+|   7.5% | 5.43 MiB |       1,470 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
+|   3.7% | 2.69 MiB |         802 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
+|   3.1% | 2.27 MiB |         352 | `source_to_code`            | `<frozen importlib._bootstrap_external>:999`  |
+|   0.4% |  333 KiB |         341 | `_handle_fromlist`          | `<frozen importlib._bootstrap>:1209`          |
+|   0.4% |  311 KiB |         341 | `_compile_bytecode`         | `<frozen importlib._bootstrap_external>:727`  |
+|   0.3% |  222 KiB |           1 | `decode`                    | `<frozen codecs>:319`                         |
+|   0.2% |  112 KiB |         108 | `_code_to_timestamp_pyc`    | `<frozen importlib._bootstrap_external>:740`  |
+|   0.1% | 75.7 KiB |          79 | `__new__`                   | `<frozen abc>:105`                            |
+|   0.1% | 47.8 KiB |          25 | `compile`                   | `/usr/lib/python3.11/re/__init__.py:225`      |
+|   0.1% | 47.1 KiB |          24 | `_compile`                  | `/usr/lib/python3.11/re/__init__.py:272`      |
+|   0.1% | 46.5 KiB |          23 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`     |
 
 ##### Third-party
 
-|      % |     Size | Samples | Function       | Location                                                                         |
-| -----: | -------: | ------: | -------------- | -------------------------------------------------------------------------------- |
-| 100.0% | 72.4 MiB |  23,696 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40`                   |
-|  92.5% |   67 MiB |  22,200 | `__call__`     | `/venv/lib/python3.11/site-packages/click/core.py:1567`                          |
-|  92.5% |   67 MiB |  22,199 | `main`         | `/venv/lib/python3.11/site-packages/click/core.py:1422`                          |
-|  92.4% | 66.9 MiB |  22,180 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339`                          |
-|  92.4% | 66.9 MiB |  22,177 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:853`                           |
-|  92.4% | 66.9 MiB |  22,175 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                      |
-|   1.8% | 1.31 MiB |     304 | `<module>`     | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                         |
-|   1.7% | 1.23 MiB |     233 | `<module>`     | `/venv/lib/python3.11/site-packages/click/core.py:1`                             |
-|   1.4% | 1.02 MiB |      24 | `<module>`     | `/venv/lib/python3.11/site-packages/click/formatting.py:1`                       |
-|   1.4% | 1.01 MiB |      11 | `<module>`     | `/venv/lib/python3.11/site-packages/click/parser.py:1`                           |
-|   0.2% |  173 KiB |     141 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`                   |
-|   0.2% |  125 KiB |     127 | `<module>`     | `/venv/lib/python3.11/site-packages/click/types.py:1`                            |
-|   0.1% | 99.6 KiB |      72 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                        |
-|   0.1% | 93.8 KiB |     119 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`                      |
-|   0.1% | 91.5 KiB |     115 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`                     |
-|   0.1% | 74.5 KiB |      43 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                         |
-|   0.1% | 65.5 KiB |      84 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`                 |
-|   0.1% | 47.3 KiB |      33 | `decorator`    | `/venv/lib/python3.11/site-packages/click/decorators.py:373`                     |
-|   0.1% | 46.9 KiB |      59 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1` |
-|   0.1% | 45.5 KiB |      32 | `__init__`     | `/venv/lib/python3.11/site-packages/click/core.py:2883`                          |
+|      % |     Size | Allocations | Function       | Location                                                                         |
+| -----: | -------: | ----------: | -------------- | -------------------------------------------------------------------------------- |
+| 100.0% | 72.4 MiB |      23,696 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40`                   |
+|  92.5% |   67 MiB |      22,200 | `__call__`     | `/venv/lib/python3.11/site-packages/click/core.py:1567`                          |
+|  92.5% |   67 MiB |      22,199 | `main`         | `/venv/lib/python3.11/site-packages/click/core.py:1422`                          |
+|  92.4% | 66.9 MiB |      22,180 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339`                          |
+|  92.4% | 66.9 MiB |      22,177 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:853`                           |
+|  92.4% | 66.9 MiB |      22,175 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                      |
+|   1.8% | 1.31 MiB |         304 | `<module>`     | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                         |
+|   1.7% | 1.23 MiB |         233 | `<module>`     | `/venv/lib/python3.11/site-packages/click/core.py:1`                             |
+|   1.4% | 1.02 MiB |          24 | `<module>`     | `/venv/lib/python3.11/site-packages/click/formatting.py:1`                       |
+|   1.4% | 1.01 MiB |          11 | `<module>`     | `/venv/lib/python3.11/site-packages/click/parser.py:1`                           |
+|   0.2% |  173 KiB |         141 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`                   |
+|   0.2% |  125 KiB |         127 | `<module>`     | `/venv/lib/python3.11/site-packages/click/types.py:1`                            |
+|   0.1% | 99.6 KiB |          72 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                        |
+|   0.1% | 93.8 KiB |         119 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`                      |
+|   0.1% | 91.5 KiB |         115 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`                     |
+|   0.1% | 74.5 KiB |          43 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                         |
+|   0.1% | 65.5 KiB |          84 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`                 |
+|   0.1% | 47.3 KiB |          33 | `decorator`    | `/venv/lib/python3.11/site-packages/click/decorators.py:373`                     |
+|   0.1% | 46.9 KiB |          59 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1` |
+|   0.1% | 45.5 KiB |          32 | `__init__`     | `/venv/lib/python3.11/site-packages/click/core.py:2883`                          |
 
 #### Callees
 
@@ -1055,367 +1055,367 @@ Callees ranked by contribution to each function's total size. Inlining can make 
 
 ##### `_run_tracker` (`/venv/lib/python3.11/site-packages/memray/commands/run.py:40`)
 
-|      % |     Size | Samples | Callee       | Location             |
-| -----: | -------: | ------: | ------------ | -------------------- |
-| 100.0% | 72.4 MiB |  23,695 | `run_module` | `<frozen runpy>:201` |
+|      % |     Size | Allocations | Callee       | Location             |
+| -----: | -------: | ----------: | ------------ | -------------------- |
+| 100.0% | 72.4 MiB |      23,695 | `run_module` | `<frozen runpy>:201` |
 
 ##### `run_module` (`<frozen runpy>:201`)
 
-|     % |     Size | Samples | Callee                | Location             |
-| ----: | -------: | ------: | --------------------- | -------------------- |
-| 92.5% |   67 MiB |  22,200 | `_run_module_code`    | `<frozen runpy>:91`  |
-|  7.5% | 5.46 MiB |   1,494 | `_get_module_details` | `<frozen runpy>:105` |
+|     % |     Size | Allocations | Callee                | Location             |
+| ----: | -------: | ----------: | --------------------- | -------------------- |
+| 92.5% |   67 MiB |      22,200 | `_run_module_code`    | `<frozen runpy>:91`  |
+|  7.5% | 5.46 MiB |       1,494 | `_get_module_details` | `<frozen runpy>:105` |
 
 ##### `__call__` (`/venv/lib/python3.11/site-packages/click/core.py:1567`)
 
-|      % |   Size | Samples | Callee | Location                                                |
-| -----: | -----: | ------: | ------ | ------------------------------------------------------- |
-| 100.0% | 67 MiB |  22,199 | `main` | `/venv/lib/python3.11/site-packages/click/core.py:1422` |
+|      % |   Size | Allocations | Callee | Location                                                |
+| -----: | -----: | ----------: | ------ | ------------------------------------------------------- |
+| 100.0% | 67 MiB |      22,199 | `main` | `/venv/lib/python3.11/site-packages/click/core.py:1422` |
 
 ##### `patched_main` (`black/__init__.py:1594`)
 
-|      % |   Size | Samples | Callee     | Location                                                |
-| -----: | -----: | ------: | ---------- | ------------------------------------------------------- |
-| 100.0% | 67 MiB |  22,200 | `__call__` | `/venv/lib/python3.11/site-packages/click/core.py:1567` |
+|      % |   Size | Allocations | Callee     | Location                                                |
+| -----: | -----: | ----------: | ---------- | ------------------------------------------------------- |
+| 100.0% | 67 MiB |      22,200 | `__call__` | `/venv/lib/python3.11/site-packages/click/core.py:1567` |
 
 ##### `<module>` (`black/__main__.py:1`)
 
-|      % |   Size | Samples | Callee         | Location                 |
-| -----: | -----: | ------: | -------------- | ------------------------ |
-| 100.0% | 67 MiB |  22,200 | `patched_main` | `black/__init__.py:1594` |
+|      % |   Size | Allocations | Callee         | Location                 |
+| -----: | -----: | ----------: | -------------- | ------------------------ |
+| 100.0% | 67 MiB |      22,200 | `patched_main` | `black/__init__.py:1594` |
 
 ##### `_run_code` (`<frozen runpy>:65`)
 
-|      % |   Size | Samples | Callee     | Location              |
-| -----: | -----: | ------: | ---------- | --------------------- |
-| 100.0% | 67 MiB |  22,200 | `<module>` | `black/__main__.py:1` |
+|      % |   Size | Allocations | Callee     | Location              |
+| -----: | -----: | ----------: | ---------- | --------------------- |
+| 100.0% | 67 MiB |      22,200 | `<module>` | `black/__main__.py:1` |
 
 ##### `_run_module_code` (`<frozen runpy>:91`)
 
-|      % |   Size | Samples | Callee      | Location            |
-| -----: | -----: | ------: | ----------- | ------------------- |
-| 100.0% | 67 MiB |  22,200 | `_run_code` | `<frozen runpy>:65` |
+|      % |   Size | Allocations | Callee      | Location            |
+| -----: | -----: | ----------: | ----------- | ------------------- |
+| 100.0% | 67 MiB |      22,200 | `_run_code` | `<frozen runpy>:65` |
 
 ##### `main` (`/venv/lib/python3.11/site-packages/click/core.py:1422`)
 
-|      % |     Size | Samples | Callee         | Location                                                |
-| -----: | -------: | ------: | -------------- | ------------------------------------------------------- |
-| 100.0% | 66.9 MiB |  22,180 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339` |
-|  <0.1% | 14.1 KiB |      17 | `make_context` | `/venv/lib/python3.11/site-packages/click/core.py:1266` |
-|  <0.1% |     32 B |       1 | `__enter__`    | `/venv/lib/python3.11/site-packages/click/core.py:545`  |
+|      % |     Size | Allocations | Callee         | Location                                                |
+| -----: | -------: | ----------: | -------------- | ------------------------------------------------------- |
+| 100.0% | 66.9 MiB |      22,180 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339` |
+|  <0.1% | 14.1 KiB |          17 | `make_context` | `/venv/lib/python3.11/site-packages/click/core.py:1266` |
+|  <0.1% |     32 B |           1 | `__enter__`    | `/venv/lib/python3.11/site-packages/click/core.py:545`  |
 
 ##### `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:1339`)
 
-|      % |     Size | Samples | Callee   | Location                                               |
-| -----: | -------: | ------: | -------- | ------------------------------------------------------ |
-| 100.0% | 66.9 MiB |  22,177 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
+|      % |     Size | Allocations | Callee   | Location                                               |
+| -----: | -------: | ----------: | -------- | ------------------------------------------------------ |
+| 100.0% | 66.9 MiB |      22,177 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
 
 ##### `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`)
 
-|      % |     Size | Samples | Callee     | Location                                                    |
-| -----: | -------: | ------: | ---------- | ----------------------------------------------------------- |
-| 100.0% | 66.9 MiB |  22,175 | `new_func` | `/venv/lib/python3.11/site-packages/click/decorators.py:33` |
+|      % |     Size | Allocations | Callee     | Location                                                    |
+| -----: | -------: | ----------: | ---------- | ----------------------------------------------------------- |
+| 100.0% | 66.9 MiB |      22,175 | `new_func` | `/venv/lib/python3.11/site-packages/click/decorators.py:33` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Callee | Location                |
-| -----: | -------: | ------: | ------ | ----------------------- |
-| 100.0% | 66.9 MiB |  22,172 | `main` | `black/__init__.py:244` |
+|      % |     Size | Allocations | Callee | Location                |
+| -----: | -------: | ----------: | ------ | ----------------------- |
+| 100.0% | 66.9 MiB |      22,172 | `main` | `black/__init__.py:244` |
 
 ##### `main` (`black/__init__.py:244`)
 
-|      % |     Size | Samples | Callee         | Location                |
-| -----: | -------: | ------: | -------------- | ----------------------- |
-| 100.0% | 66.9 MiB |  22,168 | `reformat_one` | `black/__init__.py:860` |
-|  <0.1% | 2.06 KiB |       2 | `get_sources`  | `black/__init__.py:724` |
+|      % |     Size | Allocations | Callee         | Location                |
+| -----: | -------: | ----------: | -------------- | ----------------------- |
+| 100.0% | 66.9 MiB |      22,168 | `reformat_one` | `black/__init__.py:860` |
+|  <0.1% | 2.06 KiB |           2 | `get_sources`  | `black/__init__.py:724` |
 
 ##### `reformat_one` (`black/__init__.py:860`)
 
-|      % |     Size | Samples | Callee                 | Location                |
-| -----: | -------: | ------: | ---------------------- | ----------------------- |
-| 100.0% | 66.9 MiB |  22,165 | `format_file_in_place` | `black/__init__.py:917` |
-|  <0.1% | 1.13 KiB |       1 | `read`                 | `black/cache.py:60`     |
+|      % |     Size | Allocations | Callee                 | Location                |
+| -----: | -------: | ----------: | ---------------------- | ----------------------- |
+| 100.0% | 66.9 MiB |      22,165 | `format_file_in_place` | `black/__init__.py:917` |
+|  <0.1% | 1.13 KiB |           1 | `read`                 | `black/cache.py:60`     |
 
 ##### `format_file_in_place` (`black/__init__.py:917`)
 
-|     % |     Size | Samples | Callee                 | Location                 |
-| ----: | -------: | ------: | ---------------------- | ------------------------ |
-| 99.7% | 66.7 MiB |  22,162 | `format_file_contents` | `black/__init__.py:1054` |
-|  0.3% |  223 KiB |       2 | `decode_bytes`         | `black/__init__.py:1290` |
+|     % |     Size | Allocations | Callee                 | Location                 |
+| ----: | -------: | ----------: | ---------------------- | ------------------------ |
+| 99.7% | 66.7 MiB |      22,162 | `format_file_contents` | `black/__init__.py:1054` |
+|  0.3% |  223 KiB |           2 | `decode_bytes`         | `black/__init__.py:1290` |
 
 ##### `format_file_contents` (`black/__init__.py:1054`)
 
-|     % |     Size | Samples | Callee                            | Location                 |
-| ----: | -------: | ------: | --------------------------------- | ------------------------ |
-| 76.1% | 50.8 MiB |  21,147 | `format_str`                      | `black/__init__.py:1189` |
-| 23.9% |   16 MiB |   1,015 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+|     % |     Size | Allocations | Callee                            | Location                 |
+| ----: | -------: | ----------: | --------------------------------- | ------------------------ |
+| 76.1% | 50.8 MiB |      21,147 | `format_str`                      | `black/__init__.py:1189` |
+| 23.9% |   16 MiB |       1,015 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
 
 ##### `format_str` (`black/__init__.py:1189`)
 
-|      % |     Size | Samples | Callee             | Location                 |
-| -----: | -------: | ------: | ------------------ | ------------------------ |
-| 100.0% | 50.8 MiB |  21,146 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |     Size | Allocations | Callee             | Location                 |
+| -----: | -------: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 50.8 MiB |      21,146 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `_format_str_once` (`black/__init__.py:1236`)
 
-|     % |     Size | Samples | Callee              | Location                |
-| ----: | -------: | ------: | ------------------- | ----------------------- |
-| 67.9% | 34.4 MiB |  21,085 | `visit`             | `black/nodes.py:163`    |
-| 21.8% |   11 MiB |      30 | `lib2to3_parse`     | `black/parsing.py:55`   |
-|  7.9% | 4.01 MiB |      18 | `transform_line`    | `black/linegen.py:601`  |
-|  2.0% |    1 MiB |       3 | `maybe_empty_lines` | `black/lines.py:560`    |
-| <0.1% | 19.9 KiB |       3 | `normalize_fmt_off` | `black/comments.py:168` |
+|     % |     Size | Allocations | Callee              | Location                |
+| ----: | -------: | ----------: | ------------------- | ----------------------- |
+| 67.9% | 34.4 MiB |      21,085 | `visit`             | `black/nodes.py:163`    |
+| 21.8% |   11 MiB |          30 | `lib2to3_parse`     | `black/parsing.py:55`   |
+|  7.9% | 4.01 MiB |          18 | `transform_line`    | `black/linegen.py:601`  |
+|  2.0% |    1 MiB |           3 | `maybe_empty_lines` | `black/lines.py:560`    |
+| <0.1% | 19.9 KiB |           3 | `normalize_fmt_off` | `black/comments.py:168` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|      % |     Size | Samples | Callee              | Location               |
-| -----: | -------: | ------: | ------------------- | ---------------------- |
-| 100.0% | 34.4 MiB |  21,083 | `visit_default`     | `black/linegen.py:134` |
-|  99.2% | 34.2 MiB |  20,712 | `visit_stmt`        | `black/linegen.py:199` |
-|  98.2% | 33.8 MiB |  20,271 | `visit_funcdef`     | `black/linegen.py:254` |
-|  97.9% | 33.7 MiB |  20,145 | `visit_suite`       | `black/linegen.py:288` |
-|  69.2% | 23.8 MiB |  13,402 | `visit_simple_stmt` | `black/linegen.py:295` |
+|      % |     Size | Allocations | Callee              | Location               |
+| -----: | -------: | ----------: | ------------------- | ---------------------- |
+| 100.0% | 34.4 MiB |      21,083 | `visit_default`     | `black/linegen.py:134` |
+|  99.2% | 34.2 MiB |      20,712 | `visit_stmt`        | `black/linegen.py:199` |
+|  98.2% | 33.8 MiB |      20,271 | `visit_funcdef`     | `black/linegen.py:254` |
+|  97.9% | 33.7 MiB |      20,145 | `visit_suite`       | `black/linegen.py:288` |
+|  69.2% | 23.8 MiB |      13,402 | `visit_simple_stmt` | `black/linegen.py:295` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|      % |     Size | Samples | Callee              | Location               |
-| -----: | -------: | ------: | ------------------- | ---------------------- |
-| 100.0% | 34.4 MiB |  21,083 | `visit_default`     | `black/nodes.py:187`   |
-|  56.0% | 19.3 MiB |  20,884 | `append`            | `black/lines.py:63`    |
-|  20.3% |    7 MiB |       7 | `generate_comments` | `black/comments.py:52` |
+|      % |     Size | Allocations | Callee              | Location               |
+| -----: | -------: | ----------: | ------------------- | ---------------------- |
+| 100.0% | 34.4 MiB |      21,083 | `visit_default`     | `black/nodes.py:187`   |
+|  56.0% | 19.3 MiB |      20,884 | `append`            | `black/lines.py:63`    |
+|  20.3% |    7 MiB |           7 | `generate_comments` | `black/comments.py:52` |
 
 ##### `visit_default` (`black/nodes.py:187`)
 
-|      % |     Size | Samples | Callee  | Location             |
-| -----: | -------: | ------: | ------- | -------------------- |
-| 100.0% | 34.4 MiB |  21,083 | `visit` | `black/nodes.py:163` |
+|      % |     Size | Allocations | Callee  | Location             |
+| -----: | -------: | ----------: | ------- | -------------------- |
+| 100.0% | 34.4 MiB |      21,083 | `visit` | `black/nodes.py:163` |
 
 ##### `visit_stmt` (`black/linegen.py:199`)
 
-|      % |     Size | Samples | Callee                       | Location                |
-| -----: | -------: | ------: | ---------------------------- | ----------------------- |
-| 100.0% | 34.2 MiB |  20,710 | `visit`                      | `black/nodes.py:163`    |
-|   8.8% |    3 MiB |       4 | `normalize_invisible_parens` | `black/linegen.py:1328` |
+|      % |     Size | Allocations | Callee                       | Location                |
+| -----: | -------: | ----------: | ---------------------------- | ----------------------- |
+| 100.0% | 34.2 MiB |      20,710 | `visit`                      | `black/nodes.py:163`    |
+|   8.8% |    3 MiB |           4 | `normalize_invisible_parens` | `black/linegen.py:1328` |
 
 ##### `visit_funcdef` (`black/linegen.py:254`)
 
-|      % |     Size | Samples | Callee  | Location             |
-| -----: | -------: | ------: | ------- | -------------------- |
-| 100.0% | 33.8 MiB |  20,271 | `visit` | `black/nodes.py:163` |
+|      % |     Size | Allocations | Callee  | Location             |
+| -----: | -------: | ----------: | ------- | -------------------- |
+| 100.0% | 33.8 MiB |      20,271 | `visit` | `black/nodes.py:163` |
 
 ##### `visit_suite` (`black/linegen.py:288`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 33.7 MiB |  20,145 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 33.7 MiB |      20,145 | `visit_default` | `black/linegen.py:134` |
 
 ##### `visit_simple_stmt` (`black/linegen.py:295`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 23.8 MiB |  13,402 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 23.8 MiB |      13,402 | `visit_default` | `black/linegen.py:134` |
 
 ##### `append` (`black/lines.py:63`)
 
-|     % |     Size | Samples | Callee       | Location               |
-| ----: | -------: | ------: | ------------ | ---------------------- |
-| 89.3% | 17.2 MiB |  20,789 | `mark`       | `black/brackets.py:70` |
-| 10.7% | 2.05 MiB |      91 | `whitespace` | `black/nodes.py:194`   |
+|     % |     Size | Allocations | Callee       | Location               |
+| ----: | -------: | ----------: | ------------ | ---------------------- |
+| 89.3% | 17.2 MiB |      20,789 | `mark`       | `black/brackets.py:70` |
+| 10.7% | 2.05 MiB |          91 | `whitespace` | `black/nodes.py:194`   |
 
 ##### `visit_power` (`black/linegen.py:341`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 16.9 MiB |  10,807 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 16.9 MiB |      10,807 | `visit_default` | `black/linegen.py:134` |
 
 ##### `check_stability_and_equivalence` (`black/__init__.py:1037`)
 
-|      % |   Size | Samples | Callee              | Location                 |
-| -----: | -----: | ------: | ------------------- | ------------------------ |
-| 100.0% | 16 MiB |   1,014 | `assert_equivalent` | `black/__init__.py:1524` |
+|      % |   Size | Allocations | Callee              | Location                 |
+| -----: | -----: | ----------: | ------------------- | ------------------------ |
+| 100.0% | 16 MiB |       1,014 | `assert_equivalent` | `black/__init__.py:1524` |
 
 ##### `_parse_single_version` (`black/parsing.py:117`)
 
-|      % |   Size | Samples | Callee  | Location                        |
-| -----: | -----: | ------: | ------- | ------------------------------- |
-| 100.0% | 16 MiB |   1,014 | `parse` | `/usr/lib/python3.11/ast.py:33` |
+|      % |   Size | Allocations | Callee  | Location                        |
+| -----: | -----: | ----------: | ------- | ------------------------------- |
+| 100.0% | 16 MiB |       1,014 | `parse` | `/usr/lib/python3.11/ast.py:33` |
 
 ##### `_get_module_details` (`<frozen runpy>:105`)
 
-|     % |     Size | Samples | Callee                | Location                             |
-| ----: | -------: | ------: | --------------------- | ------------------------------------ |
-| 99.9% | 5.45 MiB |   1,487 | `_find_and_load`      | `<frozen importlib._bootstrap>:1167` |
-| 99.9% | 5.45 MiB |   1,487 | `_get_module_details` | `<frozen runpy>:105`                 |
-|  0.1% | 5.66 KiB |       6 | `find_spec`           | `<frozen importlib.util>:73`         |
+|     % |     Size | Allocations | Callee                | Location                             |
+| ----: | -------: | ----------: | --------------------- | ------------------------------------ |
+| 99.9% | 5.45 MiB |       1,487 | `_find_and_load`      | `<frozen importlib._bootstrap>:1167` |
+| 99.9% | 5.45 MiB |       1,487 | `_get_module_details` | `<frozen runpy>:105`                 |
+|  0.1% | 5.66 KiB |           6 | `find_spec`           | `<frozen importlib.util>:73`         |
 
 ##### `_find_and_load` (`<frozen importlib._bootstrap>:1167`)
 
-|      % |     Size | Samples | Callee                    | Location                             |
-| -----: | -------: | ------: | ------------------------- | ------------------------------------ |
-| 100.0% | 5.45 MiB |   1,485 | `_find_and_load_unlocked` | `<frozen importlib._bootstrap>:1122` |
-|  <0.1% |    560 B |       1 | `__enter__`               | `<frozen importlib._bootstrap>:169`  |
+|      % |     Size | Allocations | Callee                    | Location                             |
+| -----: | -------: | ----------: | ------------------------- | ------------------------------------ |
+| 100.0% | 5.45 MiB |       1,485 | `_find_and_load_unlocked` | `<frozen importlib._bootstrap>:1122` |
+|  <0.1% |    560 B |           1 | `__enter__`               | `<frozen importlib._bootstrap>:169`  |
 
 ##### `_find_and_load_unlocked` (`<frozen importlib._bootstrap>:1122`)
 
-|      % |     Size | Samples | Callee                      | Location                             |
-| -----: | -------: | ------: | --------------------------- | ------------------------------------ |
-| 100.0% | 5.45 MiB |   1,484 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`  |
-|   0.7% | 37.2 KiB |      47 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`  |
-|   0.1% | 7.48 KiB |       4 | `_find_spec`                | `<frozen importlib._bootstrap>:1056` |
+|      % |     Size | Allocations | Callee                      | Location                             |
+| -----: | -------: | ----------: | --------------------------- | ------------------------------------ |
+| 100.0% | 5.45 MiB |       1,484 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`  |
+|   0.7% | 37.2 KiB |          47 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`  |
+|   0.1% | 7.48 KiB |           4 | `_find_spec`                | `<frozen importlib._bootstrap>:1056` |
 
 ##### `_load_unlocked` (`<frozen importlib._bootstrap>:666`)
 
-|      % |     Size | Samples | Callee             | Location                                     |
-| -----: | -------: | ------: | ------------------ | -------------------------------------------- |
-| 100.0% | 5.45 MiB |   1,482 | `exec_module`      | `<frozen importlib._bootstrap_external>:934` |
-|  <0.1% | 1.83 KiB |       2 | `module_from_spec` | `<frozen importlib._bootstrap>:566`          |
+|      % |     Size | Allocations | Callee             | Location                                     |
+| -----: | -------: | ----------: | ------------------ | -------------------------------------------- |
+| 100.0% | 5.45 MiB |       1,482 | `exec_module`      | `<frozen importlib._bootstrap_external>:934` |
+|  <0.1% | 1.83 KiB |           2 | `module_from_spec` | `<frozen importlib._bootstrap>:566`          |
 
 ##### `exec_module` (`<frozen importlib._bootstrap_external>:934`)
 
-|     % |     Size | Samples | Callee                      | Location                                      |
-| ----: | -------: | ------: | --------------------------- | --------------------------------------------- |
-| 99.1% |  5.4 MiB |   1,436 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
-| 49.3% | 2.69 MiB |     802 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
+|     % |     Size | Allocations | Callee                      | Location                                      |
+| ----: | -------: | ----------: | --------------------------- | --------------------------------------------- |
+| 99.1% |  5.4 MiB |       1,436 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
+| 49.3% | 2.69 MiB |         802 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`)
 
-|     % |     Size | Samples | Callee     | Location                                                 |
-| ----: | -------: | ------: | ---------- | -------------------------------------------------------- |
-| 99.4% |  5.4 MiB |   1,436 | `<module>` | `black/__init__.py:1`                                    |
-| 43.0% | 2.34 MiB |     316 | `<module>` | `black/comments.py:1`                                    |
-| 24.2% | 1.32 MiB |     295 | `<module>` | `black/nodes.py:1`                                       |
-| 24.1% | 1.31 MiB |     304 | `<module>` | `/venv/lib/python3.11/site-packages/click/__init__.py:1` |
-| 22.7% | 1.23 MiB |     233 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`     |
+|     % |     Size | Allocations | Callee     | Location                                                 |
+| ----: | -------: | ----------: | ---------- | -------------------------------------------------------- |
+| 99.4% |  5.4 MiB |       1,436 | `<module>` | `black/__init__.py:1`                                    |
+| 43.0% | 2.34 MiB |         316 | `<module>` | `black/comments.py:1`                                    |
+| 24.2% | 1.32 MiB |         295 | `<module>` | `black/nodes.py:1`                                       |
+| 24.1% | 1.31 MiB |         304 | `<module>` | `/venv/lib/python3.11/site-packages/click/__init__.py:1` |
+| 22.7% | 1.23 MiB |         233 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`     |
 
 ##### `get_code` (`<frozen importlib._bootstrap_external>:1007`)
 
-|     % |     Size | Samples | Callee                   | Location                                      |
-| ----: | -------: | ------: | ------------------------ | --------------------------------------------- |
-| 84.6% | 2.27 MiB |     352 | `source_to_code`         | `<frozen importlib._bootstrap_external>:999`  |
-| 11.3% |  311 KiB |     341 | `_compile_bytecode`      | `<frozen importlib._bootstrap_external>:727`  |
-|  4.1% |  112 KiB |     108 | `_code_to_timestamp_pyc` | `<frozen importlib._bootstrap_external>:740`  |
-| <0.1% |    624 B |       1 | `_cache_bytecode`        | `<frozen importlib._bootstrap_external>:1151` |
+|     % |     Size | Allocations | Callee                   | Location                                      |
+| ----: | -------: | ----------: | ------------------------ | --------------------------------------------- |
+| 84.6% | 2.27 MiB |         352 | `source_to_code`         | `<frozen importlib._bootstrap_external>:999`  |
+| 11.3% |  311 KiB |         341 | `_compile_bytecode`      | `<frozen importlib._bootstrap_external>:727`  |
+|  4.1% |  112 KiB |         108 | `_code_to_timestamp_pyc` | `<frozen importlib._bootstrap_external>:740`  |
+| <0.1% |    624 B |           1 | `_cache_bytecode`        | `<frozen importlib._bootstrap_external>:1151` |
 
 ##### `source_to_code` (`<frozen importlib._bootstrap_external>:999`)
 
-|      % |     Size | Samples | Callee                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.27 MiB |     352 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Callee                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.27 MiB |         352 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|     % |    Size | Samples | Callee           | Location                             |
-| ----: | ------: | ------: | ---------------- | ------------------------------------ |
-| 99.8% | 1.3 MiB |     303 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |    Size | Allocations | Callee           | Location                             |
+| ----: | ------: | ----------: | ---------------- | ------------------------------------ |
+| 99.8% | 1.3 MiB |         303 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|     % |     Size | Samples | Callee             | Location                                               |
-| ----: | -------: | ------: | ------------------ | ------------------------------------------------------ |
-| 85.5% | 1.05 MiB |      53 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167`                   |
-| 11.1% |  140 KiB |     145 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209`                   |
-|  1.1% | 13.9 KiB |       9 | `__new__`          | `<frozen abc>:105`                                     |
-|  0.2% | 2.49 KiB |       3 | `__new__`          | `/usr/lib/python3.11/enum.py:488`                      |
-|  0.1% |    768 B |       1 | `Context`          | `/venv/lib/python3.11/site-packages/click/core.py:204` |
+|     % |     Size | Allocations | Callee             | Location                                               |
+| ----: | -------: | ----------: | ------------------ | ------------------------------------------------------ |
+| 85.5% | 1.05 MiB |          53 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167`                   |
+| 11.1% |  140 KiB |         145 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209`                   |
+|  1.1% | 13.9 KiB |           9 | `__new__`          | `<frozen abc>:105`                                     |
+|  0.2% | 2.49 KiB |           3 | `__new__`          | `/usr/lib/python3.11/enum.py:488`                      |
+|  0.1% |    768 B |           1 | `Context`          | `/venv/lib/python3.11/site-packages/click/core.py:204` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 99.8% | 1.02 MiB |      22 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 99.8% | 1.02 MiB |          22 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `_handle_fromlist` (`<frozen importlib._bootstrap>:1209`)
 
-|      % |    Size | Samples | Callee                      | Location                            |
-| -----: | ------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 333 KiB |     341 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |    Size | Allocations | Callee                      | Location                            |
+| -----: | ------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 333 KiB |         341 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                                                         |
-| ----: | -------: | ------: | ---------------- | ---------------------------------------------------------------- |
-| 90.2% |  156 KiB |     130 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                             |
-|  4.9% |  8.5 KiB |       2 | `Specifier`      | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220` |
-|  3.5% | 6.07 KiB |       7 | `__new__`        | `<frozen abc>:105`                                               |
+|     % |     Size | Allocations | Callee           | Location                                                         |
+| ----: | -------: | ----------: | ---------------- | ---------------------------------------------------------------- |
+| 90.2% |  156 KiB |         130 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                             |
+|  4.9% |  8.5 KiB |           2 | `Specifier`      | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220` |
+|  3.5% | 6.07 KiB |           7 | `__new__`        | `<frozen abc>:105`                                               |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 53.0% | 66.2 KiB |      58 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
-| 30.6% | 38.2 KiB |      45 | `__new__`        | `<frozen abc>:105`                   |
-| 12.6% | 15.7 KiB |      19 | `__new__`        | `/usr/lib/python3.11/typing.py:2891` |
-|  1.1% | 1.42 KiB |       2 | `inner`          | `/usr/lib/python3.11/typing.py:338`  |
-|  0.4% |    542 B |       1 | `__init__`       | `/usr/lib/python3.11/typing.py:992`  |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 53.0% | 66.2 KiB |          58 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+| 30.6% | 38.2 KiB |          45 | `__new__`        | `<frozen abc>:105`                   |
+| 12.6% | 15.7 KiB |          19 | `__new__`        | `/usr/lib/python3.11/typing.py:2891` |
+|  1.1% | 1.42 KiB |           2 | `inner`          | `/usr/lib/python3.11/typing.py:338`  |
+|  0.4% |    542 B |           1 | `__init__`       | `/usr/lib/python3.11/typing.py:992`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 96.4% | 96.1 KiB |      68 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 96.4% | 96.1 KiB |          68 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 99.2% | 93.1 KiB |     118 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 99.2% | 93.1 KiB |         118 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`)
 
-|     % |   Size | Samples | Callee           | Location                             |
-| ----: | -----: | ------: | ---------------- | ------------------------------------ |
-| 97.3% | 89 KiB |     112 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |   Size | Allocations | Callee           | Location                             |
+| ----: | -----: | ----------: | ---------------- | ------------------------------------ |
+| 97.3% | 89 KiB |         112 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|     % |     Size | Samples | Callee             | Location                             |
-| ----: | -------: | ------: | ------------------ | ------------------------------------ |
-| 22.4% | 16.7 KiB |      17 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167` |
-| 21.2% | 15.8 KiB |      19 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209` |
+|     % |     Size | Allocations | Callee             | Location                             |
+| ----: | -------: | ----------: | ------------------ | ------------------------------------ |
+| 22.4% | 16.7 KiB |          17 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167` |
+| 21.2% | 15.8 KiB |          19 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 98.9% | 64.8 KiB |      83 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 98.9% | 64.8 KiB |          83 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `compile` (`/usr/lib/python3.11/re/__init__.py:225`)
 
-|     % |     Size | Samples | Callee     | Location                                 |
-| ----: | -------: | ------: | ---------- | ---------------------------------------- |
-| 98.6% | 47.1 KiB |      24 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
+|     % |     Size | Allocations | Callee     | Location                                 |
+| ----: | -------: | ----------: | ---------- | ---------------------------------------- |
+| 98.6% | 47.1 KiB |          24 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
 
 ##### `decorator` (`/venv/lib/python3.11/site-packages/click/decorators.py:373`)
 
-|     % |     Size | Samples | Callee     | Location                                                |
-| ----: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 96.2% | 45.5 KiB |      32 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2883` |
+|     % |     Size | Allocations | Callee     | Location                                                |
+| ----: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 96.2% | 45.5 KiB |          32 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2883` |
 
 ##### `_compile` (`/usr/lib/python3.11/re/__init__.py:272`)
 
-|     % |     Size | Samples | Callee    | Location                                  |
-| ----: | -------: | ------: | --------- | ----------------------------------------- |
-| 98.6% | 46.5 KiB |      23 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
-|  1.4% |    698 B |       1 | `__and__` | `/usr/lib/python3.11/enum.py:1504`        |
+|     % |     Size | Allocations | Callee    | Location                                  |
+| ----: | -------: | ----------: | --------- | ----------------------------------------- |
+| 98.6% | 46.5 KiB |          23 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
+|  1.4% |    698 B |           1 | `__and__` | `/usr/lib/python3.11/enum.py:1504`        |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 94.8% | 44.5 KiB |      56 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 94.8% | 44.5 KiB |          56 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|     % |     Size | Samples | Callee  | Location                                  |
-| ----: | -------: | ------: | ------- | ----------------------------------------- |
-| 31.0% | 14.4 KiB |       5 | `parse` | `/usr/lib/python3.11/re/_parser.py:970`   |
-| 20.4% |  9.5 KiB |       6 | `_code` | `/usr/lib/python3.11/re/_compiler.py:571` |
+|     % |     Size | Allocations | Callee  | Location                                  |
+| ----: | -------: | ----------: | ------- | ----------------------------------------- |
+| 31.0% | 14.4 KiB |           5 | `parse` | `/usr/lib/python3.11/re/_parser.py:970`   |
+| 20.4% |  9.5 KiB |           6 | `_code` | `/usr/lib/python3.11/re/_compiler.py:571` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|    % |     Size | Samples | Callee     | Location                                                |
-| ---: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 2.6% | 1.17 KiB |       1 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2237` |
+|    % |     Size | Allocations | Callee     | Location                                                |
+| ---: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 2.6% | 1.17 KiB |           1 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2237` |
 
 ## Hottest call stacks
 
@@ -1423,38 +1423,38 @@ Call stacks ranked by bytes held at peak memory in their leaf frame.
 
 Common call stack: `run_module` (`<frozen runpy>:201`) ← `_run_tracker` (`/venv/lib/python3.11/site-packages/memray/commands/run.py:40`)
 
-|     % |     Size | Samples | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| ----: | -------: | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 22.0% |   16 MiB |   1,014 | `parse` (`/usr/lib/python3.11/ast.py:33`) ← `_parse_single_version` (`black/parsing.py:117`) ← `parse_ast` (129) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-|  6.9% |    5 MiB |       5 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `shift` (`blib2to3/pgen2/parse.py:373`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-|  4.1% |    3 MiB |       8 | `transform_line` (`black/linegen.py:601`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-|  2.8% |    2 MiB |       2 | `push` (`blib2to3/pgen2/parse.py:386`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-|  2.8% |    2 MiB |       2 | `convert` (`blib2to3/pytree.py:486`) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-|  1.5% | 1.07 MiB |      96 | `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `source_to_code` (`<frozen importlib._bootstrap_external>:999`) ← `get_code` (1007) ← `exec_module` (934) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-|  1.4% | 1.04 MiB |      49 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-|  1.4% | 1.01 MiB |       6 | `make_grammar` (`blib2to3/pgen2/pgen.py:49`) ← `generate_grammar` (426) ← `load_grammar` (`blib2to3/pgen2/driver.py:246`) ← `load_packaged_grammar` (280) ← `initialize` (`blib2to3/pygram.py:165`) ← `<module>` (`black/nodes.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-|  1.4% | 1.01 MiB |      15 | `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `source_to_code` (`<frozen importlib._bootstrap_external>:999`) ← `get_code` (1007) ← `exec_module` (934) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-|  1.4% | 1.01 MiB |      11 | `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-|  1.4% |    1 MiB |       4 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-|  1.4% |    1 MiB |       2 | `maybe_empty_lines` (`black/lines.py:560`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-|  1.4% |    1 MiB |       1 | `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-|  1.4% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `preceding_leaf` (`black/nodes.py:441`) ← `whitespace` (194) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-|  1.4% |    1 MiB |       1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit_NUMBER` (505) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                |
-|  1.4% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
-|  1.4% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                         |
-|  1.4% |    1 MiB |       1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_test` (160) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-|  1.4% |    1 MiB |       1 | `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                      |
-|  1.4% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `wrap_in_parentheses` (`black/nodes.py:935`) ← `normalize_invisible_parens` (`black/linegen.py:1328`) ← `visit_stmt` (199) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+|     % |     Size | Allocations | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ----: | -------: | ----------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 22.0% |   16 MiB |       1,014 | `parse` (`/usr/lib/python3.11/ast.py:33`) ← `_parse_single_version` (`black/parsing.py:117`) ← `parse_ast` (129) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+|  6.9% |    5 MiB |           5 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `shift` (`blib2to3/pgen2/parse.py:373`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+|  4.1% |    3 MiB |           8 | `transform_line` (`black/linegen.py:601`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+|  2.8% |    2 MiB |           2 | `push` (`blib2to3/pgen2/parse.py:386`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+|  2.8% |    2 MiB |           2 | `convert` (`blib2to3/pytree.py:486`) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+|  1.5% | 1.07 MiB |          96 | `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `source_to_code` (`<frozen importlib._bootstrap_external>:999`) ← `get_code` (1007) ← `exec_module` (934) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+|  1.4% | 1.04 MiB |          49 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+|  1.4% | 1.01 MiB |           6 | `make_grammar` (`blib2to3/pgen2/pgen.py:49`) ← `generate_grammar` (426) ← `load_grammar` (`blib2to3/pgen2/driver.py:246`) ← `load_packaged_grammar` (280) ← `initialize` (`blib2to3/pygram.py:165`) ← `<module>` (`black/nodes.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+|  1.4% | 1.01 MiB |          15 | `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `source_to_code` (`<frozen importlib._bootstrap_external>:999`) ← `get_code` (1007) ← `exec_module` (934) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+|  1.4% | 1.01 MiB |          11 | `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+|  1.4% |    1 MiB |           4 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+|  1.4% |    1 MiB |           2 | `maybe_empty_lines` (`black/lines.py:560`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+|  1.4% |    1 MiB |           1 | `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+|  1.4% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `preceding_leaf` (`black/nodes.py:441`) ← `whitespace` (194) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+|  1.4% |    1 MiB |           1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit_NUMBER` (505) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                |
+|  1.4% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
+|  1.4% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                         |
+|  1.4% |    1 MiB |           1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_test` (160) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+|  1.4% |    1 MiB |           1 | `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                      |
+|  1.4% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `wrap_in_parentheses` (`black/nodes.py:935`) ← `normalize_invisible_parens` (`black/linegen.py:1328`) ← `visit_stmt` (199) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 
 # Leaked memory profile
 
-Leaked 57.1 MiB over 22,684 samples (2.58 KiB per sample).
+Leaked 57.1 MiB over 22,684 allocations (2.58 KiB per allocation).
 
-| Category         |     % |     Size | Samples |
-| ---------------- | ----: | -------: | ------: |
-| Ours             | 89.1% | 50.9 MiB |  21,386 |
-| Standard library |  8.7% | 4.97 MiB |   1,068 |
-| Third-party      |  2.2% | 1.23 MiB |     230 |
+| Category         |     % |     Size | Allocations |
+| ---------------- | ----: | -------: | ----------: |
+| Ours             | 89.1% | 50.9 MiB |      21,386 |
+| Standard library |  8.7% | 4.97 MiB |       1,068 |
+| Third-party      |  2.2% | 1.23 MiB |         230 |
 
 ## Hottest functions
 
@@ -1462,105 +1462,105 @@ Leaked 57.1 MiB over 22,684 samples (2.58 KiB per sample).
 
 Functions ranked by bytes never freed directly in the function body, excluding callees.
 
-|     % |     Size | Samples | Function                               | Location                                               |
-| ----: | -------: | ------: | -------------------------------------- | ------------------------------------------------------ |
-| 30.2% | 17.2 MiB |  20,789 | `mark`                                 | `black/brackets.py:70`                                 |
-| 10.5% |    6 MiB |       6 | `changed`                              | `blib2to3/pytree.py:171`                               |
-|  8.8% |    5 MiB |       5 | `__new__`                              | `blib2to3/pytree.py:81`                                |
-|  5.4% | 3.07 MiB |       9 | `transform_line`                       | `black/linegen.py:601`                                 |
-|  5.3% |    3 MiB |       4 | `visit_default`                        | `black/linegen.py:134`                                 |
-|  5.3% |    3 MiB |       3 | `generate_comments`                    | `black/comments.py:52`                                 |
-|  4.0% | 2.27 MiB |     352 | `_call_with_frames_removed`            | `<frozen importlib._bootstrap>:233`                    |
-|  3.8% | 2.14 MiB |     197 | `update_sibling_maps`                  | `blib2to3/pytree.py:369`                               |
-|  3.5% | 2.01 MiB |       3 | `parse`                                | `/usr/lib/python3.11/ast.py:33`                        |
-|  3.5% |    2 MiB |       2 | `convert`                              | `blib2to3/pytree.py:486`                               |
-|  3.5% |    2 MiB |       2 | `push`                                 | `blib2to3/pgen2/parse.py:386`                          |
-|  1.8% | 1.01 MiB |       6 | `make_grammar`                         | `blib2to3/pgen2/pgen.py:49`                            |
-|  1.8% | 1.01 MiB |      11 | `<module>`                             | `/venv/lib/python3.11/site-packages/click/parser.py:1` |
-|  1.8% |    1 MiB |       5 | `visit`                                | `black/nodes.py:163`                                   |
-|  1.8% |    1 MiB |       2 | `maybe_empty_lines`                    | `black/lines.py:560`                                   |
-|  1.8% |    1 MiB |       1 | `contains_uncollapsable_type_comments` | `black/lines.py:276`                                   |
-|  1.8% |    1 MiB |       1 | `__init__`                             | `<string>:2`                                           |
-|  1.8% |    1 MiB |       1 | `_addtoken`                            | `blib2to3/pgen2/parse.py:290`                          |
-|  1.8% |    1 MiB |       1 | `__init__`                             | `blib2to3/pytree.py:400`                               |
-|  0.5% |  311 KiB |     341 | `_compile_bytecode`                    | `<frozen importlib._bootstrap_external>:727`           |
+|     % |     Size | Allocations | Function                               | Location                                               |
+| ----: | -------: | ----------: | -------------------------------------- | ------------------------------------------------------ |
+| 30.2% | 17.2 MiB |      20,789 | `mark`                                 | `black/brackets.py:70`                                 |
+| 10.5% |    6 MiB |           6 | `changed`                              | `blib2to3/pytree.py:171`                               |
+|  8.8% |    5 MiB |           5 | `__new__`                              | `blib2to3/pytree.py:81`                                |
+|  5.4% | 3.07 MiB |           9 | `transform_line`                       | `black/linegen.py:601`                                 |
+|  5.3% |    3 MiB |           4 | `visit_default`                        | `black/linegen.py:134`                                 |
+|  5.3% |    3 MiB |           3 | `generate_comments`                    | `black/comments.py:52`                                 |
+|  4.0% | 2.27 MiB |         352 | `_call_with_frames_removed`            | `<frozen importlib._bootstrap>:233`                    |
+|  3.8% | 2.14 MiB |         197 | `update_sibling_maps`                  | `blib2to3/pytree.py:369`                               |
+|  3.5% | 2.01 MiB |           3 | `parse`                                | `/usr/lib/python3.11/ast.py:33`                        |
+|  3.5% |    2 MiB |           2 | `convert`                              | `blib2to3/pytree.py:486`                               |
+|  3.5% |    2 MiB |           2 | `push`                                 | `blib2to3/pgen2/parse.py:386`                          |
+|  1.8% | 1.01 MiB |           6 | `make_grammar`                         | `blib2to3/pgen2/pgen.py:49`                            |
+|  1.8% | 1.01 MiB |          11 | `<module>`                             | `/venv/lib/python3.11/site-packages/click/parser.py:1` |
+|  1.8% |    1 MiB |           5 | `visit`                                | `black/nodes.py:163`                                   |
+|  1.8% |    1 MiB |           2 | `maybe_empty_lines`                    | `black/lines.py:560`                                   |
+|  1.8% |    1 MiB |           1 | `contains_uncollapsable_type_comments` | `black/lines.py:276`                                   |
+|  1.8% |    1 MiB |           1 | `__init__`                             | `<string>:2`                                           |
+|  1.8% |    1 MiB |           1 | `_addtoken`                            | `blib2to3/pgen2/parse.py:290`                          |
+|  1.8% |    1 MiB |           1 | `__init__`                             | `blib2to3/pytree.py:400`                               |
+|  0.5% |  311 KiB |         341 | `_compile_bytecode`                    | `<frozen importlib._bootstrap_external>:727`           |
 
 #### Categories
 
 ##### Ours
 
-|     % |     Size | Samples | Function                               | Location                        |
-| ----: | -------: | ------: | -------------------------------------- | ------------------------------- |
-| 30.2% | 17.2 MiB |  20,789 | `mark`                                 | `black/brackets.py:70`          |
-| 10.5% |    6 MiB |       6 | `changed`                              | `blib2to3/pytree.py:171`        |
-|  8.8% |    5 MiB |       5 | `__new__`                              | `blib2to3/pytree.py:81`         |
-|  5.4% | 3.07 MiB |       9 | `transform_line`                       | `black/linegen.py:601`          |
-|  5.3% |    3 MiB |       4 | `visit_default`                        | `black/linegen.py:134`          |
-|  5.3% |    3 MiB |       3 | `generate_comments`                    | `black/comments.py:52`          |
-|  3.8% | 2.14 MiB |     197 | `update_sibling_maps`                  | `blib2to3/pytree.py:369`        |
-|  3.5% |    2 MiB |       2 | `convert`                              | `blib2to3/pytree.py:486`        |
-|  3.5% |    2 MiB |       2 | `push`                                 | `blib2to3/pgen2/parse.py:386`   |
-|  1.8% | 1.01 MiB |       6 | `make_grammar`                         | `blib2to3/pgen2/pgen.py:49`     |
-|  1.8% |    1 MiB |       5 | `visit`                                | `black/nodes.py:163`            |
-|  1.8% |    1 MiB |       2 | `maybe_empty_lines`                    | `black/lines.py:560`            |
-|  1.8% |    1 MiB |       1 | `contains_uncollapsable_type_comments` | `black/lines.py:276`            |
-|  1.8% |    1 MiB |       1 | `__init__`                             | `<string>:2`                    |
-|  1.8% |    1 MiB |       1 | `_addtoken`                            | `blib2to3/pgen2/parse.py:290`   |
-|  1.8% |    1 MiB |       1 | `__init__`                             | `blib2to3/pytree.py:400`        |
-|  0.1% | 57.2 KiB |      65 | `normalize_string_prefix`              | `black/strings.py:143`          |
-|  0.1% | 41.5 KiB |      16 | `copy`                                 | `blib2to3/pgen2/grammar.py:131` |
-|  0.1% |   32 KiB |       1 | `classify`                             | `blib2to3/pgen2/parse.py:336`   |
-| <0.1% | 25.3 KiB |      40 | `make_first`                           | `blib2to3/pgen2/pgen.py:74`     |
+|     % |     Size | Allocations | Function                               | Location                        |
+| ----: | -------: | ----------: | -------------------------------------- | ------------------------------- |
+| 30.2% | 17.2 MiB |      20,789 | `mark`                                 | `black/brackets.py:70`          |
+| 10.5% |    6 MiB |           6 | `changed`                              | `blib2to3/pytree.py:171`        |
+|  8.8% |    5 MiB |           5 | `__new__`                              | `blib2to3/pytree.py:81`         |
+|  5.4% | 3.07 MiB |           9 | `transform_line`                       | `black/linegen.py:601`          |
+|  5.3% |    3 MiB |           4 | `visit_default`                        | `black/linegen.py:134`          |
+|  5.3% |    3 MiB |           3 | `generate_comments`                    | `black/comments.py:52`          |
+|  3.8% | 2.14 MiB |         197 | `update_sibling_maps`                  | `blib2to3/pytree.py:369`        |
+|  3.5% |    2 MiB |           2 | `convert`                              | `blib2to3/pytree.py:486`        |
+|  3.5% |    2 MiB |           2 | `push`                                 | `blib2to3/pgen2/parse.py:386`   |
+|  1.8% | 1.01 MiB |           6 | `make_grammar`                         | `blib2to3/pgen2/pgen.py:49`     |
+|  1.8% |    1 MiB |           5 | `visit`                                | `black/nodes.py:163`            |
+|  1.8% |    1 MiB |           2 | `maybe_empty_lines`                    | `black/lines.py:560`            |
+|  1.8% |    1 MiB |           1 | `contains_uncollapsable_type_comments` | `black/lines.py:276`            |
+|  1.8% |    1 MiB |           1 | `__init__`                             | `<string>:2`                    |
+|  1.8% |    1 MiB |           1 | `_addtoken`                            | `blib2to3/pgen2/parse.py:290`   |
+|  1.8% |    1 MiB |           1 | `__init__`                             | `blib2to3/pytree.py:400`        |
+|  0.1% | 57.2 KiB |          65 | `normalize_string_prefix`              | `black/strings.py:143`          |
+|  0.1% | 41.5 KiB |          16 | `copy`                                 | `blib2to3/pgen2/grammar.py:131` |
+|  0.1% |   32 KiB |           1 | `classify`                             | `blib2to3/pgen2/parse.py:336`   |
+| <0.1% | 25.3 KiB |          40 | `make_first`                           | `blib2to3/pgen2/pgen.py:74`     |
 
 ##### Standard library
 
-|     % |     Size | Samples | Function                    | Location                                          |
-| ----: | -------: | ------: | --------------------------- | ------------------------------------------------- |
-|  4.0% | 2.27 MiB |     352 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`               |
-|  3.5% | 2.01 MiB |       3 | `parse`                     | `/usr/lib/python3.11/ast.py:33`                   |
-|  0.5% |  311 KiB |     341 | `_compile_bytecode`         | `<frozen importlib._bootstrap_external>:727`      |
-|  0.2% |  112 KiB |     108 | `_code_to_timestamp_pyc`    | `<frozen importlib._bootstrap_external>:740`      |
-|  0.1% | 75.7 KiB |      79 | `__new__`                   | `<frozen abc>:105`                                |
-| <0.1% | 24.1 KiB |      27 | `__new__`                   | `/usr/lib/python3.11/enum.py:488`                 |
-| <0.1% | 22.6 KiB |      12 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`         |
-| <0.1% | 19.8 KiB |      12 | `<module>`                  | `/usr/lib/python3.11/tomllib/_parser.py:1`        |
-| <0.1% | 17.4 KiB |      21 | `__new__`                   | `/usr/lib/python3.11/typing.py:2891`              |
-| <0.1% |   12 KiB |       3 | `inner`                     | `/usr/lib/python3.11/typing.py:338`               |
-| <0.1% |    8 KiB |       4 | `_fill_cache`               | `<frozen importlib._bootstrap_external>:1655`     |
-| <0.1% | 7.97 KiB |       1 | `_parse_sub`                | `/usr/lib/python3.11/re/_parser.py:447`           |
-| <0.1% | 6.73 KiB |       8 | `__setattr__`               | `/usr/lib/python3.11/enum.py:831`                 |
-| <0.1% | 5.63 KiB |       6 | `namedtuple`                | `/usr/lib/python3.11/collections/__init__.py:348` |
-| <0.1% | 5.61 KiB |       3 | `_parse`                    | `/usr/lib/python3.11/re/_parser.py:507`           |
-| <0.1% | 5.32 KiB |       2 | `_code`                     | `/usr/lib/python3.11/re/_compiler.py:571`         |
-| <0.1% | 4.73 KiB |       6 | `<module>`                  | `/usr/lib/python3.11/pkgutil.py:1`                |
-| <0.1% | 2.85 KiB |       1 | `wrap`                      | `/usr/lib/python3.11/dataclasses.py:1209`         |
-| <0.1% | 2.85 KiB |       4 | `_process_class`            | `/usr/lib/python3.11/dataclasses.py:884`          |
-| <0.1% | 2.56 KiB |       3 | `_signature_from_function`  | `/usr/lib/python3.11/inspect.py:2331`             |
+|     % |     Size | Allocations | Function                    | Location                                          |
+| ----: | -------: | ----------: | --------------------------- | ------------------------------------------------- |
+|  4.0% | 2.27 MiB |         352 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`               |
+|  3.5% | 2.01 MiB |           3 | `parse`                     | `/usr/lib/python3.11/ast.py:33`                   |
+|  0.5% |  311 KiB |         341 | `_compile_bytecode`         | `<frozen importlib._bootstrap_external>:727`      |
+|  0.2% |  112 KiB |         108 | `_code_to_timestamp_pyc`    | `<frozen importlib._bootstrap_external>:740`      |
+|  0.1% | 75.7 KiB |          79 | `__new__`                   | `<frozen abc>:105`                                |
+| <0.1% | 24.1 KiB |          27 | `__new__`                   | `/usr/lib/python3.11/enum.py:488`                 |
+| <0.1% | 22.6 KiB |          12 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`         |
+| <0.1% | 19.8 KiB |          12 | `<module>`                  | `/usr/lib/python3.11/tomllib/_parser.py:1`        |
+| <0.1% | 17.4 KiB |          21 | `__new__`                   | `/usr/lib/python3.11/typing.py:2891`              |
+| <0.1% |   12 KiB |           3 | `inner`                     | `/usr/lib/python3.11/typing.py:338`               |
+| <0.1% |    8 KiB |           4 | `_fill_cache`               | `<frozen importlib._bootstrap_external>:1655`     |
+| <0.1% | 7.97 KiB |           1 | `_parse_sub`                | `/usr/lib/python3.11/re/_parser.py:447`           |
+| <0.1% | 6.73 KiB |           8 | `__setattr__`               | `/usr/lib/python3.11/enum.py:831`                 |
+| <0.1% | 5.63 KiB |           6 | `namedtuple`                | `/usr/lib/python3.11/collections/__init__.py:348` |
+| <0.1% | 5.61 KiB |           3 | `_parse`                    | `/usr/lib/python3.11/re/_parser.py:507`           |
+| <0.1% | 5.32 KiB |           2 | `_code`                     | `/usr/lib/python3.11/re/_compiler.py:571`         |
+| <0.1% | 4.73 KiB |           6 | `<module>`                  | `/usr/lib/python3.11/pkgutil.py:1`                |
+| <0.1% | 2.85 KiB |           1 | `wrap`                      | `/usr/lib/python3.11/dataclasses.py:1209`         |
+| <0.1% | 2.85 KiB |           4 | `_process_class`            | `/usr/lib/python3.11/dataclasses.py:884`          |
+| <0.1% | 2.56 KiB |           3 | `_signature_from_function`  | `/usr/lib/python3.11/inspect.py:2331`             |
 
 ##### Third-party
 
-|     % |     Size | Samples | Function              | Location                                                                   |
-| ----: | -------: | ------: | --------------------- | -------------------------------------------------------------------------- |
-|  1.8% | 1.01 MiB |      11 | `<module>`            | `/venv/lib/python3.11/site-packages/click/parser.py:1`                     |
-|  0.1% | 44.3 KiB |      31 | `__init__`            | `/venv/lib/python3.11/site-packages/click/core.py:2883`                    |
-| <0.1% |   25 KiB |      22 | `<module>`            | `/venv/lib/python3.11/site-packages/click/core.py:1`                       |
-| <0.1% |   15 KiB |      18 | `<module>`            | `/venv/lib/python3.11/site-packages/mypy_extensions.py:1`                  |
-| <0.1% | 13.4 KiB |      15 | `<module>`            | `/venv/lib/python3.11/site-packages/click/exceptions.py:1`                 |
-| <0.1% | 9.61 KiB |       9 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/version.py:1`                |
-| <0.1% | 7.08 KiB |       8 | `<module>`            | `/venv/lib/python3.11/site-packages/click/utils.py:1`                      |
-| <0.1% | 6.48 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/util.py:1`                    |
-| <0.1% | 6.24 KiB |       5 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                |
-| <0.1% | 5.97 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                   |
-| <0.1% |  5.8 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/click/_compat.py:1`                    |
-| <0.1% | 3.82 KiB |       1 | `Specifier`           | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`           |
-| <0.1% | 3.72 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`                 |
-| <0.1% | 3.56 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                  |
-| <0.1% | 3.37 KiB |       5 | `handle_parse_result` | `/venv/lib/python3.11/site-packages/click/core.py:2663`                    |
-| <0.1% | 3.19 KiB |       1 | `<module>`            | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                   |
-| <0.1% | 3.19 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`                |
-| <0.1% | 3.04 KiB |       2 | `new_func`            | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                |
-| <0.1% | 2.81 KiB |       3 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1` |
-| <0.1% | 2.76 KiB |       2 | `<module>`            | `/venv/lib/python3.11/site-packages/click/types.py:1`                      |
+|     % |     Size | Allocations | Function              | Location                                                                   |
+| ----: | -------: | ----------: | --------------------- | -------------------------------------------------------------------------- |
+|  1.8% | 1.01 MiB |          11 | `<module>`            | `/venv/lib/python3.11/site-packages/click/parser.py:1`                     |
+|  0.1% | 44.3 KiB |          31 | `__init__`            | `/venv/lib/python3.11/site-packages/click/core.py:2883`                    |
+| <0.1% |   25 KiB |          22 | `<module>`            | `/venv/lib/python3.11/site-packages/click/core.py:1`                       |
+| <0.1% |   15 KiB |          18 | `<module>`            | `/venv/lib/python3.11/site-packages/mypy_extensions.py:1`                  |
+| <0.1% | 13.4 KiB |          15 | `<module>`            | `/venv/lib/python3.11/site-packages/click/exceptions.py:1`                 |
+| <0.1% | 9.61 KiB |           9 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/version.py:1`                |
+| <0.1% | 7.08 KiB |           8 | `<module>`            | `/venv/lib/python3.11/site-packages/click/utils.py:1`                      |
+| <0.1% | 6.48 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/util.py:1`                    |
+| <0.1% | 6.24 KiB |           5 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                |
+| <0.1% | 5.97 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                   |
+| <0.1% |  5.8 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/click/_compat.py:1`                    |
+| <0.1% | 3.82 KiB |           1 | `Specifier`           | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`           |
+| <0.1% | 3.72 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`                 |
+| <0.1% | 3.56 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                  |
+| <0.1% | 3.37 KiB |           5 | `handle_parse_result` | `/venv/lib/python3.11/site-packages/click/core.py:2663`                    |
+| <0.1% | 3.19 KiB |           1 | `<module>`            | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                   |
+| <0.1% | 3.19 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`                |
+| <0.1% | 3.04 KiB |           2 | `new_func`            | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                |
+| <0.1% | 2.81 KiB |           3 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1` |
+| <0.1% | 2.76 KiB |           2 | `<module>`            | `/venv/lib/python3.11/site-packages/click/types.py:1`                      |
 
 #### Lines
 
@@ -1568,447 +1568,447 @@ Lines ranked by contribution to each function's self size.
 
 ##### `mark` (`black/brackets.py:70`)
 
-|      % |     Size | Samples | Location                |
-| -----: | -------: | ------: | ----------------------- |
-| 100.0% | 17.2 MiB |  20,788 | `black/brackets.py:112` |
-|  <0.1% | 1.49 KiB |       1 | `black/brackets.py:114` |
+|      % |     Size | Allocations | Location                |
+| -----: | -------: | ----------: | ----------------------- |
+| 100.0% | 17.2 MiB |      20,788 | `black/brackets.py:112` |
+|  <0.1% | 1.49 KiB |           1 | `black/brackets.py:114` |
 
 ##### `changed` (`blib2to3/pytree.py:171`)
 
-|     % |  Size | Samples | Location                 |
-| ----: | ----: | ------: | ------------------------ |
-| 66.7% | 4 MiB |       4 | `blib2to3/pytree.py:175` |
-| 33.3% | 2 MiB |       2 | `blib2to3/pytree.py:176` |
+|     % |  Size | Allocations | Location                 |
+| ----: | ----: | ----------: | ------------------------ |
+| 66.7% | 4 MiB |           4 | `blib2to3/pytree.py:175` |
+| 33.3% | 2 MiB |           2 | `blib2to3/pytree.py:176` |
 
 ##### `__new__` (`blib2to3/pytree.py:81`)
 
-|      % |  Size | Samples | Location                |
-| -----: | ----: | ------: | ----------------------- |
-| 100.0% | 5 MiB |       5 | `blib2to3/pytree.py:84` |
+|      % |  Size | Allocations | Location                |
+| -----: | ----: | ----------: | ----------------------- |
+| 100.0% | 5 MiB |           5 | `blib2to3/pytree.py:84` |
 
 ##### `transform_line` (`black/linegen.py:601`)
 
-|     % |     Size | Samples | Location               |
-| ----: | -------: | ------: | ---------------------- |
-| 34.9% | 1.07 MiB |       4 | `black/linegen.py:679` |
-| 32.6% |    1 MiB |       2 | `black/linegen.py:714` |
-| 32.5% |    1 MiB |       1 | `black/linegen.py:626` |
-| <0.1% | 1.39 KiB |       1 | `black/linegen.py:635` |
-| <0.1% |    518 B |       1 | `black/linegen.py:631` |
+|     % |     Size | Allocations | Location               |
+| ----: | -------: | ----------: | ---------------------- |
+| 34.9% | 1.07 MiB |           4 | `black/linegen.py:679` |
+| 32.6% |    1 MiB |           2 | `black/linegen.py:714` |
+| 32.5% |    1 MiB |           1 | `black/linegen.py:626` |
+| <0.1% | 1.39 KiB |           1 | `black/linegen.py:635` |
+| <0.1% |    518 B |           1 | `black/linegen.py:631` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|      % |  Size | Samples | Location               |
-| -----: | ----: | ------: | ---------------------- |
-| 100.0% | 3 MiB |       3 | `black/linegen.py:158` |
-|  <0.1% | 702 B |       1 | `black/linegen.py:144` |
+|      % |  Size | Allocations | Location               |
+| -----: | ----: | ----------: | ---------------------- |
+| 100.0% | 3 MiB |           3 | `black/linegen.py:158` |
+|  <0.1% | 702 B |           1 | `black/linegen.py:144` |
 
 ##### `generate_comments` (`black/comments.py:52`)
 
-|     % |  Size | Samples | Location               |
-| ----: | ----: | ------: | ---------------------- |
-| 66.7% | 2 MiB |       2 | `black/comments.py:76` |
-| 33.3% | 1 MiB |       1 | `black/comments.py:72` |
+|     % |  Size | Allocations | Location               |
+| ----: | ----: | ----------: | ---------------------- |
+| 66.7% | 2 MiB |           2 | `black/comments.py:76` |
+| 33.3% | 1 MiB |           1 | `black/comments.py:72` |
 
 ##### `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`)
 
-|      % |     Size | Samples | Location                            |
-| -----: | -------: | ------: | ----------------------------------- |
-| 100.0% | 2.27 MiB |     352 | `<frozen importlib._bootstrap>:241` |
+|      % |     Size | Allocations | Location                            |
+| -----: | -------: | ----------: | ----------------------------------- |
+| 100.0% | 2.27 MiB |         352 | `<frozen importlib._bootstrap>:241` |
 
 ##### `update_sibling_maps` (`blib2to3/pytree.py:369`)
 
-|     % |     Size | Samples | Location                 |
-| ----: | -------: | ------: | ------------------------ |
-| 96.6% | 2.07 MiB |      95 | `blib2to3/pytree.py:377` |
-|  3.2% | 70.3 KiB |      93 | `blib2to3/pytree.py:376` |
-|  0.2% | 4.99 KiB |       9 | `blib2to3/pytree.py:379` |
+|     % |     Size | Allocations | Location                 |
+| ----: | -------: | ----------: | ------------------------ |
+| 96.6% | 2.07 MiB |          95 | `blib2to3/pytree.py:377` |
+|  3.2% | 70.3 KiB |          93 | `blib2to3/pytree.py:376` |
+|  0.2% | 4.99 KiB |           9 | `blib2to3/pytree.py:379` |
 
 ##### `parse` (`/usr/lib/python3.11/ast.py:33`)
 
-|      % |     Size | Samples | Location                        |
-| -----: | -------: | ------: | ------------------------------- |
-| 100.0% | 2.01 MiB |       3 | `/usr/lib/python3.11/ast.py:50` |
+|      % |     Size | Allocations | Location                        |
+| -----: | -------: | ----------: | ------------------------------- |
+| 100.0% | 2.01 MiB |           3 | `/usr/lib/python3.11/ast.py:50` |
 
 ##### `convert` (`blib2to3/pytree.py:486`)
 
-|      % |  Size | Samples | Location                 |
-| -----: | ----: | ------: | ------------------------ |
-| 100.0% | 2 MiB |       2 | `blib2to3/pytree.py:501` |
+|      % |  Size | Allocations | Location                 |
+| -----: | ----: | ----------: | ------------------------ |
+| 100.0% | 2 MiB |           2 | `blib2to3/pytree.py:501` |
 
 ##### `push` (`blib2to3/pgen2/parse.py:386`)
 
-|      % |  Size | Samples | Location                      |
-| -----: | ----: | ------: | ----------------------------- |
-| 100.0% | 2 MiB |       2 | `blib2to3/pgen2/parse.py:394` |
+|      % |  Size | Allocations | Location                      |
+| -----: | ----: | ----------: | ----------------------------- |
+| 100.0% | 2 MiB |           2 | `blib2to3/pgen2/parse.py:394` |
 
 ##### `make_grammar` (`blib2to3/pgen2/pgen.py:49`)
 
-|     % |     Size | Samples | Location                    |
-| ----: | -------: | ------: | --------------------------- |
-| 98.6% |    1 MiB |       1 | `blib2to3/pgen2/pgen.py:56` |
-|  0.4% | 4.52 KiB |       1 | `blib2to3/pgen2/pgen.py:70` |
-|  0.4% | 4.52 KiB |       1 | `blib2to3/pgen2/pgen.py:58` |
-|  0.3% | 3.19 KiB |       1 | `blib2to3/pgen2/pgen.py:57` |
-|  0.1% |    1 KiB |       1 | `blib2to3/pgen2/pgen.py:69` |
+|     % |     Size | Allocations | Location                    |
+| ----: | -------: | ----------: | --------------------------- |
+| 98.6% |    1 MiB |           1 | `blib2to3/pgen2/pgen.py:56` |
+|  0.4% | 4.52 KiB |           1 | `blib2to3/pgen2/pgen.py:70` |
+|  0.4% | 4.52 KiB |           1 | `blib2to3/pgen2/pgen.py:58` |
+|  0.3% | 3.19 KiB |           1 | `blib2to3/pgen2/pgen.py:57` |
+|  0.1% |    1 KiB |           1 | `blib2to3/pgen2/pgen.py:69` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`)
 
-|     % |     Size | Samples | Location                                                 |
-| ----: | -------: | ------: | -------------------------------------------------------- |
-| 99.2% |    1 MiB |       1 | `/venv/lib/python3.11/site-packages/click/parser.py:25`  |
-|  0.2% | 2.29 KiB |       3 | `/venv/lib/python3.11/site-packages/click/parser.py:224` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:185` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:127` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:216` |
+|     % |     Size | Allocations | Location                                                 |
+| ----: | -------: | ----------: | -------------------------------------------------------- |
+| 99.2% |    1 MiB |           1 | `/venv/lib/python3.11/site-packages/click/parser.py:25`  |
+|  0.2% | 2.29 KiB |           3 | `/venv/lib/python3.11/site-packages/click/parser.py:224` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:185` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:127` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:216` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|     % |     Size | Samples | Location             |
-| ----: | -------: | ------: | -------------------- |
-| 99.7% |    1 MiB |       2 | `black/nodes.py:185` |
-|  0.3% | 2.68 KiB |       3 | `black/nodes.py:183` |
+|     % |     Size | Allocations | Location             |
+| ----: | -------: | ----------: | -------------------- |
+| 99.7% |    1 MiB |           2 | `black/nodes.py:185` |
+|  0.3% | 2.68 KiB |           3 | `black/nodes.py:183` |
 
 ##### `maybe_empty_lines` (`black/lines.py:560`)
 
-|     % |     Size | Samples | Location             |
-| ----: | -------: | ------: | -------------------- |
-| 99.9% |    1 MiB |       1 | `black/lines.py:584` |
-|  0.1% | 1.11 KiB |       1 | `black/lines.py:571` |
+|     % |     Size | Allocations | Location             |
+| ----: | -------: | ----------: | -------------------- |
+| 99.9% |    1 MiB |           1 | `black/lines.py:584` |
+|  0.1% | 1.11 KiB |           1 | `black/lines.py:571` |
 
 ##### `contains_uncollapsable_type_comments` (`black/lines.py:276`)
 
-|      % |  Size | Samples | Location             |
-| -----: | ----: | ------: | -------------------- |
-| 100.0% | 1 MiB |       1 | `black/lines.py:280` |
+|      % |  Size | Allocations | Location             |
+| -----: | ----: | ----------: | -------------------- |
+| 100.0% | 1 MiB |           1 | `black/lines.py:280` |
 
 ##### `__init__` (`<string>:2`)
 
-|      % |  Size | Samples | Location     |
-| -----: | ----: | ------: | ------------ |
-| 100.0% | 1 MiB |       1 | `<string>:7` |
+|      % |  Size | Allocations | Location     |
+| -----: | ----: | ----------: | ------------ |
+| 100.0% | 1 MiB |           1 | `<string>:7` |
 
 ##### `_addtoken` (`blib2to3/pgen2/parse.py:290`)
 
-|      % |  Size | Samples | Location                      |
-| -----: | ----: | ------: | ----------------------------- |
-| 100.0% | 1 MiB |       1 | `blib2to3/pgen2/parse.py:315` |
+|      % |  Size | Allocations | Location                      |
+| -----: | ----: | ----------: | ----------------------------- |
+| 100.0% | 1 MiB |           1 | `blib2to3/pgen2/parse.py:315` |
 
 ##### `__init__` (`blib2to3/pytree.py:400`)
 
-|      % |  Size | Samples | Location                 |
-| -----: | ----: | ------: | ------------------------ |
-| 100.0% | 1 MiB |       1 | `blib2to3/pytree.py:425` |
+|      % |  Size | Allocations | Location                 |
+| -----: | ----: | ----------: | ------------------------ |
+| 100.0% | 1 MiB |           1 | `blib2to3/pytree.py:425` |
 
 ##### `_compile_bytecode` (`<frozen importlib._bootstrap_external>:727`)
 
-|      % |    Size | Samples | Location                                     |
-| -----: | ------: | ------: | -------------------------------------------- |
-| 100.0% | 311 KiB |     341 | `<frozen importlib._bootstrap_external>:729` |
+|      % |    Size | Allocations | Location                                     |
+| -----: | ------: | ----------: | -------------------------------------------- |
+| 100.0% | 311 KiB |         341 | `<frozen importlib._bootstrap_external>:729` |
 
 ##### `_code_to_timestamp_pyc` (`<frozen importlib._bootstrap_external>:740`)
 
-|      % |    Size | Samples | Location                                     |
-| -----: | ------: | ------: | -------------------------------------------- |
-| 100.0% | 112 KiB |     108 | `<frozen importlib._bootstrap_external>:746` |
+|      % |    Size | Allocations | Location                                     |
+| -----: | ------: | ----------: | -------------------------------------------- |
+| 100.0% | 112 KiB |         108 | `<frozen importlib._bootstrap_external>:746` |
 
 ##### `__new__` (`<frozen abc>:105`)
 
-|      % |     Size | Samples | Location           |
-| -----: | -------: | ------: | ------------------ |
-| 100.0% | 75.7 KiB |      79 | `<frozen abc>:106` |
+|      % |     Size | Allocations | Location           |
+| -----: | -------: | ----------: | ------------------ |
+| 100.0% | 75.7 KiB |          79 | `<frozen abc>:106` |
 
 ##### `normalize_string_prefix` (`black/strings.py:143`)
 
-|      % |     Size | Samples | Location               |
-| -----: | -------: | ------: | ---------------------- |
-| 100.0% | 57.2 KiB |      65 | `black/strings.py:158` |
+|      % |     Size | Allocations | Location               |
+| -----: | -------: | ----------: | ---------------------- |
+| 100.0% | 57.2 KiB |          65 | `black/strings.py:158` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|     % |   Size | Samples | Location                                                |
-| ----: | -----: | ------: | ------------------------------------------------------- |
-| 97.1% | 43 KiB |      29 | `/venv/lib/python3.11/site-packages/click/core.py:3023` |
-|  1.6% |  704 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2905` |
-|  1.4% |  614 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2907` |
+|     % |   Size | Allocations | Location                                                |
+| ----: | -----: | ----------: | ------------------------------------------------------- |
+| 97.1% | 43 KiB |          29 | `/venv/lib/python3.11/site-packages/click/core.py:3023` |
+|  1.6% |  704 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2905` |
+|  1.4% |  614 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2907` |
 
 ##### `copy` (`blib2to3/pgen2/grammar.py:131`)
 
-|     % |     Size | Samples | Location                        |
-| ----: | -------: | ------: | ------------------------------- |
-| 88.2% | 36.6 KiB |      12 | `blib2to3/pgen2/grammar.py:145` |
-|  7.6% | 3.16 KiB |       2 | `blib2to3/pgen2/grammar.py:146` |
-|  4.2% | 1.75 KiB |       2 | `blib2to3/pgen2/grammar.py:147` |
+|     % |     Size | Allocations | Location                        |
+| ----: | -------: | ----------: | ------------------------------- |
+| 88.2% | 36.6 KiB |          12 | `blib2to3/pgen2/grammar.py:145` |
+|  7.6% | 3.16 KiB |           2 | `blib2to3/pgen2/grammar.py:146` |
+|  4.2% | 1.75 KiB |           2 | `blib2to3/pgen2/grammar.py:147` |
 
 ##### `classify` (`blib2to3/pgen2/parse.py:336`)
 
-|      % |   Size | Samples | Location                      |
-| -----: | -----: | ------: | ----------------------------- |
-| 100.0% | 32 KiB |       1 | `blib2to3/pgen2/parse.py:343` |
+|      % |   Size | Allocations | Location                      |
+| -----: | -----: | ----------: | ----------------------------- |
+| 100.0% | 32 KiB |           1 | `blib2to3/pgen2/parse.py:343` |
 
 ##### `make_first` (`blib2to3/pgen2/pgen.py:74`)
 
-|      % |     Size | Samples | Location                    |
-| -----: | -------: | ------: | --------------------------- |
-| 100.0% | 25.3 KiB |      40 | `blib2to3/pgen2/pgen.py:81` |
+|      % |     Size | Allocations | Location                    |
+| -----: | -------: | ----------: | --------------------------- |
+| 100.0% | 25.3 KiB |          40 | `blib2to3/pgen2/pgen.py:81` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 30.4% |  7.6 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:204`  |
-| 19.2% | 4.79 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:956`  |
-| 15.7% | 3.92 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:1587` |
-|  9.5% | 2.37 KiB |       3 | `/venv/lib/python3.11/site-packages/click/core.py:2057` |
-|  6.8% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/core.py:2050` |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 30.4% |  7.6 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:204`  |
+| 19.2% | 4.79 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:956`  |
+| 15.7% | 3.92 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:1587` |
+|  9.5% | 2.37 KiB |           3 | `/venv/lib/python3.11/site-packages/click/core.py:2057` |
+|  6.8% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/core.py:2050` |
 
 ##### `__new__` (`/usr/lib/python3.11/enum.py:488`)
 
-|      % |     Size | Samples | Location                          |
-| -----: | -------: | ------: | --------------------------------- |
-| 100.0% | 24.1 KiB |      27 | `/usr/lib/python3.11/enum.py:554` |
+|      % |     Size | Allocations | Location                          |
+| -----: | -------: | ----------: | --------------------------------- |
+| 100.0% | 24.1 KiB |          27 | `/usr/lib/python3.11/enum.py:554` |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|      % |     Size | Samples | Location                                  |
-| -----: | -------: | ------: | ----------------------------------------- |
-| 100.0% | 22.6 KiB |      12 | `/usr/lib/python3.11/re/_compiler.py:759` |
+|      % |     Size | Allocations | Location                                  |
+| -----: | -------: | ----------: | ----------------------------------------- |
+| 100.0% | 22.6 KiB |          12 | `/usr/lib/python3.11/re/_compiler.py:759` |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/_parser.py:1`)
 
-|     % |  Size | Samples | Location                                    |
-| ----: | ----: | ------: | ------------------------------------------- |
-| 20.2% | 4 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:37` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:26` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:22` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:38` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:27` |
+|     % |  Size | Allocations | Location                                    |
+| ----: | ----: | ----------: | ------------------------------------------- |
+| 20.2% | 4 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:37` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:26` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:22` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:38` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:27` |
 
 ##### `__new__` (`/usr/lib/python3.11/typing.py:2891`)
 
-|      % |     Size | Samples | Location                             |
-| -----: | -------: | ------: | ------------------------------------ |
-| 100.0% | 17.4 KiB |      21 | `/usr/lib/python3.11/typing.py:2909` |
+|      % |     Size | Allocations | Location                             |
+| -----: | -------: | ----------: | ------------------------------------ |
+| 100.0% | 17.4 KiB |          21 | `/usr/lib/python3.11/typing.py:2909` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/mypy_extensions.py:1`)
 
-|     % |     Size | Samples | Location                                                    |
-| ----: | -------: | ------: | ----------------------------------------------------------- |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:198` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:167` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:212` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:191` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:154` |
+|     % |     Size | Allocations | Location                                                    |
+| ----: | -------: | ----------: | ----------------------------------------------------------- |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:198` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:167` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:212` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:191` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:154` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/exceptions.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 18.4% | 2.45 KiB |       3 | `/venv/lib/python3.11/site-packages/click/exceptions.py:114` |
-| 11.5% | 1.53 KiB |       2 | `/venv/lib/python3.11/site-packages/click/exceptions.py:366` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:304` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:268` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:232` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 18.4% | 2.45 KiB |           3 | `/venv/lib/python3.11/site-packages/click/exceptions.py:114` |
+| 11.5% | 1.53 KiB |           2 | `/venv/lib/python3.11/site-packages/click/exceptions.py:366` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:304` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:268` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:232` |
 
 ##### `inner` (`/usr/lib/python3.11/typing.py:338`)
 
-|      % |   Size | Samples | Location                            |
-| -----: | -----: | ------: | ----------------------------------- |
-| 100.0% | 12 KiB |       3 | `/usr/lib/python3.11/typing.py:341` |
+|      % |   Size | Allocations | Location                            |
+| -----: | -----: | ----------: | ----------------------------------- |
+| 100.0% | 12 KiB |           3 | `/usr/lib/python3.11/typing.py:341` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/version.py:1`)
 
-|     % |     Size | Samples | Location                                                      |
-| ----: | -------: | ------: | ------------------------------------------------------------- |
-| 38.2% | 3.68 KiB |       3 | `/venv/lib/python3.11/site-packages/packaging/version.py:340` |
-| 15.5% | 1.49 KiB |       2 | `/venv/lib/python3.11/site-packages/packaging/version.py:124` |
-| 15.4% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:285` |
-| 11.3% | 1.09 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:228` |
-|  9.8% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:134` |
+|     % |     Size | Allocations | Location                                                      |
+| ----: | -------: | ----------: | ------------------------------------------------------------- |
+| 38.2% | 3.68 KiB |           3 | `/venv/lib/python3.11/site-packages/packaging/version.py:340` |
+| 15.5% | 1.49 KiB |           2 | `/venv/lib/python3.11/site-packages/packaging/version.py:124` |
+| 15.4% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:285` |
+| 11.3% | 1.09 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:228` |
+|  9.8% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:134` |
 
 ##### `_fill_cache` (`<frozen importlib._bootstrap_external>:1655`)
 
-|      % |  Size | Samples | Location                                      |
-| -----: | ----: | ------: | --------------------------------------------- |
-| 100.0% | 8 KiB |       4 | `<frozen importlib._bootstrap_external>:1667` |
+|      % |  Size | Allocations | Location                                      |
+| -----: | ----: | ----------: | --------------------------------------------- |
+| 100.0% | 8 KiB |           4 | `<frozen importlib._bootstrap_external>:1667` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|      % |     Size | Samples | Location                                |
-| -----: | -------: | ------: | --------------------------------------- |
-| 100.0% | 7.97 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:455` |
+|      % |     Size | Allocations | Location                                |
+| -----: | -------: | ----------: | --------------------------------------- |
+| 100.0% | 7.97 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:455` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/utils.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 44.8% | 3.17 KiB |       3 | `/venv/lib/python3.11/site-packages/click/utils.py:522` |
-| 31.4% | 2.22 KiB |       3 | `/venv/lib/python3.11/site-packages/click/utils.py:207` |
-| 23.8% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/utils.py:113` |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 44.8% | 3.17 KiB |           3 | `/venv/lib/python3.11/site-packages/click/utils.py:522` |
+| 31.4% | 2.22 KiB |           3 | `/venv/lib/python3.11/site-packages/click/utils.py:207` |
+| 23.8% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/utils.py:113` |
 
 ##### `__setattr__` (`/usr/lib/python3.11/enum.py:831`)
 
-|      % |     Size | Samples | Location                          |
-| -----: | -------: | ------: | --------------------------------- |
-| 100.0% | 6.73 KiB |       8 | `/usr/lib/python3.11/enum.py:842` |
+|      % |     Size | Allocations | Location                          |
+| -----: | -------: | ----------: | --------------------------------- |
+| 100.0% | 6.73 KiB |           8 | `/usr/lib/python3.11/enum.py:842` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/util.py:1`)
 
-|     % |     Size | Samples | Location                                                  |
-| ----: | -------: | ------: | --------------------------------------------------------- |
-| 22.9% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:254` |
-| 16.9% | 1.09 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:765` |
-| 16.3% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:710` |
-| 15.1% |   1000 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:741` |
-| 14.5% |    960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:651` |
+|     % |     Size | Allocations | Location                                                  |
+| ----: | -------: | ----------: | --------------------------------------------------------- |
+| 22.9% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:254` |
+| 16.9% | 1.09 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:765` |
+| 16.3% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:710` |
+| 15.1% |   1000 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:741` |
+| 14.5% |    960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:651` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|     % |     Size | Samples | Location                                                      |
-| ----: | -------: | ------: | ------------------------------------------------------------- |
-| 23.8% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:681` |
-| 23.0% | 1.43 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:44`  |
-| 19.4% | 1.21 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:63`  |
-| 16.9% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:179` |
-| 16.9% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:236` |
+|     % |     Size | Allocations | Location                                                      |
+| ----: | -------: | ----------: | ------------------------------------------------------------- |
+| 23.8% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:681` |
+| 23.0% | 1.43 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:44`  |
+| 19.4% | 1.21 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:63`  |
+| 16.9% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:179` |
+| 16.9% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:236` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|     % |     Size | Samples | Location                                                   |
-| ----: | -------: | ------: | ---------------------------------------------------------- |
-| 28.0% | 1.67 KiB |       2 | `/venv/lib/python3.11/site-packages/packaging/tags.py:118` |
-| 24.9% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:322` |
-| 15.7% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:110` |
-| 15.7% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:101` |
-| 15.7% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:93`  |
+|     % |     Size | Allocations | Location                                                   |
+| ----: | -------: | ----------: | ---------------------------------------------------------- |
+| 28.0% | 1.67 KiB |           2 | `/venv/lib/python3.11/site-packages/packaging/tags.py:118` |
+| 24.9% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:322` |
+| 15.7% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:110` |
+| 15.7% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:101` |
+| 15.7% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:93`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/_compat.py:1`)
 
-|     % |     Size | Samples | Location                                                  |
-| ----: | -------: | ------: | --------------------------------------------------------- |
-| 29.1% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/_compat.py:452` |
-| 29.1% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/_compat.py:82`  |
-| 25.6% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/click/_compat.py:344` |
-| 16.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/_compat.py:56`  |
+|     % |     Size | Allocations | Location                                                  |
+| ----: | -------: | ----------: | --------------------------------------------------------- |
+| 29.1% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/_compat.py:452` |
+| 29.1% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/_compat.py:82`  |
+| 25.6% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/click/_compat.py:344` |
+| 16.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/_compat.py:56`  |
 
 ##### `namedtuple` (`/usr/lib/python3.11/collections/__init__.py:348`)
 
-|      % |     Size | Samples | Location                                          |
-| -----: | -------: | ------: | ------------------------------------------------- |
-| 100.0% | 5.63 KiB |       6 | `/usr/lib/python3.11/collections/__init__.py:501` |
+|      % |     Size | Allocations | Location                                          |
+| -----: | -------: | ----------: | ------------------------------------------------- |
+| 100.0% | 5.63 KiB |           6 | `/usr/lib/python3.11/collections/__init__.py:501` |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|     % |     Size | Samples | Location                                |
-| ----: | -------: | ------: | --------------------------------------- |
-| 43.4% | 2.43 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:539` |
-| 33.9% |  1.9 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:568` |
-| 22.7% | 1.28 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:838` |
+|     % |     Size | Allocations | Location                                |
+| ----: | -------: | ----------: | --------------------------------------- |
+| 43.4% | 2.43 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:539` |
+| 33.9% |  1.9 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:568` |
+| 22.7% | 1.28 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:838` |
 
 ##### `_code` (`/usr/lib/python3.11/re/_compiler.py:571`)
 
-|     % |     Size | Samples | Location                                  |
-| ----: | -------: | ------: | ----------------------------------------- |
-| 81.6% | 4.34 KiB |       1 | `/usr/lib/python3.11/re/_compiler.py:580` |
-| 18.4% |   1002 B |       1 | `/usr/lib/python3.11/re/_compiler.py:577` |
+|     % |     Size | Allocations | Location                                  |
+| ----: | -------: | ----------: | ----------------------------------------- |
+| 81.6% | 4.34 KiB |           1 | `/usr/lib/python3.11/re/_compiler.py:580` |
+| 18.4% |   1002 B |           1 | `/usr/lib/python3.11/re/_compiler.py:577` |
 
 ##### `<module>` (`/usr/lib/python3.11/pkgutil.py:1`)
 
-|     % |     Size | Samples | Location                             |
-| ----: | -------: | ------: | ------------------------------------ |
-| 35.7% | 1.69 KiB |       2 | `/usr/lib/python3.11/pkgutil.py:269` |
-| 35.7% | 1.69 KiB |       2 | `/usr/lib/python3.11/pkgutil.py:194` |
-| 15.9% |    768 B |       1 | `/usr/lib/python3.11/pkgutil.py:137` |
-| 12.8% |    620 B |       1 | `/usr/lib/python3.11/pkgutil.py:184` |
+|     % |     Size | Allocations | Location                             |
+| ----: | -------: | ----------: | ------------------------------------ |
+| 35.7% | 1.69 KiB |           2 | `/usr/lib/python3.11/pkgutil.py:269` |
+| 35.7% | 1.69 KiB |           2 | `/usr/lib/python3.11/pkgutil.py:194` |
+| 15.9% |    768 B |           1 | `/usr/lib/python3.11/pkgutil.py:137` |
+| 12.8% |    620 B |           1 | `/usr/lib/python3.11/pkgutil.py:184` |
 
 ##### `Specifier` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`)
 
-|      % |     Size | Samples | Location                                                         |
-| -----: | -------: | ------: | ---------------------------------------------------------------- |
-| 100.0% | 3.82 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:340` |
+|      % |     Size | Allocations | Location                                                         |
+| -----: | -------: | ----------: | ---------------------------------------------------------------- |
+| 100.0% | 3.82 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:340` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 46.4% | 1.73 KiB |       2 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:29`  |
-| 27.3% | 1.02 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:90`  |
-| 26.3% |   1000 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:245` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 46.4% | 1.73 KiB |           2 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:29`  |
+| 27.3% | 1.02 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:90`  |
+| 26.3% |   1000 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:245` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|     % |  Size | Samples | Location                                                   |
-| ----: | ----: | ------: | ---------------------------------------------------------- |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:62` |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:46` |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:54` |
-| 21.1% | 768 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:27` |
+|     % |  Size | Allocations | Location                                                   |
+| ----: | ----: | ----------: | ---------------------------------------------------------- |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:62` |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:46` |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:54` |
+| 21.1% | 768 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:27` |
 
 ##### `handle_parse_result` (`/venv/lib/python3.11/site-packages/click/core.py:2663`)
 
-|     % |    Size | Samples | Location                                                |
-| ----: | ------: | ------: | ------------------------------------------------------- |
-| 38.5% | 1.3 KiB |       2 | `/venv/lib/python3.11/site-packages/click/core.py:2686` |
-| 22.3% |   768 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2739` |
-| 22.3% |   768 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2740` |
-| 17.0% |   586 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2711` |
+|     % |    Size | Allocations | Location                                                |
+| ----: | ------: | ----------: | ------------------------------------------------------- |
+| 38.5% | 1.3 KiB |           2 | `/venv/lib/python3.11/site-packages/click/core.py:2686` |
+| 22.3% |   768 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2739` |
+| 22.3% |   768 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2740` |
+| 17.0% |   586 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2711` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|      % |     Size | Samples | Location                                                  |
-| -----: | -------: | ------: | --------------------------------------------------------- |
-| 100.0% | 3.19 KiB |       1 | `/venv/lib/python3.11/site-packages/click/__init__.py:74` |
+|      % |     Size | Allocations | Location                                                  |
+| -----: | -------: | ----------: | --------------------------------------------------------- |
+| 100.0% | 3.19 KiB |           1 | `/venv/lib/python3.11/site-packages/click/__init__.py:74` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 76.5% | 2.44 KiB |       3 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:55` |
-| 23.5% |    768 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:14` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 76.5% | 2.44 KiB |           3 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:55` |
+| 23.5% |    768 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:14` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Location                                                    |
-| -----: | -------: | ------: | ----------------------------------------------------------- |
-| 100.0% | 3.04 KiB |       2 | `/venv/lib/python3.11/site-packages/click/decorators.py:34` |
+|      % |     Size | Allocations | Location                                                    |
+| -----: | -------: | ----------: | ----------------------------------------------------------- |
+| 100.0% | 3.04 KiB |           2 | `/venv/lib/python3.11/site-packages/click/decorators.py:34` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|      % |     Size | Samples | Location                                  |
-| -----: | -------: | ------: | ----------------------------------------- |
-| 100.0% | 2.85 KiB |       1 | `/usr/lib/python3.11/dataclasses.py:1210` |
+|      % |     Size | Allocations | Location                                  |
+| -----: | -------: | ----------: | ----------------------------------------- |
+| 100.0% | 2.85 KiB |           1 | `/usr/lib/python3.11/dataclasses.py:1210` |
 
 ##### `_process_class` (`/usr/lib/python3.11/dataclasses.py:884`)
 
-|     % |     Size | Samples | Location                                  |
-| ----: | -------: | ------: | ----------------------------------------- |
-| 41.3% | 1.18 KiB |       1 | `/usr/lib/python3.11/dataclasses.py:958`  |
-| 21.0% |    612 B |       1 | `/usr/lib/python3.11/dataclasses.py:1027` |
-| 19.9% |    580 B |       1 | `/usr/lib/python3.11/dataclasses.py:1096` |
-| 17.8% |    518 B |       1 | `/usr/lib/python3.11/dataclasses.py:947`  |
+|     % |     Size | Allocations | Location                                  |
+| ----: | -------: | ----------: | ----------------------------------------- |
+| 41.3% | 1.18 KiB |           1 | `/usr/lib/python3.11/dataclasses.py:958`  |
+| 21.0% |    612 B |           1 | `/usr/lib/python3.11/dataclasses.py:1027` |
+| 19.9% |    580 B |           1 | `/usr/lib/python3.11/dataclasses.py:1096` |
+| 17.8% |    518 B |           1 | `/usr/lib/python3.11/dataclasses.py:947`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1`)
 
-|     % |  Size | Samples | Location                                                                     |
-| ----: | ----: | ------: | ---------------------------------------------------------------------------- |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:22`  |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:205` |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:197` |
+|     % |  Size | Allocations | Location                                                                     |
+| ----: | ----: | ----------: | ---------------------------------------------------------------------------- |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:22`  |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:205` |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:197` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 53.7% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/click/types.py:464` |
-| 46.3% | 1.28 KiB |       1 | `/venv/lib/python3.11/site-packages/click/types.py:37`  |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 53.7% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/click/types.py:464` |
+| 46.3% | 1.28 KiB |           1 | `/venv/lib/python3.11/site-packages/click/types.py:37`  |
 
 ##### `_signature_from_function` (`/usr/lib/python3.11/inspect.py:2331`)
 
-|     % |     Size | Samples | Location                              |
-| ----: | -------: | ------: | ------------------------------------- |
-| 41.4% | 1.06 KiB |       1 | `/usr/lib/python3.11/inspect.py:2358` |
-| 37.0% |    972 B |       1 | `/usr/lib/python3.11/inspect.py:2376` |
-| 21.6% |    568 B |       1 | `/usr/lib/python3.11/inspect.py:2421` |
+|     % |     Size | Allocations | Location                              |
+| ----: | -------: | ----------: | ------------------------------------- |
+| 41.4% | 1.06 KiB |           1 | `/usr/lib/python3.11/inspect.py:2358` |
+| 37.0% |    972 B |           1 | `/usr/lib/python3.11/inspect.py:2376` |
+| 21.6% |    568 B |           1 | `/usr/lib/python3.11/inspect.py:2421` |
 
 #### Callers
 
@@ -2016,483 +2016,483 @@ Callers ranked by contribution to each function's self size. Inlining can make c
 
 ##### `mark` (`black/brackets.py:70`)
 
-|     % |     Size | Samples | Caller                           | Location                |
-| ----: | -------: | ------: | -------------------------------- | ----------------------- |
-| 94.2% | 16.2 MiB |  20,788 | `append`                         | `black/lines.py:63`     |
-|  5.8% |    1 MiB |       1 | `max_delimiter_priority_in_atom` | `black/brackets.py:328` |
+|     % |     Size | Allocations | Caller                           | Location                |
+| ----: | -------: | ----------: | -------------------------------- | ----------------------- |
+| 94.2% | 16.2 MiB |      20,788 | `append`                         | `black/lines.py:63`     |
+|  5.8% |    1 MiB |           1 | `max_delimiter_priority_in_atom` | `black/brackets.py:328` |
 
 ##### `changed` (`blib2to3/pytree.py:171`)
 
-|     % |  Size | Samples | Caller    | Location                 |
-| ----: | ----: | ------: | --------- | ------------------------ |
-| 66.7% | 4 MiB |       4 | `changed` | `blib2to3/pytree.py:171` |
-| 33.3% | 2 MiB |       2 | `prefix`  | `blib2to3/pytree.py:480` |
+|     % |  Size | Allocations | Caller    | Location                 |
+| ----: | ----: | ----------: | --------- | ------------------------ |
+| 66.7% | 4 MiB |           4 | `changed` | `blib2to3/pytree.py:171` |
+| 33.3% | 2 MiB |           2 | `prefix`  | `blib2to3/pytree.py:480` |
 
 ##### `__new__` (`blib2to3/pytree.py:81`)
 
-|      % |  Size | Samples | Caller    | Location                 |
-| -----: | ----: | ------: | --------- | ------------------------ |
-| 100.0% | 5 MiB |       5 | `convert` | `blib2to3/pytree.py:486` |
+|      % |  Size | Allocations | Caller    | Location                 |
+| -----: | ----: | ----------: | --------- | ------------------------ |
+| 100.0% | 5 MiB |           5 | `convert` | `blib2to3/pytree.py:486` |
 
 ##### `transform_line` (`black/linegen.py:601`)
 
-|      % |     Size | Samples | Caller             | Location                 |
-| -----: | -------: | ------: | ------------------ | ------------------------ |
-| 100.0% | 3.07 MiB |       9 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |     Size | Allocations | Caller             | Location                 |
+| -----: | -------: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 3.07 MiB |           9 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|      % |  Size | Samples | Caller         | Location               |
-| -----: | ----: | ------: | -------------- | ---------------------- |
-| 100.0% | 3 MiB |       3 | `visit`        | `black/nodes.py:163`   |
-|  <0.1% | 702 B |       1 | `visit_STRING` | `black/linegen.py:413` |
+|      % |  Size | Allocations | Caller         | Location               |
+| -----: | ----: | ----------: | -------------- | ---------------------- |
+| 100.0% | 3 MiB |           3 | `visit`        | `black/nodes.py:163`   |
+|  <0.1% | 702 B |           1 | `visit_STRING` | `black/linegen.py:413` |
 
 ##### `generate_comments` (`black/comments.py:52`)
 
-|      % |  Size | Samples | Caller          | Location               |
-| -----: | ----: | ------: | --------------- | ---------------------- |
-| 100.0% | 3 MiB |       3 | `visit_default` | `black/linegen.py:134` |
+|      % |  Size | Allocations | Caller          | Location               |
+| -----: | ----: | ----------: | --------------- | ---------------------- |
+| 100.0% | 3 MiB |           3 | `visit_default` | `black/linegen.py:134` |
 
 ##### `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`)
 
-|      % |     Size | Samples | Caller           | Location                                     |
-| -----: | -------: | ------: | ---------------- | -------------------------------------------- |
-| 100.0% | 2.27 MiB |     352 | `source_to_code` | `<frozen importlib._bootstrap_external>:999` |
+|      % |     Size | Allocations | Caller           | Location                                     |
+| -----: | -------: | ----------: | ---------------- | -------------------------------------------- |
+| 100.0% | 2.27 MiB |         352 | `source_to_code` | `<frozen importlib._bootstrap_external>:999` |
 
 ##### `update_sibling_maps` (`blib2to3/pytree.py:369`)
 
-|      % |     Size | Samples | Caller         | Location                 |
-| -----: | -------: | ------: | -------------- | ------------------------ |
-| 100.0% | 2.14 MiB |     197 | `prev_sibling` | `blib2to3/pytree.py:207` |
+|      % |     Size | Allocations | Caller         | Location                 |
+| -----: | -------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 2.14 MiB |         197 | `prev_sibling` | `blib2to3/pytree.py:207` |
 
 ##### `parse` (`/usr/lib/python3.11/ast.py:33`)
 
-|      % |     Size | Samples | Caller                  | Location               |
-| -----: | -------: | ------: | ----------------------- | ---------------------- |
-| 100.0% | 2.01 MiB |       3 | `_parse_single_version` | `black/parsing.py:117` |
+|      % |     Size | Allocations | Caller                  | Location               |
+| -----: | -------: | ----------: | ----------------------- | ---------------------- |
+| 100.0% | 2.01 MiB |           3 | `_parse_single_version` | `black/parsing.py:117` |
 
 ##### `convert` (`blib2to3/pytree.py:486`)
 
-|      % |  Size | Samples | Caller | Location                      |
-| -----: | ----: | ------: | ------ | ----------------------------- |
-| 100.0% | 2 MiB |       2 | `pop`  | `blib2to3/pgen2/parse.py:398` |
+|      % |  Size | Allocations | Caller | Location                      |
+| -----: | ----: | ----------: | ------ | ----------------------------- |
+| 100.0% | 2 MiB |           2 | `pop`  | `blib2to3/pgen2/parse.py:398` |
 
 ##### `push` (`blib2to3/pgen2/parse.py:386`)
 
-|      % |  Size | Samples | Caller      | Location                      |
-| -----: | ----: | ------: | ----------- | ----------------------------- |
-| 100.0% | 2 MiB |       2 | `_addtoken` | `blib2to3/pgen2/parse.py:290` |
+|      % |  Size | Allocations | Caller      | Location                      |
+| -----: | ----: | ----------: | ----------- | ----------------------------- |
+| 100.0% | 2 MiB |           2 | `_addtoken` | `blib2to3/pgen2/parse.py:290` |
 
 ##### `make_grammar` (`blib2to3/pgen2/pgen.py:49`)
 
-|      % |     Size | Samples | Caller             | Location                     |
-| -----: | -------: | ------: | ------------------ | ---------------------------- |
-| 100.0% | 1.01 MiB |       6 | `generate_grammar` | `blib2to3/pgen2/pgen.py:426` |
+|      % |     Size | Allocations | Caller             | Location                     |
+| -----: | -------: | ----------: | ------------------ | ---------------------------- |
+| 100.0% | 1.01 MiB |           6 | `generate_grammar` | `blib2to3/pgen2/pgen.py:426` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 1.01 MiB |      11 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 1.01 MiB |          11 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|     % |  Size | Samples | Caller             | Location                 |
-| ----: | ----: | ------: | ------------------ | ------------------------ |
-| 99.9% | 1 MiB |       4 | `visit_default`    | `black/nodes.py:187`     |
-|  0.1% | 690 B |       1 | `_format_str_once` | `black/__init__.py:1236` |
+|     % |  Size | Allocations | Caller             | Location                 |
+| ----: | ----: | ----------: | ------------------ | ------------------------ |
+| 99.9% | 1 MiB |           4 | `visit_default`    | `black/nodes.py:187`     |
+|  0.1% | 690 B |           1 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `maybe_empty_lines` (`black/lines.py:560`)
 
-|      % |  Size | Samples | Caller             | Location                 |
-| -----: | ----: | ------: | ------------------ | ------------------------ |
-| 100.0% | 1 MiB |       2 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |  Size | Allocations | Caller             | Location                 |
+| -----: | ----: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 1 MiB |           2 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `contains_uncollapsable_type_comments` (`black/lines.py:276`)
 
-|      % |  Size | Samples | Caller           | Location               |
-| -----: | ----: | ------: | ---------------- | ---------------------- |
-| 100.0% | 1 MiB |       1 | `transform_line` | `black/linegen.py:601` |
+|      % |  Size | Allocations | Caller           | Location               |
+| -----: | ----: | ----------: | ---------------- | ---------------------- |
+| 100.0% | 1 MiB |           1 | `transform_line` | `black/linegen.py:601` |
 
 ##### `__init__` (`<string>:2`)
 
-|      % |  Size | Samples | Caller | Location               |
-| -----: | ----: | ------: | ------ | ---------------------- |
-| 100.0% | 1 MiB |       1 | `line` | `black/linegen.py:109` |
+|      % |  Size | Allocations | Caller | Location               |
+| -----: | ----: | ----------: | ------ | ---------------------- |
+| 100.0% | 1 MiB |           1 | `line` | `black/linegen.py:109` |
 
 ##### `_addtoken` (`blib2to3/pgen2/parse.py:290`)
 
-|      % |  Size | Samples | Caller     | Location                      |
-| -----: | ----: | ------: | ---------- | ----------------------------- |
-| 100.0% | 1 MiB |       1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
+|      % |  Size | Allocations | Caller     | Location                      |
+| -----: | ----: | ----------: | ---------- | ----------------------------- |
+| 100.0% | 1 MiB |           1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
 
 ##### `__init__` (`blib2to3/pytree.py:400`)
 
-|      % |  Size | Samples | Caller    | Location                 |
-| -----: | ----: | ------: | --------- | ------------------------ |
-| 100.0% | 1 MiB |       1 | `convert` | `blib2to3/pytree.py:486` |
+|      % |  Size | Allocations | Caller    | Location                 |
+| -----: | ----: | ----------: | --------- | ------------------------ |
+| 100.0% | 1 MiB |           1 | `convert` | `blib2to3/pytree.py:486` |
 
 ##### `_compile_bytecode` (`<frozen importlib._bootstrap_external>:727`)
 
-|      % |    Size | Samples | Caller     | Location                                      |
-| -----: | ------: | ------: | ---------- | --------------------------------------------- |
-| 100.0% | 311 KiB |     341 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
+|      % |    Size | Allocations | Caller     | Location                                      |
+| -----: | ------: | ----------: | ---------- | --------------------------------------------- |
+| 100.0% | 311 KiB |         341 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `_code_to_timestamp_pyc` (`<frozen importlib._bootstrap_external>:740`)
 
-|      % |    Size | Samples | Caller     | Location                                      |
-| -----: | ------: | ------: | ---------- | --------------------------------------------- |
-| 100.0% | 112 KiB |     108 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
+|      % |    Size | Allocations | Caller     | Location                                      |
+| -----: | ------: | ----------: | ---------- | --------------------------------------------- |
+| 100.0% | 112 KiB |         108 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `__new__` (`<frozen abc>:105`)
 
-|     % |     Size | Samples | Caller     | Location                                                       |
-| ----: | -------: | ------: | ---------- | -------------------------------------------------------------- |
-| 50.5% | 38.2 KiB |      45 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`          |
-| 23.1% | 17.5 KiB |      18 | `<module>` | `black/trans.py:1`                                             |
-| 18.3% | 13.9 KiB |       9 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`           |
-|  8.0% | 6.07 KiB |       7 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
+|     % |     Size | Allocations | Caller     | Location                                                       |
+| ----: | -------: | ----------: | ---------- | -------------------------------------------------------------- |
+| 50.5% | 38.2 KiB |          45 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`          |
+| 23.1% | 17.5 KiB |          18 | `<module>` | `black/trans.py:1`                                             |
+| 18.3% | 13.9 KiB |           9 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`           |
+|  8.0% | 6.07 KiB |           7 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
 
 ##### `normalize_string_prefix` (`black/strings.py:143`)
 
-|      % |     Size | Samples | Caller         | Location               |
-| -----: | -------: | ------: | -------------- | ---------------------- |
-| 100.0% | 57.2 KiB |      65 | `visit_STRING` | `black/linegen.py:413` |
+|      % |     Size | Allocations | Caller         | Location               |
+| -----: | -------: | ----------: | -------------- | ---------------------- |
+| 100.0% | 57.2 KiB |          65 | `visit_STRING` | `black/linegen.py:413` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|      % |     Size | Samples | Caller      | Location                                                     |
-| -----: | -------: | ------: | ----------- | ------------------------------------------------------------ |
-| 100.0% | 44.3 KiB |      31 | `decorator` | `/venv/lib/python3.11/site-packages/click/decorators.py:373` |
+|      % |     Size | Allocations | Caller      | Location                                                     |
+| -----: | -------: | ----------: | ----------- | ------------------------------------------------------------ |
+| 100.0% | 44.3 KiB |          31 | `decorator` | `/venv/lib/python3.11/site-packages/click/decorators.py:373` |
 
 ##### `copy` (`blib2to3/pgen2/grammar.py:131`)
 
-|      % |     Size | Samples | Caller       | Location                 |
-| -----: | -------: | ------: | ------------ | ------------------------ |
-| 100.0% | 41.5 KiB |      16 | `initialize` | `blib2to3/pygram.py:165` |
+|      % |     Size | Allocations | Caller       | Location                 |
+| -----: | -------: | ----------: | ------------ | ------------------------ |
+| 100.0% | 41.5 KiB |          16 | `initialize` | `blib2to3/pygram.py:165` |
 
 ##### `classify` (`blib2to3/pgen2/parse.py:336`)
 
-|      % |   Size | Samples | Caller     | Location                      |
-| -----: | -----: | ------: | ---------- | ----------------------------- |
-| 100.0% | 32 KiB |       1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
+|      % |   Size | Allocations | Caller     | Location                      |
+| -----: | -----: | ----------: | ---------- | ----------------------------- |
+| 100.0% | 32 KiB |           1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
 
 ##### `make_first` (`blib2to3/pgen2/pgen.py:74`)
 
-|      % |     Size | Samples | Caller         | Location                    |
-| -----: | -------: | ------: | -------------- | --------------------------- |
-| 100.0% | 25.3 KiB |      40 | `make_grammar` | `blib2to3/pgen2/pgen.py:49` |
+|      % |     Size | Allocations | Caller         | Location                    |
+| -----: | -------: | ----------: | -------------- | --------------------------- |
+| 100.0% | 25.3 KiB |          40 | `make_grammar` | `blib2to3/pgen2/pgen.py:49` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 25 KiB |      22 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 25 KiB |          22 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__new__` (`/usr/lib/python3.11/enum.py:488`)
 
-|     % |     Size | Samples | Caller     | Location                                                     |
-| ----: | -------: | ------: | ---------- | ------------------------------------------------------------ |
-| 31.7% | 7.64 KiB |       9 | `<module>` | `black/mode.py:1`                                            |
-| 16.2% | 3.89 KiB |       4 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/_elffile.py:1` |
-| 13.7% |  3.3 KiB |       3 | `<module>` | `/venv/lib/python3.11/site-packages/click/_utils.py:1`       |
-| 10.1% | 2.44 KiB |       3 | `<module>` | `black/__init__.py:1`                                        |
-|  7.2% | 1.74 KiB |       2 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`         |
+|     % |     Size | Allocations | Caller     | Location                                                     |
+| ----: | -------: | ----------: | ---------- | ------------------------------------------------------------ |
+| 31.7% | 7.64 KiB |           9 | `<module>` | `black/mode.py:1`                                            |
+| 16.2% | 3.89 KiB |           4 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/_elffile.py:1` |
+| 13.7% |  3.3 KiB |           3 | `<module>` | `/venv/lib/python3.11/site-packages/click/_utils.py:1`       |
+| 10.1% | 2.44 KiB |           3 | `<module>` | `black/__init__.py:1`                                        |
+|  7.2% | 1.74 KiB |           2 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`         |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|      % |     Size | Samples | Caller     | Location                                 |
-| -----: | -------: | ------: | ---------- | ---------------------------------------- |
-| 100.0% | 22.6 KiB |      12 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
+|      % |     Size | Allocations | Caller     | Location                                 |
+| -----: | -------: | ----------: | ---------- | ---------------------------------------- |
+| 100.0% | 22.6 KiB |          12 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/_parser.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 19.8 KiB |      12 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 19.8 KiB |          12 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__new__` (`/usr/lib/python3.11/typing.py:2891`)
 
-|     % |     Size | Samples | Caller     | Location                                                    |
-| ----: | -------: | ------: | ---------- | ----------------------------------------------------------- |
-| 90.3% | 15.7 KiB |      19 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`       |
-|  9.7% | 1.69 KiB |       2 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/version.py:1` |
+|     % |     Size | Allocations | Caller     | Location                                                    |
+| ----: | -------: | ----------: | ---------- | ----------------------------------------------------------- |
+| 90.3% | 15.7 KiB |          19 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`       |
+|  9.7% | 1.69 KiB |           2 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/version.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/mypy_extensions.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 15 KiB |      18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 15 KiB |          18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/exceptions.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 13.4 KiB |      15 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 13.4 KiB |          15 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `inner` (`/usr/lib/python3.11/typing.py:338`)
 
-|     % |     Size | Samples | Caller        | Location                                              |
-| ----: | -------: | ------: | ------------- | ----------------------------------------------------- |
-| 75.3% | 9.02 KiB |       1 | `Line`        | `black/lines.py:49`                                   |
-| 17.9% | 2.15 KiB |       1 | `__getitem__` | `/usr/lib/python3.11/typing.py:467`                   |
-|  6.7% |    826 B |       1 | `<module>`    | `/venv/lib/python3.11/site-packages/click/types.py:1` |
+|     % |     Size | Allocations | Caller        | Location                                              |
+| ----: | -------: | ----------: | ------------- | ----------------------------------------------------- |
+| 75.3% | 9.02 KiB |           1 | `Line`        | `black/lines.py:49`                                   |
+| 17.9% | 2.15 KiB |           1 | `__getitem__` | `/usr/lib/python3.11/typing.py:467`                   |
+|  6.7% |    826 B |           1 | `<module>`    | `/venv/lib/python3.11/site-packages/click/types.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/version.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 9.61 KiB |       9 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 9.61 KiB |           9 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `_fill_cache` (`<frozen importlib._bootstrap_external>:1655`)
 
-|      % |  Size | Samples | Caller      | Location                                      |
-| -----: | ----: | ------: | ----------- | --------------------------------------------- |
-| 100.0% | 8 KiB |       4 | `find_spec` | `<frozen importlib._bootstrap_external>:1604` |
+|      % |  Size | Allocations | Caller      | Location                                      |
+| -----: | ----: | ----------: | ----------- | --------------------------------------------- |
+| 100.0% | 8 KiB |           4 | `find_spec` | `<frozen importlib._bootstrap_external>:1604` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|      % |     Size | Samples | Caller  | Location                                |
-| -----: | -------: | ------: | ------- | --------------------------------------- |
-| 100.0% | 7.97 KiB |       1 | `parse` | `/usr/lib/python3.11/re/_parser.py:970` |
+|      % |     Size | Allocations | Caller  | Location                                |
+| -----: | -------: | ----------: | ------- | --------------------------------------- |
+| 100.0% | 7.97 KiB |           1 | `parse` | `/usr/lib/python3.11/re/_parser.py:970` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/utils.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 7.08 KiB |       8 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 7.08 KiB |           8 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__setattr__` (`/usr/lib/python3.11/enum.py:831`)
 
-|     % |     Size | Samples | Caller         | Location                          |
-| ----: | -------: | ------: | -------------- | --------------------------------- |
-| 66.6% | 4.48 KiB |       5 | `__set_name__` | `/usr/lib/python3.11/enum.py:237` |
-| 33.4% | 2.25 KiB |       3 | `__new__`      | `/usr/lib/python3.11/enum.py:488` |
+|     % |     Size | Allocations | Caller         | Location                          |
+| ----: | -------: | ----------: | -------------- | --------------------------------- |
+| 66.6% | 4.48 KiB |           5 | `__set_name__` | `/usr/lib/python3.11/enum.py:237` |
+| 33.4% | 2.25 KiB |           3 | `__new__`      | `/usr/lib/python3.11/enum.py:488` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/util.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 6.48 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 6.48 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 6.24 KiB |       5 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 6.24 KiB |           5 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 5.97 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 5.97 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/_compat.py:1`)
 
-|      % |    Size | Samples | Caller                      | Location                            |
-| -----: | ------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 5.8 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |    Size | Allocations | Caller                      | Location                            |
+| -----: | ------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 5.8 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `namedtuple` (`/usr/lib/python3.11/collections/__init__.py:348`)
 
-|     % |     Size | Samples | Caller          | Location                             |
-| ----: | -------: | ------: | --------------- | ------------------------------------ |
-| 83.3% | 4.69 KiB |       5 | `_make_nmtuple` | `/usr/lib/python3.11/typing.py:2795` |
-| 16.7% |    960 B |       1 | `<module>`      | `/usr/lib/python3.11/pkgutil.py:1`   |
+|     % |     Size | Allocations | Caller          | Location                             |
+| ----: | -------: | ----------: | --------------- | ------------------------------------ |
+| 83.3% | 4.69 KiB |           5 | `_make_nmtuple` | `/usr/lib/python3.11/typing.py:2795` |
+| 16.7% |    960 B |           1 | `<module>`      | `/usr/lib/python3.11/pkgutil.py:1`   |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|      % |     Size | Samples | Caller       | Location                                |
-| -----: | -------: | ------: | ------------ | --------------------------------------- |
-| 100.0% | 5.61 KiB |       3 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
+|      % |     Size | Allocations | Caller       | Location                                |
+| -----: | -------: | ----------: | ------------ | --------------------------------------- |
+| 100.0% | 5.61 KiB |           3 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
 
 ##### `_code` (`/usr/lib/python3.11/re/_compiler.py:571`)
 
-|      % |     Size | Samples | Caller    | Location                                  |
-| -----: | -------: | ------: | --------- | ----------------------------------------- |
-| 100.0% | 5.32 KiB |       2 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
+|      % |     Size | Allocations | Caller    | Location                                  |
+| -----: | -------: | ----------: | --------- | ----------------------------------------- |
+| 100.0% | 5.32 KiB |           2 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
 
 ##### `<module>` (`/usr/lib/python3.11/pkgutil.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 4.73 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 4.73 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `Specifier` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`)
 
-|      % |     Size | Samples | Caller     | Location                                                       |
-| -----: | -------: | ------: | ---------- | -------------------------------------------------------------- |
-| 100.0% | 3.82 KiB |       1 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
+|      % |     Size | Allocations | Caller     | Location                                                       |
+| -----: | -------: | ----------: | ---------- | -------------------------------------------------------------- |
+| 100.0% | 3.82 KiB |           1 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.72 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.72 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.56 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.56 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `handle_parse_result` (`/venv/lib/python3.11/site-packages/click/core.py:2663`)
 
-|      % |     Size | Samples | Caller       | Location                                                |
-| -----: | -------: | ------: | ------------ | ------------------------------------------------------- |
-| 100.0% | 3.37 KiB |       5 | `parse_args` | `/venv/lib/python3.11/site-packages/click/core.py:1303` |
+|      % |     Size | Allocations | Caller       | Location                                                |
+| -----: | -------: | ----------: | ------------ | ------------------------------------------------------- |
+| 100.0% | 3.37 KiB |           5 | `parse_args` | `/venv/lib/python3.11/site-packages/click/core.py:1303` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.19 KiB |       1 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.19 KiB |           1 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.19 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.19 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Caller   | Location                                               |
-| -----: | -------: | ------: | -------- | ------------------------------------------------------ |
-| 100.0% | 3.04 KiB |       2 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
+|      % |     Size | Allocations | Caller   | Location                                               |
+| -----: | -------: | ----------: | -------- | ------------------------------------------------------ |
+| 100.0% | 3.04 KiB |           2 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|      % |     Size | Samples | Caller     | Location                                                   |
-| -----: | -------: | ------: | ---------- | ---------------------------------------------------------- |
-| 100.0% | 2.85 KiB |       1 | `<module>` | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1` |
+|      % |     Size | Allocations | Caller     | Location                                                   |
+| -----: | -------: | ----------: | ---------- | ---------------------------------------------------------- |
+| 100.0% | 2.85 KiB |           1 | `<module>` | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1` |
 
 ##### `_process_class` (`/usr/lib/python3.11/dataclasses.py:884`)
 
-|      % |     Size | Samples | Caller | Location                                  |
-| -----: | -------: | ------: | ------ | ----------------------------------------- |
-| 100.0% | 2.85 KiB |       4 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
+|      % |     Size | Allocations | Caller | Location                                  |
+| -----: | -------: | ----------: | ------ | ----------------------------------------- |
+| 100.0% | 2.85 KiB |           4 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.81 KiB |       3 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.81 KiB |           3 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.76 KiB |       2 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.76 KiB |           2 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `_signature_from_function` (`/usr/lib/python3.11/inspect.py:2331`)
 
-|      % |     Size | Samples | Caller                     | Location                              |
-| -----: | -------: | ------: | -------------------------- | ------------------------------------- |
-| 100.0% | 2.56 KiB |       3 | `_signature_from_callable` | `/usr/lib/python3.11/inspect.py:2426` |
+|      % |     Size | Allocations | Caller                     | Location                              |
+| -----: | -------: | ----------: | -------------------------- | ------------------------------------- |
+| 100.0% | 2.56 KiB |           3 | `_signature_from_callable` | `/usr/lib/python3.11/inspect.py:2426` |
 
 ### Total size
 
 Functions ranked by total bytes never freed in the function and all its callees.
 
-|      % |     Size | Samples | Function               | Location                                                       |
-| -----: | -------: | ------: | ---------------------- | -------------------------------------------------------------- |
-| 100.0% | 57.1 MiB |  22,684 | `_run_tracker`         | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
-| 100.0% | 57.1 MiB |  22,683 | `run_module`           | `<frozen runpy>:201`                                           |
-|  90.5% | 51.6 MiB |  21,189 | `__call__`             | `/venv/lib/python3.11/site-packages/click/core.py:1567`        |
-|  90.5% | 51.6 MiB |  21,189 | `patched_main`         | `black/__init__.py:1594`                                       |
-|  90.5% | 51.6 MiB |  21,189 | `<module>`             | `black/__main__.py:1`                                          |
-|  90.5% | 51.6 MiB |  21,189 | `_run_code`            | `<frozen runpy>:65`                                            |
-|  90.5% | 51.6 MiB |  21,189 | `_run_module_code`     | `<frozen runpy>:91`                                            |
-|  90.5% | 51.6 MiB |  21,188 | `main`                 | `/venv/lib/python3.11/site-packages/click/core.py:1422`        |
-|  90.5% | 51.6 MiB |  21,169 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:1339`        |
-|  90.5% | 51.6 MiB |  21,167 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:853`         |
-|  90.5% | 51.6 MiB |  21,166 | `new_func`             | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
-|  90.5% | 51.6 MiB |  21,164 | `main`                 | `black/__init__.py:244`                                        |
-|  90.4% | 51.6 MiB |  21,159 | `reformat_one`         | `black/__init__.py:860`                                        |
-|  90.4% | 51.6 MiB |  21,152 | `format_file_in_place` | `black/__init__.py:917`                                        |
-|  90.4% | 51.6 MiB |  21,151 | `format_file_contents` | `black/__init__.py:1054`                                       |
-|  86.9% | 49.6 MiB |  21,145 | `_format_str_once`     | `black/__init__.py:1236`                                       |
-|  59.7% | 34.1 MiB |      92 | `format_str`           | `black/__init__.py:1189`                                       |
-|  58.6% | 33.4 MiB |  21,084 | `visit`                | `black/nodes.py:163`                                           |
-|  58.6% | 33.4 MiB |  21,082 | `visit_default`        | `black/nodes.py:187`                                           |
-|  58.6% | 33.4 MiB |  21,082 | `visit_default`        | `black/linegen.py:134`                                         |
+|      % |     Size | Allocations | Function               | Location                                                       |
+| -----: | -------: | ----------: | ---------------------- | -------------------------------------------------------------- |
+| 100.0% | 57.1 MiB |      22,684 | `_run_tracker`         | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
+| 100.0% | 57.1 MiB |      22,683 | `run_module`           | `<frozen runpy>:201`                                           |
+|  90.5% | 51.6 MiB |      21,189 | `__call__`             | `/venv/lib/python3.11/site-packages/click/core.py:1567`        |
+|  90.5% | 51.6 MiB |      21,189 | `patched_main`         | `black/__init__.py:1594`                                       |
+|  90.5% | 51.6 MiB |      21,189 | `<module>`             | `black/__main__.py:1`                                          |
+|  90.5% | 51.6 MiB |      21,189 | `_run_code`            | `<frozen runpy>:65`                                            |
+|  90.5% | 51.6 MiB |      21,189 | `_run_module_code`     | `<frozen runpy>:91`                                            |
+|  90.5% | 51.6 MiB |      21,188 | `main`                 | `/venv/lib/python3.11/site-packages/click/core.py:1422`        |
+|  90.5% | 51.6 MiB |      21,169 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:1339`        |
+|  90.5% | 51.6 MiB |      21,167 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:853`         |
+|  90.5% | 51.6 MiB |      21,166 | `new_func`             | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
+|  90.5% | 51.6 MiB |      21,164 | `main`                 | `black/__init__.py:244`                                        |
+|  90.4% | 51.6 MiB |      21,159 | `reformat_one`         | `black/__init__.py:860`                                        |
+|  90.4% | 51.6 MiB |      21,152 | `format_file_in_place` | `black/__init__.py:917`                                        |
+|  90.4% | 51.6 MiB |      21,151 | `format_file_contents` | `black/__init__.py:1054`                                       |
+|  86.9% | 49.6 MiB |      21,145 | `_format_str_once`     | `black/__init__.py:1236`                                       |
+|  59.7% | 34.1 MiB |          92 | `format_str`           | `black/__init__.py:1189`                                       |
+|  58.6% | 33.4 MiB |      21,084 | `visit`                | `black/nodes.py:163`                                           |
+|  58.6% | 33.4 MiB |      21,082 | `visit_default`        | `black/nodes.py:187`                                           |
+|  58.6% | 33.4 MiB |      21,082 | `visit_default`        | `black/linegen.py:134`                                         |
 
 #### Categories
 
 ##### Ours
 
-|     % |     Size | Samples | Function                          | Location                 |
-| ----: | -------: | ------: | --------------------------------- | ------------------------ |
-| 90.5% | 51.6 MiB |  21,189 | `patched_main`                    | `black/__init__.py:1594` |
-| 90.5% | 51.6 MiB |  21,189 | `<module>`                        | `black/__main__.py:1`    |
-| 90.5% | 51.6 MiB |  21,164 | `main`                            | `black/__init__.py:244`  |
-| 90.4% | 51.6 MiB |  21,159 | `reformat_one`                    | `black/__init__.py:860`  |
-| 90.4% | 51.6 MiB |  21,152 | `format_file_in_place`            | `black/__init__.py:917`  |
-| 90.4% | 51.6 MiB |  21,151 | `format_file_contents`            | `black/__init__.py:1054` |
-| 86.9% | 49.6 MiB |  21,145 | `_format_str_once`                | `black/__init__.py:1236` |
-| 59.7% | 34.1 MiB |      92 | `format_str`                      | `black/__init__.py:1189` |
-| 58.6% | 33.4 MiB |  21,084 | `visit`                           | `black/nodes.py:163`     |
-| 58.6% | 33.4 MiB |  21,082 | `visit_default`                   | `black/nodes.py:187`     |
-| 58.6% | 33.4 MiB |  21,082 | `visit_default`                   | `black/linegen.py:134`   |
-| 58.1% | 33.2 MiB |  20,711 | `visit_stmt`                      | `black/linegen.py:199`   |
-| 57.5% | 32.8 MiB |  20,270 | `visit_funcdef`                   | `black/linegen.py:254`   |
-| 57.4% | 32.7 MiB |  20,144 | `visit_suite`                     | `black/linegen.py:288`   |
-| 40.0% | 22.8 MiB |  13,401 | `visit_simple_stmt`               | `black/linegen.py:295`   |
-| 32.0% | 18.3 MiB |  20,883 | `append`                          | `black/lines.py:63`      |
-| 30.7% | 17.5 MiB |  21,059 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
-| 30.2% | 17.2 MiB |  20,789 | `mark`                            | `black/brackets.py:70`   |
-| 29.6% | 16.9 MiB |  10,808 | `visit_power`                     | `black/linegen.py:341`   |
-| 27.2% | 15.5 MiB |  21,054 | `assert_stable`                   | `black/__init__.py:1557` |
+|     % |     Size | Allocations | Function                          | Location                 |
+| ----: | -------: | ----------: | --------------------------------- | ------------------------ |
+| 90.5% | 51.6 MiB |      21,189 | `patched_main`                    | `black/__init__.py:1594` |
+| 90.5% | 51.6 MiB |      21,189 | `<module>`                        | `black/__main__.py:1`    |
+| 90.5% | 51.6 MiB |      21,164 | `main`                            | `black/__init__.py:244`  |
+| 90.4% | 51.6 MiB |      21,159 | `reformat_one`                    | `black/__init__.py:860`  |
+| 90.4% | 51.6 MiB |      21,152 | `format_file_in_place`            | `black/__init__.py:917`  |
+| 90.4% | 51.6 MiB |      21,151 | `format_file_contents`            | `black/__init__.py:1054` |
+| 86.9% | 49.6 MiB |      21,145 | `_format_str_once`                | `black/__init__.py:1236` |
+| 59.7% | 34.1 MiB |          92 | `format_str`                      | `black/__init__.py:1189` |
+| 58.6% | 33.4 MiB |      21,084 | `visit`                           | `black/nodes.py:163`     |
+| 58.6% | 33.4 MiB |      21,082 | `visit_default`                   | `black/nodes.py:187`     |
+| 58.6% | 33.4 MiB |      21,082 | `visit_default`                   | `black/linegen.py:134`   |
+| 58.1% | 33.2 MiB |      20,711 | `visit_stmt`                      | `black/linegen.py:199`   |
+| 57.5% | 32.8 MiB |      20,270 | `visit_funcdef`                   | `black/linegen.py:254`   |
+| 57.4% | 32.7 MiB |      20,144 | `visit_suite`                     | `black/linegen.py:288`   |
+| 40.0% | 22.8 MiB |      13,401 | `visit_simple_stmt`               | `black/linegen.py:295`   |
+| 32.0% | 18.3 MiB |      20,883 | `append`                          | `black/lines.py:63`      |
+| 30.7% | 17.5 MiB |      21,059 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+| 30.2% | 17.2 MiB |      20,789 | `mark`                            | `black/brackets.py:70`   |
+| 29.6% | 16.9 MiB |      10,808 | `visit_power`                     | `black/linegen.py:341`   |
+| 27.2% | 15.5 MiB |      21,054 | `assert_stable`                   | `black/__init__.py:1557` |
 
 ##### Standard library
 
-|      % |     Size | Samples | Function                    | Location                                      |
-| -----: | -------: | ------: | --------------------------- | --------------------------------------------- |
-| 100.0% | 57.1 MiB |  22,683 | `run_module`                | `<frozen runpy>:201`                          |
-|  90.5% | 51.6 MiB |  21,189 | `_run_code`                 | `<frozen runpy>:65`                           |
-|  90.5% | 51.6 MiB |  21,189 | `_run_module_code`          | `<frozen runpy>:91`                           |
-|   9.5% | 5.42 MiB |   1,493 | `_get_module_details`       | `<frozen runpy>:105`                          |
-|   9.5% | 5.42 MiB |   1,486 | `_find_and_load`            | `<frozen importlib._bootstrap>:1167`          |
-|   9.5% | 5.42 MiB |   1,484 | `_find_and_load_unlocked`   | `<frozen importlib._bootstrap>:1122`          |
-|   9.5% | 5.42 MiB |   1,483 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`           |
-|   9.5% | 5.41 MiB |   1,481 | `exec_module`               | `<frozen importlib._bootstrap_external>:934`  |
-|   9.5% |  5.4 MiB |   1,469 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
-|   4.7% | 2.69 MiB |     802 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
-|   4.0% | 2.27 MiB |     352 | `source_to_code`            | `<frozen importlib._bootstrap_external>:999`  |
-|   3.5% | 2.01 MiB |       3 | `parse`                     | `/usr/lib/python3.11/ast.py:33`               |
-|   0.6% |  333 KiB |     341 | `_handle_fromlist`          | `<frozen importlib._bootstrap>:1209`          |
-|   0.5% |  311 KiB |     341 | `_compile_bytecode`         | `<frozen importlib._bootstrap_external>:727`  |
-|   0.2% |  112 KiB |     108 | `_code_to_timestamp_pyc`    | `<frozen importlib._bootstrap_external>:740`  |
-|   0.1% | 75.7 KiB |      79 | `__new__`                   | `<frozen abc>:105`                            |
-|   0.1% | 47.8 KiB |      25 | `compile`                   | `/usr/lib/python3.11/re/__init__.py:225`      |
-|   0.1% | 47.1 KiB |      24 | `_compile`                  | `/usr/lib/python3.11/re/__init__.py:272`      |
-|   0.1% | 46.5 KiB |      23 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`     |
-|   0.1% |   35 KiB |      32 | `<module>`                  | `/usr/lib/python3.11/tomllib/__init__.py:1`   |
+|      % |     Size | Allocations | Function                    | Location                                      |
+| -----: | -------: | ----------: | --------------------------- | --------------------------------------------- |
+| 100.0% | 57.1 MiB |      22,683 | `run_module`                | `<frozen runpy>:201`                          |
+|  90.5% | 51.6 MiB |      21,189 | `_run_code`                 | `<frozen runpy>:65`                           |
+|  90.5% | 51.6 MiB |      21,189 | `_run_module_code`          | `<frozen runpy>:91`                           |
+|   9.5% | 5.42 MiB |       1,493 | `_get_module_details`       | `<frozen runpy>:105`                          |
+|   9.5% | 5.42 MiB |       1,486 | `_find_and_load`            | `<frozen importlib._bootstrap>:1167`          |
+|   9.5% | 5.42 MiB |       1,484 | `_find_and_load_unlocked`   | `<frozen importlib._bootstrap>:1122`          |
+|   9.5% | 5.42 MiB |       1,483 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`           |
+|   9.5% | 5.41 MiB |       1,481 | `exec_module`               | `<frozen importlib._bootstrap_external>:934`  |
+|   9.5% |  5.4 MiB |       1,469 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
+|   4.7% | 2.69 MiB |         802 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
+|   4.0% | 2.27 MiB |         352 | `source_to_code`            | `<frozen importlib._bootstrap_external>:999`  |
+|   3.5% | 2.01 MiB |           3 | `parse`                     | `/usr/lib/python3.11/ast.py:33`               |
+|   0.6% |  333 KiB |         341 | `_handle_fromlist`          | `<frozen importlib._bootstrap>:1209`          |
+|   0.5% |  311 KiB |         341 | `_compile_bytecode`         | `<frozen importlib._bootstrap_external>:727`  |
+|   0.2% |  112 KiB |         108 | `_code_to_timestamp_pyc`    | `<frozen importlib._bootstrap_external>:740`  |
+|   0.1% | 75.7 KiB |          79 | `__new__`                   | `<frozen abc>:105`                            |
+|   0.1% | 47.8 KiB |          25 | `compile`                   | `/usr/lib/python3.11/re/__init__.py:225`      |
+|   0.1% | 47.1 KiB |          24 | `_compile`                  | `/usr/lib/python3.11/re/__init__.py:272`      |
+|   0.1% | 46.5 KiB |          23 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`     |
+|   0.1% |   35 KiB |          32 | `<module>`                  | `/usr/lib/python3.11/tomllib/__init__.py:1`   |
 
 ##### Third-party
 
-|      % |     Size | Samples | Function       | Location                                                                         |
-| -----: | -------: | ------: | -------------- | -------------------------------------------------------------------------------- |
-| 100.0% | 57.1 MiB |  22,684 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40`                   |
-|  90.5% | 51.6 MiB |  21,189 | `__call__`     | `/venv/lib/python3.11/site-packages/click/core.py:1567`                          |
-|  90.5% | 51.6 MiB |  21,188 | `main`         | `/venv/lib/python3.11/site-packages/click/core.py:1422`                          |
-|  90.5% | 51.6 MiB |  21,169 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339`                          |
-|  90.5% | 51.6 MiB |  21,167 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:853`                           |
-|  90.5% | 51.6 MiB |  21,166 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                      |
-|   2.3% | 1.31 MiB |     304 | `<module>`     | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                         |
-|   2.2% | 1.23 MiB |     233 | `<module>`     | `/venv/lib/python3.11/site-packages/click/core.py:1`                             |
-|   1.8% | 1.02 MiB |      24 | `<module>`     | `/venv/lib/python3.11/site-packages/click/formatting.py:1`                       |
-|   1.8% | 1.01 MiB |      11 | `<module>`     | `/venv/lib/python3.11/site-packages/click/parser.py:1`                           |
-|   0.2% |  137 KiB |     140 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`                   |
-|   0.2% |  125 KiB |     127 | `<module>`     | `/venv/lib/python3.11/site-packages/click/types.py:1`                            |
-|   0.2% | 93.8 KiB |     119 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`                      |
-|   0.2% | 91.5 KiB |     115 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`                     |
-|   0.1% | 65.5 KiB |      84 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`                 |
-|   0.1% | 63.6 KiB |      71 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                        |
-|   0.1% | 47.3 KiB |      33 | `decorator`    | `/venv/lib/python3.11/site-packages/click/decorators.py:373`                     |
-|   0.1% | 46.9 KiB |      59 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1` |
-|   0.1% | 45.5 KiB |      32 | `__init__`     | `/venv/lib/python3.11/site-packages/click/core.py:2883`                          |
-|   0.1% | 40.8 KiB |      42 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                      |
+|      % |     Size | Allocations | Function       | Location                                                                         |
+| -----: | -------: | ----------: | -------------- | -------------------------------------------------------------------------------- |
+| 100.0% | 57.1 MiB |      22,684 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40`                   |
+|  90.5% | 51.6 MiB |      21,189 | `__call__`     | `/venv/lib/python3.11/site-packages/click/core.py:1567`                          |
+|  90.5% | 51.6 MiB |      21,188 | `main`         | `/venv/lib/python3.11/site-packages/click/core.py:1422`                          |
+|  90.5% | 51.6 MiB |      21,169 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339`                          |
+|  90.5% | 51.6 MiB |      21,167 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:853`                           |
+|  90.5% | 51.6 MiB |      21,166 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                      |
+|   2.3% | 1.31 MiB |         304 | `<module>`     | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                         |
+|   2.2% | 1.23 MiB |         233 | `<module>`     | `/venv/lib/python3.11/site-packages/click/core.py:1`                             |
+|   1.8% | 1.02 MiB |          24 | `<module>`     | `/venv/lib/python3.11/site-packages/click/formatting.py:1`                       |
+|   1.8% | 1.01 MiB |          11 | `<module>`     | `/venv/lib/python3.11/site-packages/click/parser.py:1`                           |
+|   0.2% |  137 KiB |         140 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`                   |
+|   0.2% |  125 KiB |         127 | `<module>`     | `/venv/lib/python3.11/site-packages/click/types.py:1`                            |
+|   0.2% | 93.8 KiB |         119 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`                      |
+|   0.2% | 91.5 KiB |         115 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`                     |
+|   0.1% | 65.5 KiB |          84 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`                 |
+|   0.1% | 63.6 KiB |          71 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                        |
+|   0.1% | 47.3 KiB |          33 | `decorator`    | `/venv/lib/python3.11/site-packages/click/decorators.py:373`                     |
+|   0.1% | 46.9 KiB |          59 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1` |
+|   0.1% | 45.5 KiB |          32 | `__init__`     | `/venv/lib/python3.11/site-packages/click/core.py:2883`                          |
+|   0.1% | 40.8 KiB |          42 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                      |
 
 #### Callees
 
@@ -2500,376 +2500,376 @@ Callees ranked by contribution to each function's total size. Inlining can make 
 
 ##### `_run_tracker` (`/venv/lib/python3.11/site-packages/memray/commands/run.py:40`)
 
-|      % |     Size | Samples | Callee       | Location             |
-| -----: | -------: | ------: | ------------ | -------------------- |
-| 100.0% | 57.1 MiB |  22,683 | `run_module` | `<frozen runpy>:201` |
+|      % |     Size | Allocations | Callee       | Location             |
+| -----: | -------: | ----------: | ------------ | -------------------- |
+| 100.0% | 57.1 MiB |      22,683 | `run_module` | `<frozen runpy>:201` |
 
 ##### `run_module` (`<frozen runpy>:201`)
 
-|     % |     Size | Samples | Callee                | Location             |
-| ----: | -------: | ------: | --------------------- | -------------------- |
-| 90.5% | 51.6 MiB |  21,189 | `_run_module_code`    | `<frozen runpy>:91`  |
-|  9.5% | 5.42 MiB |   1,493 | `_get_module_details` | `<frozen runpy>:105` |
+|     % |     Size | Allocations | Callee                | Location             |
+| ----: | -------: | ----------: | --------------------- | -------------------- |
+| 90.5% | 51.6 MiB |      21,189 | `_run_module_code`    | `<frozen runpy>:91`  |
+|  9.5% | 5.42 MiB |       1,493 | `_get_module_details` | `<frozen runpy>:105` |
 
 ##### `__call__` (`/venv/lib/python3.11/site-packages/click/core.py:1567`)
 
-|      % |     Size | Samples | Callee | Location                                                |
-| -----: | -------: | ------: | ------ | ------------------------------------------------------- |
-| 100.0% | 51.6 MiB |  21,188 | `main` | `/venv/lib/python3.11/site-packages/click/core.py:1422` |
+|      % |     Size | Allocations | Callee | Location                                                |
+| -----: | -------: | ----------: | ------ | ------------------------------------------------------- |
+| 100.0% | 51.6 MiB |      21,188 | `main` | `/venv/lib/python3.11/site-packages/click/core.py:1422` |
 
 ##### `patched_main` (`black/__init__.py:1594`)
 
-|      % |     Size | Samples | Callee     | Location                                                |
-| -----: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 100.0% | 51.6 MiB |  21,189 | `__call__` | `/venv/lib/python3.11/site-packages/click/core.py:1567` |
+|      % |     Size | Allocations | Callee     | Location                                                |
+| -----: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 100.0% | 51.6 MiB |      21,189 | `__call__` | `/venv/lib/python3.11/site-packages/click/core.py:1567` |
 
 ##### `<module>` (`black/__main__.py:1`)
 
-|      % |     Size | Samples | Callee         | Location                 |
-| -----: | -------: | ------: | -------------- | ------------------------ |
-| 100.0% | 51.6 MiB |  21,189 | `patched_main` | `black/__init__.py:1594` |
+|      % |     Size | Allocations | Callee         | Location                 |
+| -----: | -------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 51.6 MiB |      21,189 | `patched_main` | `black/__init__.py:1594` |
 
 ##### `_run_code` (`<frozen runpy>:65`)
 
-|      % |     Size | Samples | Callee     | Location              |
-| -----: | -------: | ------: | ---------- | --------------------- |
-| 100.0% | 51.6 MiB |  21,189 | `<module>` | `black/__main__.py:1` |
+|      % |     Size | Allocations | Callee     | Location              |
+| -----: | -------: | ----------: | ---------- | --------------------- |
+| 100.0% | 51.6 MiB |      21,189 | `<module>` | `black/__main__.py:1` |
 
 ##### `_run_module_code` (`<frozen runpy>:91`)
 
-|      % |     Size | Samples | Callee      | Location            |
-| -----: | -------: | ------: | ----------- | ------------------- |
-| 100.0% | 51.6 MiB |  21,189 | `_run_code` | `<frozen runpy>:65` |
+|      % |     Size | Allocations | Callee      | Location            |
+| -----: | -------: | ----------: | ----------- | ------------------- |
+| 100.0% | 51.6 MiB |      21,189 | `_run_code` | `<frozen runpy>:65` |
 
 ##### `main` (`/venv/lib/python3.11/site-packages/click/core.py:1422`)
 
-|      % |     Size | Samples | Callee         | Location                                                |
-| -----: | -------: | ------: | -------------- | ------------------------------------------------------- |
-| 100.0% | 51.6 MiB |  21,169 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339` |
-|  <0.1% | 13.6 KiB |      16 | `make_context` | `/venv/lib/python3.11/site-packages/click/core.py:1266` |
-|  <0.1% |    529 B |       2 | `__exit__`     | `/venv/lib/python3.11/site-packages/click/core.py:550`  |
+|      % |     Size | Allocations | Callee         | Location                                                |
+| -----: | -------: | ----------: | -------------- | ------------------------------------------------------- |
+| 100.0% | 51.6 MiB |      21,169 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339` |
+|  <0.1% | 13.6 KiB |          16 | `make_context` | `/venv/lib/python3.11/site-packages/click/core.py:1266` |
+|  <0.1% |    529 B |           2 | `__exit__`     | `/venv/lib/python3.11/site-packages/click/core.py:550`  |
 
 ##### `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:1339`)
 
-|      % |     Size | Samples | Callee   | Location                                               |
-| -----: | -------: | ------: | -------- | ------------------------------------------------------ |
-| 100.0% | 51.6 MiB |  21,167 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
+|      % |     Size | Allocations | Callee   | Location                                               |
+| -----: | -------: | ----------: | -------- | ------------------------------------------------------ |
+| 100.0% | 51.6 MiB |      21,167 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
 
 ##### `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`)
 
-|      % |     Size | Samples | Callee     | Location                                                    |
-| -----: | -------: | ------: | ---------- | ----------------------------------------------------------- |
-| 100.0% | 51.6 MiB |  21,166 | `new_func` | `/venv/lib/python3.11/site-packages/click/decorators.py:33` |
+|      % |     Size | Allocations | Callee     | Location                                                    |
+| -----: | -------: | ----------: | ---------- | ----------------------------------------------------------- |
+| 100.0% | 51.6 MiB |      21,166 | `new_func` | `/venv/lib/python3.11/site-packages/click/decorators.py:33` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Callee | Location                |
-| -----: | -------: | ------: | ------ | ----------------------- |
-| 100.0% | 51.6 MiB |  21,164 | `main` | `black/__init__.py:244` |
+|      % |     Size | Allocations | Callee | Location                |
+| -----: | -------: | ----------: | ------ | ----------------------- |
+| 100.0% | 51.6 MiB |      21,164 | `main` | `black/__init__.py:244` |
 
 ##### `main` (`black/__init__.py:244`)
 
-|      % |     Size | Samples | Callee         | Location                |
-| -----: | -------: | ------: | -------------- | ----------------------- |
-| 100.0% | 51.6 MiB |  21,159 | `reformat_one` | `black/__init__.py:860` |
-|  <0.1% | 2.06 KiB |       2 | `get_sources`  | `black/__init__.py:724` |
+|      % |     Size | Allocations | Callee         | Location                |
+| -----: | -------: | ----------: | -------------- | ----------------------- |
+| 100.0% | 51.6 MiB |      21,159 | `reformat_one` | `black/__init__.py:860` |
+|  <0.1% | 2.06 KiB |           2 | `get_sources`  | `black/__init__.py:724` |
 
 ##### `reformat_one` (`black/__init__.py:860`)
 
-|      % |     Size | Samples | Callee                 | Location                |
-| -----: | -------: | ------: | ---------------------- | ----------------------- |
-| 100.0% | 51.6 MiB |  21,152 | `format_file_in_place` | `black/__init__.py:917` |
-|  <0.1% | 1.92 KiB |       2 | `done`                 | `black/report.py:36`    |
-|  <0.1% | 1.13 KiB |       1 | `read`                 | `black/cache.py:60`     |
-|  <0.1% |     72 B |       2 | `write`                | `black/cache.py:132`    |
+|      % |     Size | Allocations | Callee                 | Location                |
+| -----: | -------: | ----------: | ---------------------- | ----------------------- |
+| 100.0% | 51.6 MiB |      21,152 | `format_file_in_place` | `black/__init__.py:917` |
+|  <0.1% | 1.92 KiB |           2 | `done`                 | `black/report.py:36`    |
+|  <0.1% | 1.13 KiB |           1 | `read`                 | `black/cache.py:60`     |
+|  <0.1% |     72 B |           2 | `write`                | `black/cache.py:132`    |
 
 ##### `format_file_in_place` (`black/__init__.py:917`)
 
-|      % |     Size | Samples | Callee                 | Location                 |
-| -----: | -------: | ------: | ---------------------- | ------------------------ |
-| 100.0% | 51.6 MiB |  21,151 | `format_file_contents` | `black/__init__.py:1054` |
-|  <0.1% |    552 B |       1 | `decode_bytes`         | `black/__init__.py:1290` |
+|      % |     Size | Allocations | Callee                 | Location                 |
+| -----: | -------: | ----------: | ---------------------- | ------------------------ |
+| 100.0% | 51.6 MiB |      21,151 | `format_file_contents` | `black/__init__.py:1054` |
+|  <0.1% |    552 B |           1 | `decode_bytes`         | `black/__init__.py:1290` |
 
 ##### `format_file_contents` (`black/__init__.py:1054`)
 
-|     % |     Size | Samples | Callee                            | Location                 |
-| ----: | -------: | ------: | --------------------------------- | ------------------------ |
-| 66.0% | 34.1 MiB |      92 | `format_str`                      | `black/__init__.py:1189` |
-| 34.0% | 17.5 MiB |  21,059 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+|     % |     Size | Allocations | Callee                            | Location                 |
+| ----: | -------: | ----------: | --------------------------------- | ------------------------ |
+| 66.0% | 34.1 MiB |          92 | `format_str`                      | `black/__init__.py:1189` |
+| 34.0% | 17.5 MiB |      21,059 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
 
 ##### `_format_str_once` (`black/__init__.py:1236`)
 
-|     % |     Size | Samples | Callee              | Location                |
-| ----: | -------: | ------: | ------------------- | ----------------------- |
-| 67.4% | 33.4 MiB |  21,084 | `visit`             | `black/nodes.py:163`    |
-| 22.3% |   11 MiB |      30 | `lib2to3_parse`     | `black/parsing.py:55`   |
-|  8.2% | 4.08 MiB |      19 | `transform_line`    | `black/linegen.py:601`  |
-|  2.0% |    1 MiB |       3 | `maybe_empty_lines` | `black/lines.py:560`    |
-| <0.1% | 19.9 KiB |       3 | `normalize_fmt_off` | `black/comments.py:168` |
+|     % |     Size | Allocations | Callee              | Location                |
+| ----: | -------: | ----------: | ------------------- | ----------------------- |
+| 67.4% | 33.4 MiB |      21,084 | `visit`             | `black/nodes.py:163`    |
+| 22.3% |   11 MiB |          30 | `lib2to3_parse`     | `black/parsing.py:55`   |
+|  8.2% | 4.08 MiB |          19 | `transform_line`    | `black/linegen.py:601`  |
+|  2.0% |    1 MiB |           3 | `maybe_empty_lines` | `black/lines.py:560`    |
+| <0.1% | 19.9 KiB |           3 | `normalize_fmt_off` | `black/comments.py:168` |
 
 ##### `format_str` (`black/__init__.py:1189`)
 
-|      % |     Size | Samples | Callee             | Location                 |
-| -----: | -------: | ------: | ------------------ | ------------------------ |
-| 100.0% | 34.1 MiB |      91 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |     Size | Allocations | Callee             | Location                 |
+| -----: | -------: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 34.1 MiB |          91 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|      % |     Size | Samples | Callee              | Location               |
-| -----: | -------: | ------: | ------------------- | ---------------------- |
-| 100.0% | 33.4 MiB |  21,082 | `visit_default`     | `black/linegen.py:134` |
-|  99.2% | 33.2 MiB |  20,711 | `visit_stmt`        | `black/linegen.py:199` |
-|  98.1% | 32.8 MiB |  20,270 | `visit_funcdef`     | `black/linegen.py:254` |
-|  97.9% | 32.7 MiB |  20,144 | `visit_suite`       | `black/linegen.py:288` |
-|  68.3% | 22.8 MiB |  13,401 | `visit_simple_stmt` | `black/linegen.py:295` |
+|      % |     Size | Allocations | Callee              | Location               |
+| -----: | -------: | ----------: | ------------------- | ---------------------- |
+| 100.0% | 33.4 MiB |      21,082 | `visit_default`     | `black/linegen.py:134` |
+|  99.2% | 33.2 MiB |      20,711 | `visit_stmt`        | `black/linegen.py:199` |
+|  98.1% | 32.8 MiB |      20,270 | `visit_funcdef`     | `black/linegen.py:254` |
+|  97.9% | 32.7 MiB |      20,144 | `visit_suite`       | `black/linegen.py:288` |
+|  68.3% | 22.8 MiB |      13,401 | `visit_simple_stmt` | `black/linegen.py:295` |
 
 ##### `visit_default` (`black/nodes.py:187`)
 
-|      % |     Size | Samples | Callee  | Location             |
-| -----: | -------: | ------: | ------- | -------------------- |
-| 100.0% | 33.4 MiB |  21,082 | `visit` | `black/nodes.py:163` |
+|      % |     Size | Allocations | Callee  | Location             |
+| -----: | -------: | ----------: | ------- | -------------------- |
+| 100.0% | 33.4 MiB |      21,082 | `visit` | `black/nodes.py:163` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|      % |     Size | Samples | Callee              | Location               |
-| -----: | -------: | ------: | ------------------- | ---------------------- |
-| 100.0% | 33.4 MiB |  21,082 | `visit_default`     | `black/nodes.py:187`   |
-|  54.7% | 18.3 MiB |  20,883 | `append`            | `black/lines.py:63`    |
-|  20.9% |    7 MiB |       7 | `generate_comments` | `black/comments.py:52` |
+|      % |     Size | Allocations | Callee              | Location               |
+| -----: | -------: | ----------: | ------------------- | ---------------------- |
+| 100.0% | 33.4 MiB |      21,082 | `visit_default`     | `black/nodes.py:187`   |
+|  54.7% | 18.3 MiB |      20,883 | `append`            | `black/lines.py:63`    |
+|  20.9% |    7 MiB |           7 | `generate_comments` | `black/comments.py:52` |
 
 ##### `visit_stmt` (`black/linegen.py:199`)
 
-|      % |     Size | Samples | Callee                       | Location                |
-| -----: | -------: | ------: | ---------------------------- | ----------------------- |
-| 100.0% | 33.2 MiB |  20,709 | `visit`                      | `black/nodes.py:163`    |
-|   9.0% |    3 MiB |       4 | `normalize_invisible_parens` | `black/linegen.py:1328` |
+|      % |     Size | Allocations | Callee                       | Location                |
+| -----: | -------: | ----------: | ---------------------------- | ----------------------- |
+| 100.0% | 33.2 MiB |      20,709 | `visit`                      | `black/nodes.py:163`    |
+|   9.0% |    3 MiB |           4 | `normalize_invisible_parens` | `black/linegen.py:1328` |
 
 ##### `visit_funcdef` (`black/linegen.py:254`)
 
-|      % |     Size | Samples | Callee  | Location             |
-| -----: | -------: | ------: | ------- | -------------------- |
-| 100.0% | 32.8 MiB |  20,270 | `visit` | `black/nodes.py:163` |
+|      % |     Size | Allocations | Callee  | Location             |
+| -----: | -------: | ----------: | ------- | -------------------- |
+| 100.0% | 32.8 MiB |      20,270 | `visit` | `black/nodes.py:163` |
 
 ##### `visit_suite` (`black/linegen.py:288`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 32.7 MiB |  20,144 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 32.7 MiB |      20,144 | `visit_default` | `black/linegen.py:134` |
 
 ##### `visit_simple_stmt` (`black/linegen.py:295`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 22.8 MiB |  13,401 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 22.8 MiB |      13,401 | `visit_default` | `black/linegen.py:134` |
 
 ##### `append` (`black/lines.py:63`)
 
-|     % |     Size | Samples | Callee       | Location               |
-| ----: | -------: | ------: | ------------ | ---------------------- |
-| 88.7% | 16.2 MiB |  20,788 | `mark`       | `black/brackets.py:70` |
-| 11.2% | 2.05 MiB |      91 | `whitespace` | `black/nodes.py:194`   |
+|     % |     Size | Allocations | Callee       | Location               |
+| ----: | -------: | ----------: | ------------ | ---------------------- |
+| 88.7% | 16.2 MiB |      20,788 | `mark`       | `black/brackets.py:70` |
+| 11.2% | 2.05 MiB |          91 | `whitespace` | `black/nodes.py:194`   |
 
 ##### `check_stability_and_equivalence` (`black/__init__.py:1037`)
 
-|     % |     Size | Samples | Callee              | Location                 |
-| ----: | -------: | ------: | ------------------- | ------------------------ |
-| 88.6% | 15.5 MiB |  21,054 | `assert_stable`     | `black/__init__.py:1557` |
-| 11.4% | 2.01 MiB |       4 | `assert_equivalent` | `black/__init__.py:1524` |
+|     % |     Size | Allocations | Callee              | Location                 |
+| ----: | -------: | ----------: | ------------------- | ------------------------ |
+| 88.6% | 15.5 MiB |      21,054 | `assert_stable`     | `black/__init__.py:1557` |
+| 11.4% | 2.01 MiB |           4 | `assert_equivalent` | `black/__init__.py:1524` |
 
 ##### `visit_power` (`black/linegen.py:341`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 16.9 MiB |  10,807 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 16.9 MiB |      10,807 | `visit_default` | `black/linegen.py:134` |
 
 ##### `assert_stable` (`black/__init__.py:1557`)
 
-|      % |     Size | Samples | Callee             | Location                 |
-| -----: | -------: | ------: | ------------------ | ------------------------ |
-| 100.0% | 15.5 MiB |  21,054 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |     Size | Allocations | Callee             | Location                 |
+| -----: | -------: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 15.5 MiB |      21,054 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `_get_module_details` (`<frozen runpy>:105`)
 
-|     % |     Size | Samples | Callee                | Location                             |
-| ----: | -------: | ------: | --------------------- | ------------------------------------ |
-| 99.9% | 5.42 MiB |   1,486 | `_find_and_load`      | `<frozen importlib._bootstrap>:1167` |
-| 99.9% | 5.42 MiB |   1,486 | `_get_module_details` | `<frozen runpy>:105`                 |
-|  0.1% | 5.66 KiB |       6 | `find_spec`           | `<frozen importlib.util>:73`         |
+|     % |     Size | Allocations | Callee                | Location                             |
+| ----: | -------: | ----------: | --------------------- | ------------------------------------ |
+| 99.9% | 5.42 MiB |       1,486 | `_find_and_load`      | `<frozen importlib._bootstrap>:1167` |
+| 99.9% | 5.42 MiB |       1,486 | `_get_module_details` | `<frozen runpy>:105`                 |
+|  0.1% | 5.66 KiB |           6 | `find_spec`           | `<frozen importlib.util>:73`         |
 
 ##### `_find_and_load` (`<frozen importlib._bootstrap>:1167`)
 
-|      % |     Size | Samples | Callee                    | Location                             |
-| -----: | -------: | ------: | ------------------------- | ------------------------------------ |
-| 100.0% | 5.42 MiB |   1,484 | `_find_and_load_unlocked` | `<frozen importlib._bootstrap>:1122` |
-|  <0.1% |    560 B |       1 | `__enter__`               | `<frozen importlib._bootstrap>:169`  |
+|      % |     Size | Allocations | Callee                    | Location                             |
+| -----: | -------: | ----------: | ------------------------- | ------------------------------------ |
+| 100.0% | 5.42 MiB |       1,484 | `_find_and_load_unlocked` | `<frozen importlib._bootstrap>:1122` |
+|  <0.1% |    560 B |           1 | `__enter__`               | `<frozen importlib._bootstrap>:169`  |
 
 ##### `_find_and_load_unlocked` (`<frozen importlib._bootstrap>:1122`)
 
-|      % |     Size | Samples | Callee                      | Location                             |
-| -----: | -------: | ------: | --------------------------- | ------------------------------------ |
-| 100.0% | 5.42 MiB |   1,483 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`  |
-|   0.7% | 37.2 KiB |      47 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`  |
-|   0.1% | 7.48 KiB |       4 | `_find_spec`                | `<frozen importlib._bootstrap>:1056` |
+|      % |     Size | Allocations | Callee                      | Location                             |
+| -----: | -------: | ----------: | --------------------------- | ------------------------------------ |
+| 100.0% | 5.42 MiB |       1,483 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`  |
+|   0.7% | 37.2 KiB |          47 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`  |
+|   0.1% | 7.48 KiB |           4 | `_find_spec`                | `<frozen importlib._bootstrap>:1056` |
 
 ##### `_load_unlocked` (`<frozen importlib._bootstrap>:666`)
 
-|      % |     Size | Samples | Callee             | Location                                     |
-| -----: | -------: | ------: | ------------------ | -------------------------------------------- |
-| 100.0% | 5.41 MiB |   1,481 | `exec_module`      | `<frozen importlib._bootstrap_external>:934` |
-|  <0.1% | 1.83 KiB |       2 | `module_from_spec` | `<frozen importlib._bootstrap>:566`          |
+|      % |     Size | Allocations | Callee             | Location                                     |
+| -----: | -------: | ----------: | ------------------ | -------------------------------------------- |
+| 100.0% | 5.41 MiB |       1,481 | `exec_module`      | `<frozen importlib._bootstrap_external>:934` |
+|  <0.1% | 1.83 KiB |           2 | `module_from_spec` | `<frozen importlib._bootstrap>:566`          |
 
 ##### `exec_module` (`<frozen importlib._bootstrap_external>:934`)
 
-|     % |     Size | Samples | Callee                      | Location                                      |
-| ----: | -------: | ------: | --------------------------- | --------------------------------------------- |
-| 99.1% | 5.37 MiB |   1,435 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
-| 49.6% | 2.69 MiB |     802 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
+|     % |     Size | Allocations | Callee                      | Location                                      |
+| ----: | -------: | ----------: | --------------------------- | --------------------------------------------- |
+| 99.1% | 5.37 MiB |       1,435 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
+| 49.6% | 2.69 MiB |         802 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`)
 
-|     % |     Size | Samples | Callee     | Location                                                 |
-| ----: | -------: | ------: | ---------- | -------------------------------------------------------- |
-| 99.4% | 5.37 MiB |   1,435 | `<module>` | `black/__init__.py:1`                                    |
-| 43.3% | 2.34 MiB |     316 | `<module>` | `black/comments.py:1`                                    |
-| 24.4% | 1.32 MiB |     295 | `<module>` | `black/nodes.py:1`                                       |
-| 24.2% | 1.31 MiB |     304 | `<module>` | `/venv/lib/python3.11/site-packages/click/__init__.py:1` |
-| 22.8% | 1.23 MiB |     233 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`     |
+|     % |     Size | Allocations | Callee     | Location                                                 |
+| ----: | -------: | ----------: | ---------- | -------------------------------------------------------- |
+| 99.4% | 5.37 MiB |       1,435 | `<module>` | `black/__init__.py:1`                                    |
+| 43.3% | 2.34 MiB |         316 | `<module>` | `black/comments.py:1`                                    |
+| 24.4% | 1.32 MiB |         295 | `<module>` | `black/nodes.py:1`                                       |
+| 24.2% | 1.31 MiB |         304 | `<module>` | `/venv/lib/python3.11/site-packages/click/__init__.py:1` |
+| 22.8% | 1.23 MiB |         233 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`     |
 
 ##### `get_code` (`<frozen importlib._bootstrap_external>:1007`)
 
-|     % |     Size | Samples | Callee                   | Location                                      |
-| ----: | -------: | ------: | ------------------------ | --------------------------------------------- |
-| 84.6% | 2.27 MiB |     352 | `source_to_code`         | `<frozen importlib._bootstrap_external>:999`  |
-| 11.3% |  311 KiB |     341 | `_compile_bytecode`      | `<frozen importlib._bootstrap_external>:727`  |
-|  4.1% |  112 KiB |     108 | `_code_to_timestamp_pyc` | `<frozen importlib._bootstrap_external>:740`  |
-| <0.1% |    624 B |       1 | `_cache_bytecode`        | `<frozen importlib._bootstrap_external>:1151` |
+|     % |     Size | Allocations | Callee                   | Location                                      |
+| ----: | -------: | ----------: | ------------------------ | --------------------------------------------- |
+| 84.6% | 2.27 MiB |         352 | `source_to_code`         | `<frozen importlib._bootstrap_external>:999`  |
+| 11.3% |  311 KiB |         341 | `_compile_bytecode`      | `<frozen importlib._bootstrap_external>:727`  |
+|  4.1% |  112 KiB |         108 | `_code_to_timestamp_pyc` | `<frozen importlib._bootstrap_external>:740`  |
+| <0.1% |    624 B |           1 | `_cache_bytecode`        | `<frozen importlib._bootstrap_external>:1151` |
 
 ##### `source_to_code` (`<frozen importlib._bootstrap_external>:999`)
 
-|      % |     Size | Samples | Callee                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.27 MiB |     352 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Callee                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.27 MiB |         352 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|     % |    Size | Samples | Callee           | Location                             |
-| ----: | ------: | ------: | ---------------- | ------------------------------------ |
-| 99.8% | 1.3 MiB |     303 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |    Size | Allocations | Callee           | Location                             |
+| ----: | ------: | ----------: | ---------------- | ------------------------------------ |
+| 99.8% | 1.3 MiB |         303 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|     % |     Size | Samples | Callee             | Location                                               |
-| ----: | -------: | ------: | ------------------ | ------------------------------------------------------ |
-| 85.5% | 1.05 MiB |      53 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167`                   |
-| 11.1% |  140 KiB |     145 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209`                   |
-|  1.1% | 13.9 KiB |       9 | `__new__`          | `<frozen abc>:105`                                     |
-|  0.2% | 2.49 KiB |       3 | `__new__`          | `/usr/lib/python3.11/enum.py:488`                      |
-|  0.1% |    768 B |       1 | `Context`          | `/venv/lib/python3.11/site-packages/click/core.py:204` |
+|     % |     Size | Allocations | Callee             | Location                                               |
+| ----: | -------: | ----------: | ------------------ | ------------------------------------------------------ |
+| 85.5% | 1.05 MiB |          53 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167`                   |
+| 11.1% |  140 KiB |         145 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209`                   |
+|  1.1% | 13.9 KiB |           9 | `__new__`          | `<frozen abc>:105`                                     |
+|  0.2% | 2.49 KiB |           3 | `__new__`          | `/usr/lib/python3.11/enum.py:488`                      |
+|  0.1% |    768 B |           1 | `Context`          | `/venv/lib/python3.11/site-packages/click/core.py:204` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 99.8% | 1.02 MiB |      22 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 99.8% | 1.02 MiB |          22 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `_handle_fromlist` (`<frozen importlib._bootstrap>:1209`)
 
-|      % |    Size | Samples | Callee                      | Location                            |
-| -----: | ------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 333 KiB |     341 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |    Size | Allocations | Callee                      | Location                            |
+| -----: | ------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 333 KiB |         341 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                                                         |
-| ----: | -------: | ------: | ---------------- | ---------------------------------------------------------------- |
-| 87.6% |  120 KiB |     129 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                             |
-|  6.2% |  8.5 KiB |       2 | `Specifier`      | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220` |
-|  4.4% | 6.07 KiB |       7 | `__new__`        | `<frozen abc>:105`                                               |
+|     % |     Size | Allocations | Callee           | Location                                                         |
+| ----: | -------: | ----------: | ---------------- | ---------------------------------------------------------------- |
+| 87.6% |  120 KiB |         129 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                             |
+|  6.2% |  8.5 KiB |           2 | `Specifier`      | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220` |
+|  4.4% | 6.07 KiB |           7 | `__new__`        | `<frozen abc>:105`                                               |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 53.0% | 66.2 KiB |      58 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
-| 30.6% | 38.2 KiB |      45 | `__new__`        | `<frozen abc>:105`                   |
-| 12.6% | 15.7 KiB |      19 | `__new__`        | `/usr/lib/python3.11/typing.py:2891` |
-|  1.1% | 1.42 KiB |       2 | `inner`          | `/usr/lib/python3.11/typing.py:338`  |
-|  0.4% |    542 B |       1 | `__init__`       | `/usr/lib/python3.11/typing.py:992`  |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 53.0% | 66.2 KiB |          58 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+| 30.6% | 38.2 KiB |          45 | `__new__`        | `<frozen abc>:105`                   |
+| 12.6% | 15.7 KiB |          19 | `__new__`        | `/usr/lib/python3.11/typing.py:2891` |
+|  1.1% | 1.42 KiB |           2 | `inner`          | `/usr/lib/python3.11/typing.py:338`  |
+|  0.4% |    542 B |           1 | `__init__`       | `/usr/lib/python3.11/typing.py:992`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 99.2% | 93.1 KiB |     118 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 99.2% | 93.1 KiB |         118 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`)
 
-|     % |   Size | Samples | Callee           | Location                             |
-| ----: | -----: | ------: | ---------------- | ------------------------------------ |
-| 97.3% | 89 KiB |     112 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |   Size | Allocations | Callee           | Location                             |
+| ----: | -----: | ----------: | ---------------- | ------------------------------------ |
+| 97.3% | 89 KiB |         112 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 98.9% | 64.8 KiB |      83 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 98.9% | 64.8 KiB |          83 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|     % |   Size | Samples | Callee           | Location                             |
-| ----: | -----: | ------: | ---------------- | ------------------------------------ |
-| 94.4% | 60 KiB |      67 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |   Size | Allocations | Callee           | Location                             |
+| ----: | -----: | ----------: | ---------------- | ------------------------------------ |
+| 94.4% | 60 KiB |          67 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `compile` (`/usr/lib/python3.11/re/__init__.py:225`)
 
-|     % |     Size | Samples | Callee     | Location                                 |
-| ----: | -------: | ------: | ---------- | ---------------------------------------- |
-| 98.6% | 47.1 KiB |      24 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
+|     % |     Size | Allocations | Callee     | Location                                 |
+| ----: | -------: | ----------: | ---------- | ---------------------------------------- |
+| 98.6% | 47.1 KiB |          24 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
 
 ##### `decorator` (`/venv/lib/python3.11/site-packages/click/decorators.py:373`)
 
-|     % |     Size | Samples | Callee     | Location                                                |
-| ----: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 96.2% | 45.5 KiB |      32 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2883` |
+|     % |     Size | Allocations | Callee     | Location                                                |
+| ----: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 96.2% | 45.5 KiB |          32 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2883` |
 
 ##### `_compile` (`/usr/lib/python3.11/re/__init__.py:272`)
 
-|     % |     Size | Samples | Callee    | Location                                  |
-| ----: | -------: | ------: | --------- | ----------------------------------------- |
-| 98.6% | 46.5 KiB |      23 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
-|  1.4% |    698 B |       1 | `__and__` | `/usr/lib/python3.11/enum.py:1504`        |
+|     % |     Size | Allocations | Callee    | Location                                  |
+| ----: | -------: | ----------: | --------- | ----------------------------------------- |
+| 98.6% | 46.5 KiB |          23 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
+|  1.4% |    698 B |           1 | `__and__` | `/usr/lib/python3.11/enum.py:1504`        |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 94.8% | 44.5 KiB |      56 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 94.8% | 44.5 KiB |          56 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|     % |     Size | Samples | Callee  | Location                                  |
-| ----: | -------: | ------: | ------- | ----------------------------------------- |
-| 31.0% | 14.4 KiB |       5 | `parse` | `/usr/lib/python3.11/re/_parser.py:970`   |
-| 20.4% |  9.5 KiB |       6 | `_code` | `/usr/lib/python3.11/re/_compiler.py:571` |
+|     % |     Size | Allocations | Callee  | Location                                  |
+| ----: | -------: | ----------: | ------- | ----------------------------------------- |
+| 31.0% | 14.4 KiB |           5 | `parse` | `/usr/lib/python3.11/re/_parser.py:970`   |
+| 20.4% |  9.5 KiB |           6 | `_code` | `/usr/lib/python3.11/re/_compiler.py:571` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|    % |     Size | Samples | Callee     | Location                                                |
-| ---: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 2.6% | 1.17 KiB |       1 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2237` |
+|    % |     Size | Allocations | Callee     | Location                                                |
+| ---: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 2.6% | 1.17 KiB |           1 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2237` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 80.6% | 32.9 KiB |      35 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
-|  4.1% | 1.69 KiB |       2 | `__new__`        | `/usr/lib/python3.11/enum.py:488`    |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 80.6% | 32.9 KiB |          35 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|  4.1% | 1.69 KiB |           2 | `__new__`        | `/usr/lib/python3.11/enum.py:488`    |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/__init__.py:1`)
 
-|      % |   Size | Samples | Callee           | Location                             |
-| -----: | -----: | ------: | ---------------- | ------------------------------------ |
-| 100.0% | 35 KiB |      32 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|      % |   Size | Allocations | Callee           | Location                             |
+| -----: | -----: | ----------: | ---------------- | ------------------------------------ |
+| 100.0% | 35 KiB |          32 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ## Hottest call stacks
 
@@ -2877,25 +2877,25 @@ Call stacks ranked by bytes never freed in their leaf frame.
 
 Common call stack: `run_module` (`<frozen runpy>:201`) ← `_run_tracker` (`/venv/lib/python3.11/site-packages/memray/commands/run.py:40`)
 
-|    % |     Size | Samples | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| ---: | -------: | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 8.8% |    5 MiB |       5 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `shift` (`blib2to3/pgen2/parse.py:373`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| 5.3% |    3 MiB |       6 | `transform_line` (`black/linegen.py:601`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| 3.5% | 2.01 MiB |       3 | `parse` (`/usr/lib/python3.11/ast.py:33`) ← `_parse_single_version` (`black/parsing.py:117`) ← `parse_ast` (129) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| 3.5% |    2 MiB |       2 | `push` (`blib2to3/pgen2/parse.py:386`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| 3.5% |    2 MiB |       2 | `convert` (`blib2to3/pytree.py:486`) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| 1.9% | 1.07 MiB |      96 | `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `source_to_code` (`<frozen importlib._bootstrap_external>:999`) ← `get_code` (1007) ← `exec_module` (934) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| 1.8% | 1.01 MiB |       6 | `make_grammar` (`blib2to3/pgen2/pgen.py:49`) ← `generate_grammar` (426) ← `load_grammar` (`blib2to3/pgen2/driver.py:246`) ← `load_packaged_grammar` (280) ← `initialize` (`blib2to3/pygram.py:165`) ← `<module>` (`black/nodes.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| 1.8% | 1.01 MiB |      15 | `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `source_to_code` (`<frozen importlib._bootstrap_external>:999`) ← `get_code` (1007) ← `exec_module` (934) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| 1.8% | 1.01 MiB |      11 | `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| 1.8% |    1 MiB |       2 | `maybe_empty_lines` (`black/lines.py:560`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| 1.8% |    1 MiB |       1 | `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| 1.8% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `preceding_leaf` (`black/nodes.py:441`) ← `whitespace` (194) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| 1.8% |    1 MiB |       1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit_NUMBER` (505) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                |
-| 1.8% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
-| 1.8% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                         |
-| 1.8% |    1 MiB |       1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_test` (160) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| 1.8% |    1 MiB |       1 | `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                      |
-| 1.8% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `wrap_in_parentheses` (`black/nodes.py:935`) ← `normalize_invisible_parens` (`black/linegen.py:1328`) ← `visit_stmt` (199) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| 1.8% |    1 MiB |       1 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| 1.8% |    1 MiB |       1 | `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+|    % |     Size | Allocations | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ---: | -------: | ----------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 8.8% |    5 MiB |           5 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `shift` (`blib2to3/pgen2/parse.py:373`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| 5.3% |    3 MiB |           6 | `transform_line` (`black/linegen.py:601`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| 3.5% | 2.01 MiB |           3 | `parse` (`/usr/lib/python3.11/ast.py:33`) ← `_parse_single_version` (`black/parsing.py:117`) ← `parse_ast` (129) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| 3.5% |    2 MiB |           2 | `push` (`blib2to3/pgen2/parse.py:386`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| 3.5% |    2 MiB |           2 | `convert` (`blib2to3/pytree.py:486`) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| 1.9% | 1.07 MiB |          96 | `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `source_to_code` (`<frozen importlib._bootstrap_external>:999`) ← `get_code` (1007) ← `exec_module` (934) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| 1.8% | 1.01 MiB |           6 | `make_grammar` (`blib2to3/pgen2/pgen.py:49`) ← `generate_grammar` (426) ← `load_grammar` (`blib2to3/pgen2/driver.py:246`) ← `load_packaged_grammar` (280) ← `initialize` (`blib2to3/pygram.py:165`) ← `<module>` (`black/nodes.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| 1.8% | 1.01 MiB |          15 | `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `source_to_code` (`<frozen importlib._bootstrap_external>:999`) ← `get_code` (1007) ← `exec_module` (934) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| 1.8% | 1.01 MiB |          11 | `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| 1.8% |    1 MiB |           2 | `maybe_empty_lines` (`black/lines.py:560`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| 1.8% |    1 MiB |           1 | `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| 1.8% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `preceding_leaf` (`black/nodes.py:441`) ← `whitespace` (194) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| 1.8% |    1 MiB |           1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit_NUMBER` (505) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                |
+| 1.8% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
+| 1.8% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                         |
+| 1.8% |    1 MiB |           1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_test` (160) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| 1.8% |    1 MiB |           1 | `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                      |
+| 1.8% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `wrap_in_parentheses` (`black/nodes.py:935`) ← `normalize_invisible_parens` (`black/linegen.py:1328`) ← `visit_stmt` (199) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| 1.8% |    1 MiB |           1 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| 1.8% |    1 MiB |           1 | `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |

--- a/examples/output/python.memray.current.memray.bin.md
+++ b/examples/output/python.memray.current.memray.bin.md
@@ -1,12 +1,12 @@
 # Peak memory profile
 
-Held 72.4 MiB over 23,696 samples (3.13 KiB per sample).
+Held 72.4 MiB over 23,696 allocations (3.13 KiB per allocation).
 
-| Category         |     % |     Size | Samples |
-| ---------------- | ----: | -------: | ------: |
-| Ours             | 71.8% |   52 MiB |  21,382 |
-| Standard library | 26.4% | 19.1 MiB |   2,080 |
-| Third-party      |  1.8% | 1.27 MiB |     234 |
+| Category         |     % |     Size | Allocations |
+| ---------------- | ----: | -------: | ----------: |
+| Ours             | 71.8% |   52 MiB |      21,382 |
+| Standard library | 26.4% | 19.1 MiB |       2,080 |
+| Third-party      |  1.8% | 1.27 MiB |         234 |
 
 ## Hottest functions
 
@@ -14,105 +14,105 @@ Held 72.4 MiB over 23,696 samples (3.13 KiB per sample).
 
 Functions ranked by bytes held at peak memory directly in the function body, excluding callees.
 
-|     % |     Size | Samples | Function                           | Location                                               |
-| ----: | -------: | ------: | ---------------------------------- | ------------------------------------------------------ |
-| 26.5% | 19.2 MiB |  20,791 | `mark`                             | `black/brackets.py:70`                                 |
-| 22.0% |   16 MiB |   1,014 | `parse`                            | `/usr/lib/python3.11/ast.py:33`                        |
-|  9.7% |    7 MiB |       7 | `changed`                          | `blib2to3/pytree.py:171`                               |
-|  6.9% |    5 MiB |       5 | `__new__`                          | `blib2to3/pytree.py:81`                                |
-|  4.3% | 3.14 MiB |     198 | `update_sibling_maps`              | `blib2to3/pytree.py:369`                               |
-|  4.1% |    3 MiB |       8 | `transform_line`                   | `black/linegen.py:601`                                 |
-|  3.1% | 2.27 MiB |     352 | `_call_with_frames_removed`        | `<frozen importlib._bootstrap>:233`                    |
-|  2.8% |    2 MiB |       2 | `convert`                          | `blib2to3/pytree.py:486`                               |
-|  2.8% |    2 MiB |       2 | `_addtoken`                        | `blib2to3/pgen2/parse.py:290`                          |
-|  2.8% |    2 MiB |       2 | `generate_comments`                | `black/comments.py:52`                                 |
-|  1.4% | 1.01 MiB |       6 | `make_grammar`                     | `blib2to3/pgen2/pgen.py:49`                            |
-|  1.4% | 1.01 MiB |      11 | `<module>`                         | `/venv/lib/python3.11/site-packages/click/parser.py:1` |
-|  1.4% |    1 MiB |       5 | `visit`                            | `black/nodes.py:163`                                   |
-|  1.4% |    1 MiB |       3 | `addtoken`                         | `blib2to3/pgen2/parse.py:242`                          |
-|  1.4% |    1 MiB |       2 | `visit_default`                    | `black/linegen.py:134`                                 |
-|  1.4% |    1 MiB |       1 | `pop`                              | `blib2to3/pgen2/parse.py:398`                          |
-|  1.4% |    1 MiB |       1 | `lines_with_leading_tabs_expanded` | `black/strings.py:46`                                  |
-|  1.4% |    1 MiB |       1 | `is_import`                        | `black/lines.py:134`                                   |
-|  1.4% |    1 MiB |       1 | `__init__`                         | `<string>:2`                                           |
-|  0.4% |  311 KiB |     341 | `_compile_bytecode`                | `<frozen importlib._bootstrap_external>:727`           |
+|     % |     Size | Allocations | Function                           | Location                                               |
+| ----: | -------: | ----------: | ---------------------------------- | ------------------------------------------------------ |
+| 26.5% | 19.2 MiB |      20,791 | `mark`                             | `black/brackets.py:70`                                 |
+| 22.0% |   16 MiB |       1,014 | `parse`                            | `/usr/lib/python3.11/ast.py:33`                        |
+|  9.7% |    7 MiB |           7 | `changed`                          | `blib2to3/pytree.py:171`                               |
+|  6.9% |    5 MiB |           5 | `__new__`                          | `blib2to3/pytree.py:81`                                |
+|  4.3% | 3.14 MiB |         198 | `update_sibling_maps`              | `blib2to3/pytree.py:369`                               |
+|  4.1% |    3 MiB |           8 | `transform_line`                   | `black/linegen.py:601`                                 |
+|  3.1% | 2.27 MiB |         352 | `_call_with_frames_removed`        | `<frozen importlib._bootstrap>:233`                    |
+|  2.8% |    2 MiB |           2 | `convert`                          | `blib2to3/pytree.py:486`                               |
+|  2.8% |    2 MiB |           2 | `_addtoken`                        | `blib2to3/pgen2/parse.py:290`                          |
+|  2.8% |    2 MiB |           2 | `generate_comments`                | `black/comments.py:52`                                 |
+|  1.4% | 1.01 MiB |           6 | `make_grammar`                     | `blib2to3/pgen2/pgen.py:49`                            |
+|  1.4% | 1.01 MiB |          11 | `<module>`                         | `/venv/lib/python3.11/site-packages/click/parser.py:1` |
+|  1.4% |    1 MiB |           5 | `visit`                            | `black/nodes.py:163`                                   |
+|  1.4% |    1 MiB |           3 | `addtoken`                         | `blib2to3/pgen2/parse.py:242`                          |
+|  1.4% |    1 MiB |           2 | `visit_default`                    | `black/linegen.py:134`                                 |
+|  1.4% |    1 MiB |           1 | `pop`                              | `blib2to3/pgen2/parse.py:398`                          |
+|  1.4% |    1 MiB |           1 | `lines_with_leading_tabs_expanded` | `black/strings.py:46`                                  |
+|  1.4% |    1 MiB |           1 | `is_import`                        | `black/lines.py:134`                                   |
+|  1.4% |    1 MiB |           1 | `__init__`                         | `<string>:2`                                           |
+|  0.4% |  311 KiB |         341 | `_compile_bytecode`                | `<frozen importlib._bootstrap_external>:727`           |
 
 #### Categories
 
 ##### Ours
 
-|     % |     Size | Samples | Function                           | Location                        |
-| ----: | -------: | ------: | ---------------------------------- | ------------------------------- |
-| 26.5% | 19.2 MiB |  20,791 | `mark`                             | `black/brackets.py:70`          |
-|  9.7% |    7 MiB |       7 | `changed`                          | `blib2to3/pytree.py:171`        |
-|  6.9% |    5 MiB |       5 | `__new__`                          | `blib2to3/pytree.py:81`         |
-|  4.3% | 3.14 MiB |     198 | `update_sibling_maps`              | `blib2to3/pytree.py:369`        |
-|  4.1% |    3 MiB |       8 | `transform_line`                   | `black/linegen.py:601`          |
-|  2.8% |    2 MiB |       2 | `convert`                          | `blib2to3/pytree.py:486`        |
-|  2.8% |    2 MiB |       2 | `_addtoken`                        | `blib2to3/pgen2/parse.py:290`   |
-|  2.8% |    2 MiB |       2 | `generate_comments`                | `black/comments.py:52`          |
-|  1.4% | 1.01 MiB |       6 | `make_grammar`                     | `blib2to3/pgen2/pgen.py:49`     |
-|  1.4% |    1 MiB |       5 | `visit`                            | `black/nodes.py:163`            |
-|  1.4% |    1 MiB |       3 | `addtoken`                         | `blib2to3/pgen2/parse.py:242`   |
-|  1.4% |    1 MiB |       2 | `visit_default`                    | `black/linegen.py:134`          |
-|  1.4% |    1 MiB |       1 | `pop`                              | `blib2to3/pgen2/parse.py:398`   |
-|  1.4% |    1 MiB |       1 | `lines_with_leading_tabs_expanded` | `black/strings.py:46`           |
-|  1.4% |    1 MiB |       1 | `is_import`                        | `black/lines.py:134`            |
-|  1.4% |    1 MiB |       1 | `__init__`                         | `<string>:2`                    |
-|  0.3% |  225 KiB |       5 | `_format_str_once`                 | `black/__init__.py:1236`        |
-|  0.1% | 57.2 KiB |      65 | `normalize_string_prefix`          | `black/strings.py:143`          |
-|  0.1% | 41.5 KiB |      16 | `copy`                             | `blib2to3/pgen2/grammar.py:131` |
-| <0.1% |   32 KiB |       1 | `classify`                         | `blib2to3/pgen2/parse.py:336`   |
+|     % |     Size | Allocations | Function                           | Location                        |
+| ----: | -------: | ----------: | ---------------------------------- | ------------------------------- |
+| 26.5% | 19.2 MiB |      20,791 | `mark`                             | `black/brackets.py:70`          |
+|  9.7% |    7 MiB |           7 | `changed`                          | `blib2to3/pytree.py:171`        |
+|  6.9% |    5 MiB |           5 | `__new__`                          | `blib2to3/pytree.py:81`         |
+|  4.3% | 3.14 MiB |         198 | `update_sibling_maps`              | `blib2to3/pytree.py:369`        |
+|  4.1% |    3 MiB |           8 | `transform_line`                   | `black/linegen.py:601`          |
+|  2.8% |    2 MiB |           2 | `convert`                          | `blib2to3/pytree.py:486`        |
+|  2.8% |    2 MiB |           2 | `_addtoken`                        | `blib2to3/pgen2/parse.py:290`   |
+|  2.8% |    2 MiB |           2 | `generate_comments`                | `black/comments.py:52`          |
+|  1.4% | 1.01 MiB |           6 | `make_grammar`                     | `blib2to3/pgen2/pgen.py:49`     |
+|  1.4% |    1 MiB |           5 | `visit`                            | `black/nodes.py:163`            |
+|  1.4% |    1 MiB |           3 | `addtoken`                         | `blib2to3/pgen2/parse.py:242`   |
+|  1.4% |    1 MiB |           2 | `visit_default`                    | `black/linegen.py:134`          |
+|  1.4% |    1 MiB |           1 | `pop`                              | `blib2to3/pgen2/parse.py:398`   |
+|  1.4% |    1 MiB |           1 | `lines_with_leading_tabs_expanded` | `black/strings.py:46`           |
+|  1.4% |    1 MiB |           1 | `is_import`                        | `black/lines.py:134`            |
+|  1.4% |    1 MiB |           1 | `__init__`                         | `<string>:2`                    |
+|  0.3% |  225 KiB |           5 | `_format_str_once`                 | `black/__init__.py:1236`        |
+|  0.1% | 57.2 KiB |          65 | `normalize_string_prefix`          | `black/strings.py:143`          |
+|  0.1% | 41.5 KiB |          16 | `copy`                             | `blib2to3/pgen2/grammar.py:131` |
+| <0.1% |   32 KiB |           1 | `classify`                         | `blib2to3/pgen2/parse.py:336`   |
 
 ##### Standard library
 
-|     % |     Size | Samples | Function                    | Location                                          |
-| ----: | -------: | ------: | --------------------------- | ------------------------------------------------- |
-| 22.0% |   16 MiB |   1,014 | `parse`                     | `/usr/lib/python3.11/ast.py:33`                   |
-|  3.1% | 2.27 MiB |     352 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`               |
-|  0.4% |  311 KiB |     341 | `_compile_bytecode`         | `<frozen importlib._bootstrap_external>:727`      |
-|  0.3% |  222 KiB |       1 | `decode`                    | `<frozen codecs>:319`                             |
-|  0.2% |  112 KiB |     108 | `_code_to_timestamp_pyc`    | `<frozen importlib._bootstrap_external>:740`      |
-|  0.1% | 75.7 KiB |      79 | `__new__`                   | `<frozen abc>:105`                                |
-| <0.1% | 24.1 KiB |      27 | `__new__`                   | `/usr/lib/python3.11/enum.py:488`                 |
-| <0.1% | 22.6 KiB |      12 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`         |
-| <0.1% | 19.8 KiB |      12 | `<module>`                  | `/usr/lib/python3.11/tomllib/_parser.py:1`        |
-| <0.1% | 17.4 KiB |      21 | `__new__`                   | `/usr/lib/python3.11/typing.py:2891`              |
-| <0.1% |   12 KiB |       3 | `inner`                     | `/usr/lib/python3.11/typing.py:338`               |
-| <0.1% |    8 KiB |       4 | `_fill_cache`               | `<frozen importlib._bootstrap_external>:1655`     |
-| <0.1% | 7.97 KiB |       1 | `_parse_sub`                | `/usr/lib/python3.11/re/_parser.py:447`           |
-| <0.1% | 6.73 KiB |       8 | `__setattr__`               | `/usr/lib/python3.11/enum.py:831`                 |
-| <0.1% | 5.63 KiB |       6 | `namedtuple`                | `/usr/lib/python3.11/collections/__init__.py:348` |
-| <0.1% | 5.61 KiB |       3 | `_parse`                    | `/usr/lib/python3.11/re/_parser.py:507`           |
-| <0.1% | 5.32 KiB |       2 | `_code`                     | `/usr/lib/python3.11/re/_compiler.py:571`         |
-| <0.1% | 4.73 KiB |       6 | `<module>`                  | `/usr/lib/python3.11/pkgutil.py:1`                |
-| <0.1% | 2.85 KiB |       1 | `wrap`                      | `/usr/lib/python3.11/dataclasses.py:1209`         |
-| <0.1% | 2.85 KiB |       4 | `_process_class`            | `/usr/lib/python3.11/dataclasses.py:884`          |
+|     % |     Size | Allocations | Function                    | Location                                          |
+| ----: | -------: | ----------: | --------------------------- | ------------------------------------------------- |
+| 22.0% |   16 MiB |       1,014 | `parse`                     | `/usr/lib/python3.11/ast.py:33`                   |
+|  3.1% | 2.27 MiB |         352 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`               |
+|  0.4% |  311 KiB |         341 | `_compile_bytecode`         | `<frozen importlib._bootstrap_external>:727`      |
+|  0.3% |  222 KiB |           1 | `decode`                    | `<frozen codecs>:319`                             |
+|  0.2% |  112 KiB |         108 | `_code_to_timestamp_pyc`    | `<frozen importlib._bootstrap_external>:740`      |
+|  0.1% | 75.7 KiB |          79 | `__new__`                   | `<frozen abc>:105`                                |
+| <0.1% | 24.1 KiB |          27 | `__new__`                   | `/usr/lib/python3.11/enum.py:488`                 |
+| <0.1% | 22.6 KiB |          12 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`         |
+| <0.1% | 19.8 KiB |          12 | `<module>`                  | `/usr/lib/python3.11/tomllib/_parser.py:1`        |
+| <0.1% | 17.4 KiB |          21 | `__new__`                   | `/usr/lib/python3.11/typing.py:2891`              |
+| <0.1% |   12 KiB |           3 | `inner`                     | `/usr/lib/python3.11/typing.py:338`               |
+| <0.1% |    8 KiB |           4 | `_fill_cache`               | `<frozen importlib._bootstrap_external>:1655`     |
+| <0.1% | 7.97 KiB |           1 | `_parse_sub`                | `/usr/lib/python3.11/re/_parser.py:447`           |
+| <0.1% | 6.73 KiB |           8 | `__setattr__`               | `/usr/lib/python3.11/enum.py:831`                 |
+| <0.1% | 5.63 KiB |           6 | `namedtuple`                | `/usr/lib/python3.11/collections/__init__.py:348` |
+| <0.1% | 5.61 KiB |           3 | `_parse`                    | `/usr/lib/python3.11/re/_parser.py:507`           |
+| <0.1% | 5.32 KiB |           2 | `_code`                     | `/usr/lib/python3.11/re/_compiler.py:571`         |
+| <0.1% | 4.73 KiB |           6 | `<module>`                  | `/usr/lib/python3.11/pkgutil.py:1`                |
+| <0.1% | 2.85 KiB |           1 | `wrap`                      | `/usr/lib/python3.11/dataclasses.py:1209`         |
+| <0.1% | 2.85 KiB |           4 | `_process_class`            | `/usr/lib/python3.11/dataclasses.py:884`          |
 
 ##### Third-party
 
-|     % |     Size | Samples | Function              | Location                                                                   |
-| ----: | -------: | ------: | --------------------- | -------------------------------------------------------------------------- |
-|  1.4% | 1.01 MiB |      11 | `<module>`            | `/venv/lib/python3.11/site-packages/click/parser.py:1`                     |
-|  0.1% | 44.3 KiB |      31 | `__init__`            | `/venv/lib/python3.11/site-packages/click/core.py:2883`                    |
-|  0.1% |   42 KiB |       7 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                   |
-| <0.1% |   25 KiB |      22 | `<module>`            | `/venv/lib/python3.11/site-packages/click/core.py:1`                       |
-| <0.1% |   15 KiB |      18 | `<module>`            | `/venv/lib/python3.11/site-packages/mypy_extensions.py:1`                  |
-| <0.1% | 13.4 KiB |      15 | `<module>`            | `/venv/lib/python3.11/site-packages/click/exceptions.py:1`                 |
-| <0.1% | 9.61 KiB |       9 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/version.py:1`                |
-| <0.1% | 7.08 KiB |       8 | `<module>`            | `/venv/lib/python3.11/site-packages/click/utils.py:1`                      |
-| <0.1% | 6.48 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/util.py:1`                    |
-| <0.1% | 6.24 KiB |       5 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                |
-| <0.1% |  5.8 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/click/_compat.py:1`                    |
-| <0.1% | 3.82 KiB |       1 | `Specifier`           | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`           |
-| <0.1% | 3.79 KiB |       3 | `new_func`            | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                |
-| <0.1% | 3.72 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`                 |
-| <0.1% | 3.56 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                  |
-| <0.1% | 3.37 KiB |       5 | `handle_parse_result` | `/venv/lib/python3.11/site-packages/click/core.py:2663`                    |
-| <0.1% | 3.19 KiB |       1 | `<module>`            | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                   |
-| <0.1% | 3.19 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`                |
-| <0.1% | 2.81 KiB |       3 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1` |
-| <0.1% | 2.76 KiB |       2 | `<module>`            | `/venv/lib/python3.11/site-packages/click/types.py:1`                      |
+|     % |     Size | Allocations | Function              | Location                                                                   |
+| ----: | -------: | ----------: | --------------------- | -------------------------------------------------------------------------- |
+|  1.4% | 1.01 MiB |          11 | `<module>`            | `/venv/lib/python3.11/site-packages/click/parser.py:1`                     |
+|  0.1% | 44.3 KiB |          31 | `__init__`            | `/venv/lib/python3.11/site-packages/click/core.py:2883`                    |
+|  0.1% |   42 KiB |           7 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                   |
+| <0.1% |   25 KiB |          22 | `<module>`            | `/venv/lib/python3.11/site-packages/click/core.py:1`                       |
+| <0.1% |   15 KiB |          18 | `<module>`            | `/venv/lib/python3.11/site-packages/mypy_extensions.py:1`                  |
+| <0.1% | 13.4 KiB |          15 | `<module>`            | `/venv/lib/python3.11/site-packages/click/exceptions.py:1`                 |
+| <0.1% | 9.61 KiB |           9 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/version.py:1`                |
+| <0.1% | 7.08 KiB |           8 | `<module>`            | `/venv/lib/python3.11/site-packages/click/utils.py:1`                      |
+| <0.1% | 6.48 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/util.py:1`                    |
+| <0.1% | 6.24 KiB |           5 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                |
+| <0.1% |  5.8 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/click/_compat.py:1`                    |
+| <0.1% | 3.82 KiB |           1 | `Specifier`           | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`           |
+| <0.1% | 3.79 KiB |           3 | `new_func`            | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                |
+| <0.1% | 3.72 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`                 |
+| <0.1% | 3.56 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                  |
+| <0.1% | 3.37 KiB |           5 | `handle_parse_result` | `/venv/lib/python3.11/site-packages/click/core.py:2663`                    |
+| <0.1% | 3.19 KiB |           1 | `<module>`            | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                   |
+| <0.1% | 3.19 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`                |
+| <0.1% | 2.81 KiB |           3 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1` |
+| <0.1% | 2.76 KiB |           2 | `<module>`            | `/venv/lib/python3.11/site-packages/click/types.py:1`                      |
 
 #### Lines
 
@@ -120,451 +120,451 @@ Lines ranked by contribution to each function's self size.
 
 ##### `mark` (`black/brackets.py:70`)
 
-|     % |     Size | Samples | Location                |
-| ----: | -------: | ------: | ----------------------- |
-| 94.8% | 18.2 MiB |  20,789 | `black/brackets.py:112` |
-|  5.2% |    1 MiB |       1 | `black/brackets.py:118` |
-| <0.1% | 1.49 KiB |       1 | `black/brackets.py:114` |
+|     % |     Size | Allocations | Location                |
+| ----: | -------: | ----------: | ----------------------- |
+| 94.8% | 18.2 MiB |      20,789 | `black/brackets.py:112` |
+|  5.2% |    1 MiB |           1 | `black/brackets.py:118` |
+| <0.1% | 1.49 KiB |           1 | `black/brackets.py:114` |
 
 ##### `parse` (`/usr/lib/python3.11/ast.py:33`)
 
-|      % |   Size | Samples | Location                        |
-| -----: | -----: | ------: | ------------------------------- |
-| 100.0% | 16 MiB |   1,014 | `/usr/lib/python3.11/ast.py:50` |
+|      % |   Size | Allocations | Location                        |
+| -----: | -----: | ----------: | ------------------------------- |
+| 100.0% | 16 MiB |       1,014 | `/usr/lib/python3.11/ast.py:50` |
 
 ##### `changed` (`blib2to3/pytree.py:171`)
 
-|     % |  Size | Samples | Location                 |
-| ----: | ----: | ------: | ------------------------ |
-| 57.1% | 4 MiB |       4 | `blib2to3/pytree.py:175` |
-| 42.9% | 3 MiB |       3 | `blib2to3/pytree.py:176` |
+|     % |  Size | Allocations | Location                 |
+| ----: | ----: | ----------: | ------------------------ |
+| 57.1% | 4 MiB |           4 | `blib2to3/pytree.py:175` |
+| 42.9% | 3 MiB |           3 | `blib2to3/pytree.py:176` |
 
 ##### `__new__` (`blib2to3/pytree.py:81`)
 
-|      % |  Size | Samples | Location                |
-| -----: | ----: | ------: | ----------------------- |
-| 100.0% | 5 MiB |       5 | `blib2to3/pytree.py:84` |
+|      % |  Size | Allocations | Location                |
+| -----: | ----: | ----------: | ----------------------- |
+| 100.0% | 5 MiB |           5 | `blib2to3/pytree.py:84` |
 
 ##### `update_sibling_maps` (`blib2to3/pytree.py:369`)
 
-|     % |     Size | Samples | Location                 |
-| ----: | -------: | ------: | ------------------------ |
-| 34.0% | 1.07 MiB |      94 | `blib2to3/pytree.py:377` |
-| 34.0% | 1.07 MiB |      94 | `blib2to3/pytree.py:376` |
-| 32.0% |    1 MiB |      10 | `blib2to3/pytree.py:379` |
+|     % |     Size | Allocations | Location                 |
+| ----: | -------: | ----------: | ------------------------ |
+| 34.0% | 1.07 MiB |          94 | `blib2to3/pytree.py:377` |
+| 34.0% | 1.07 MiB |          94 | `blib2to3/pytree.py:376` |
+| 32.0% |    1 MiB |          10 | `blib2to3/pytree.py:379` |
 
 ##### `transform_line` (`black/linegen.py:601`)
 
-|     % |     Size | Samples | Location               |
-| ----: | -------: | ------: | ---------------------- |
-| 33.3% |    1 MiB |       2 | `black/linegen.py:714` |
-| 33.3% |    1 MiB |       1 | `black/linegen.py:627` |
-| 33.3% |    1 MiB |       1 | `black/linegen.py:626` |
-|  0.1% | 1.69 KiB |       2 | `black/linegen.py:679` |
-| <0.1% | 1.39 KiB |       1 | `black/linegen.py:635` |
+|     % |     Size | Allocations | Location               |
+| ----: | -------: | ----------: | ---------------------- |
+| 33.3% |    1 MiB |           2 | `black/linegen.py:714` |
+| 33.3% |    1 MiB |           1 | `black/linegen.py:627` |
+| 33.3% |    1 MiB |           1 | `black/linegen.py:626` |
+|  0.1% | 1.69 KiB |           2 | `black/linegen.py:679` |
+| <0.1% | 1.39 KiB |           1 | `black/linegen.py:635` |
 
 ##### `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`)
 
-|      % |     Size | Samples | Location                            |
-| -----: | -------: | ------: | ----------------------------------- |
-| 100.0% | 2.27 MiB |     352 | `<frozen importlib._bootstrap>:241` |
+|      % |     Size | Allocations | Location                            |
+| -----: | -------: | ----------: | ----------------------------------- |
+| 100.0% | 2.27 MiB |         352 | `<frozen importlib._bootstrap>:241` |
 
 ##### `convert` (`blib2to3/pytree.py:486`)
 
-|      % |  Size | Samples | Location                 |
-| -----: | ----: | ------: | ------------------------ |
-| 100.0% | 2 MiB |       2 | `blib2to3/pytree.py:501` |
+|      % |  Size | Allocations | Location                 |
+| -----: | ----: | ----------: | ------------------------ |
+| 100.0% | 2 MiB |           2 | `blib2to3/pytree.py:501` |
 
 ##### `_addtoken` (`blib2to3/pgen2/parse.py:290`)
 
-|     % |  Size | Samples | Location                      |
-| ----: | ----: | ------: | ----------------------------- |
-| 50.0% | 1 MiB |       1 | `blib2to3/pgen2/parse.py:315` |
-| 50.0% | 1 MiB |       1 | `blib2to3/pgen2/parse.py:314` |
+|     % |  Size | Allocations | Location                      |
+| ----: | ----: | ----------: | ----------------------------- |
+| 50.0% | 1 MiB |           1 | `blib2to3/pgen2/parse.py:315` |
+| 50.0% | 1 MiB |           1 | `blib2to3/pgen2/parse.py:314` |
 
 ##### `generate_comments` (`black/comments.py:52`)
 
-|     % |  Size | Samples | Location               |
-| ----: | ----: | ------: | ---------------------- |
-| 50.0% | 1 MiB |       1 | `black/comments.py:76` |
-| 50.0% | 1 MiB |       1 | `black/comments.py:72` |
+|     % |  Size | Allocations | Location               |
+| ----: | ----: | ----------: | ---------------------- |
+| 50.0% | 1 MiB |           1 | `black/comments.py:76` |
+| 50.0% | 1 MiB |           1 | `black/comments.py:72` |
 
 ##### `make_grammar` (`blib2to3/pgen2/pgen.py:49`)
 
-|     % |     Size | Samples | Location                    |
-| ----: | -------: | ------: | --------------------------- |
-| 98.6% |    1 MiB |       1 | `blib2to3/pgen2/pgen.py:56` |
-|  0.4% | 4.52 KiB |       1 | `blib2to3/pgen2/pgen.py:70` |
-|  0.4% | 4.52 KiB |       1 | `blib2to3/pgen2/pgen.py:58` |
-|  0.3% | 3.19 KiB |       1 | `blib2to3/pgen2/pgen.py:57` |
-|  0.1% |    1 KiB |       1 | `blib2to3/pgen2/pgen.py:69` |
+|     % |     Size | Allocations | Location                    |
+| ----: | -------: | ----------: | --------------------------- |
+| 98.6% |    1 MiB |           1 | `blib2to3/pgen2/pgen.py:56` |
+|  0.4% | 4.52 KiB |           1 | `blib2to3/pgen2/pgen.py:70` |
+|  0.4% | 4.52 KiB |           1 | `blib2to3/pgen2/pgen.py:58` |
+|  0.3% | 3.19 KiB |           1 | `blib2to3/pgen2/pgen.py:57` |
+|  0.1% |    1 KiB |           1 | `blib2to3/pgen2/pgen.py:69` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`)
 
-|     % |     Size | Samples | Location                                                 |
-| ----: | -------: | ------: | -------------------------------------------------------- |
-| 99.2% |    1 MiB |       1 | `/venv/lib/python3.11/site-packages/click/parser.py:25`  |
-|  0.2% | 2.29 KiB |       3 | `/venv/lib/python3.11/site-packages/click/parser.py:224` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:185` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:127` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:216` |
+|     % |     Size | Allocations | Location                                                 |
+| ----: | -------: | ----------: | -------------------------------------------------------- |
+| 99.2% |    1 MiB |           1 | `/venv/lib/python3.11/site-packages/click/parser.py:25`  |
+|  0.2% | 2.29 KiB |           3 | `/venv/lib/python3.11/site-packages/click/parser.py:224` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:185` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:127` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:216` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|     % |     Size | Samples | Location             |
-| ----: | -------: | ------: | -------------------- |
-| 99.7% |    1 MiB |       2 | `black/nodes.py:185` |
-|  0.3% | 2.68 KiB |       3 | `black/nodes.py:183` |
+|     % |     Size | Allocations | Location             |
+| ----: | -------: | ----------: | -------------------- |
+| 99.7% |    1 MiB |           2 | `black/nodes.py:185` |
+|  0.3% | 2.68 KiB |           3 | `black/nodes.py:183` |
 
 ##### `addtoken` (`blib2to3/pgen2/parse.py:242`)
 
-|     % |  Size | Samples | Location                      |
-| ----: | ----: | ------: | ----------------------------- |
-| 99.9% | 1 MiB |       2 | `blib2to3/pgen2/parse.py:252` |
-|  0.1% | 560 B |       1 | `blib2to3/pgen2/parse.py:245` |
+|     % |  Size | Allocations | Location                      |
+| ----: | ----: | ----------: | ----------------------------- |
+| 99.9% | 1 MiB |           2 | `blib2to3/pgen2/parse.py:252` |
+|  0.1% | 560 B |           1 | `blib2to3/pgen2/parse.py:245` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|     % |  Size | Samples | Location               |
-| ----: | ----: | ------: | ---------------------- |
-| 99.9% | 1 MiB |       1 | `black/linegen.py:158` |
-|  0.1% | 702 B |       1 | `black/linegen.py:144` |
+|     % |  Size | Allocations | Location               |
+| ----: | ----: | ----------: | ---------------------- |
+| 99.9% | 1 MiB |           1 | `black/linegen.py:158` |
+|  0.1% | 702 B |           1 | `black/linegen.py:144` |
 
 ##### `pop` (`blib2to3/pgen2/parse.py:398`)
 
-|      % |  Size | Samples | Location                      |
-| -----: | ----: | ------: | ----------------------------- |
-| 100.0% | 1 MiB |       1 | `blib2to3/pgen2/parse.py:408` |
+|      % |  Size | Allocations | Location                      |
+| -----: | ----: | ----------: | ----------------------------- |
+| 100.0% | 1 MiB |           1 | `blib2to3/pgen2/parse.py:408` |
 
 ##### `lines_with_leading_tabs_expanded` (`black/strings.py:46`)
 
-|      % |  Size | Samples | Location              |
-| -----: | ----: | ------: | --------------------- |
-| 100.0% | 1 MiB |       1 | `black/strings.py:58` |
+|      % |  Size | Allocations | Location              |
+| -----: | ----: | ----------: | --------------------- |
+| 100.0% | 1 MiB |           1 | `black/strings.py:58` |
 
 ##### `is_import` (`black/lines.py:134`)
 
-|      % |  Size | Samples | Location             |
-| -----: | ----: | ------: | -------------------- |
-| 100.0% | 1 MiB |       1 | `black/lines.py:137` |
+|      % |  Size | Allocations | Location             |
+| -----: | ----: | ----------: | -------------------- |
+| 100.0% | 1 MiB |           1 | `black/lines.py:137` |
 
 ##### `__init__` (`<string>:2`)
 
-|      % |  Size | Samples | Location     |
-| -----: | ----: | ------: | ------------ |
-| 100.0% | 1 MiB |       1 | `<string>:6` |
+|      % |  Size | Allocations | Location     |
+| -----: | ----: | ----------: | ------------ |
+| 100.0% | 1 MiB |           1 | `<string>:6` |
 
 ##### `_compile_bytecode` (`<frozen importlib._bootstrap_external>:727`)
 
-|      % |    Size | Samples | Location                                     |
-| -----: | ------: | ------: | -------------------------------------------- |
-| 100.0% | 311 KiB |     341 | `<frozen importlib._bootstrap_external>:729` |
+|      % |    Size | Allocations | Location                                     |
+| -----: | ------: | ----------: | -------------------------------------------- |
+| 100.0% | 311 KiB |         341 | `<frozen importlib._bootstrap_external>:729` |
 
 ##### `_format_str_once` (`black/__init__.py:1236`)
 
-|     % |     Size | Samples | Location                 |
-| ----: | -------: | ------: | ------------------------ |
-| 98.6% |  222 KiB |       1 | `black/__init__.py:1287` |
-|  0.5% | 1.07 KiB |       1 | `black/__init__.py:1271` |
-|  0.3% |    800 B |       1 | `black/__init__.py:1239` |
-|  0.3% |    644 B |       1 | `black/__init__.py:1269` |
-|  0.3% |    638 B |       1 | `black/__init__.py:1244` |
+|     % |     Size | Allocations | Location                 |
+| ----: | -------: | ----------: | ------------------------ |
+| 98.6% |  222 KiB |           1 | `black/__init__.py:1287` |
+|  0.5% | 1.07 KiB |           1 | `black/__init__.py:1271` |
+|  0.3% |    800 B |           1 | `black/__init__.py:1239` |
+|  0.3% |    644 B |           1 | `black/__init__.py:1269` |
+|  0.3% |    638 B |           1 | `black/__init__.py:1244` |
 
 ##### `decode` (`<frozen codecs>:319`)
 
-|      % |    Size | Samples | Location              |
-| -----: | ------: | ------: | --------------------- |
-| 100.0% | 222 KiB |       1 | `<frozen codecs>:322` |
+|      % |    Size | Allocations | Location              |
+| -----: | ------: | ----------: | --------------------- |
+| 100.0% | 222 KiB |           1 | `<frozen codecs>:322` |
 
 ##### `_code_to_timestamp_pyc` (`<frozen importlib._bootstrap_external>:740`)
 
-|      % |    Size | Samples | Location                                     |
-| -----: | ------: | ------: | -------------------------------------------- |
-| 100.0% | 112 KiB |     108 | `<frozen importlib._bootstrap_external>:746` |
+|      % |    Size | Allocations | Location                                     |
+| -----: | ------: | ----------: | -------------------------------------------- |
+| 100.0% | 112 KiB |         108 | `<frozen importlib._bootstrap_external>:746` |
 
 ##### `__new__` (`<frozen abc>:105`)
 
-|      % |     Size | Samples | Location           |
-| -----: | -------: | ------: | ------------------ |
-| 100.0% | 75.7 KiB |      79 | `<frozen abc>:106` |
+|      % |     Size | Allocations | Location           |
+| -----: | -------: | ----------: | ------------------ |
+| 100.0% | 75.7 KiB |          79 | `<frozen abc>:106` |
 
 ##### `normalize_string_prefix` (`black/strings.py:143`)
 
-|      % |     Size | Samples | Location               |
-| -----: | -------: | ------: | ---------------------- |
-| 100.0% | 57.2 KiB |      65 | `black/strings.py:158` |
+|      % |     Size | Allocations | Location               |
+| -----: | -------: | ----------: | ---------------------- |
+| 100.0% | 57.2 KiB |          65 | `black/strings.py:158` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|     % |   Size | Samples | Location                                                |
-| ----: | -----: | ------: | ------------------------------------------------------- |
-| 97.1% | 43 KiB |      29 | `/venv/lib/python3.11/site-packages/click/core.py:3023` |
-|  1.6% |  704 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2905` |
-|  1.4% |  614 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2907` |
+|     % |   Size | Allocations | Location                                                |
+| ----: | -----: | ----------: | ------------------------------------------------------- |
+| 97.1% | 43 KiB |          29 | `/venv/lib/python3.11/site-packages/click/core.py:3023` |
+|  1.6% |  704 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2905` |
+|  1.4% |  614 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2907` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|     % |     Size | Samples | Location                                                   |
-| ----: | -------: | ------: | ---------------------------------------------------------- |
-| 89.8% | 37.7 KiB |       3 | `/venv/lib/python3.11/site-packages/packaging/tags.py:118` |
-|  3.5% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:322` |
-|  2.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:110` |
-|  2.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:101` |
-|  2.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:93`  |
+|     % |     Size | Allocations | Location                                                   |
+| ----: | -------: | ----------: | ---------------------------------------------------------- |
+| 89.8% | 37.7 KiB |           3 | `/venv/lib/python3.11/site-packages/packaging/tags.py:118` |
+|  3.5% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:322` |
+|  2.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:110` |
+|  2.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:101` |
+|  2.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:93`  |
 
 ##### `copy` (`blib2to3/pgen2/grammar.py:131`)
 
-|     % |     Size | Samples | Location                        |
-| ----: | -------: | ------: | ------------------------------- |
-| 88.2% | 36.6 KiB |      12 | `blib2to3/pgen2/grammar.py:145` |
-|  7.6% | 3.16 KiB |       2 | `blib2to3/pgen2/grammar.py:146` |
-|  4.2% | 1.75 KiB |       2 | `blib2to3/pgen2/grammar.py:147` |
+|     % |     Size | Allocations | Location                        |
+| ----: | -------: | ----------: | ------------------------------- |
+| 88.2% | 36.6 KiB |          12 | `blib2to3/pgen2/grammar.py:145` |
+|  7.6% | 3.16 KiB |           2 | `blib2to3/pgen2/grammar.py:146` |
+|  4.2% | 1.75 KiB |           2 | `blib2to3/pgen2/grammar.py:147` |
 
 ##### `classify` (`blib2to3/pgen2/parse.py:336`)
 
-|      % |   Size | Samples | Location                      |
-| -----: | -----: | ------: | ----------------------------- |
-| 100.0% | 32 KiB |       1 | `blib2to3/pgen2/parse.py:343` |
+|      % |   Size | Allocations | Location                      |
+| -----: | -----: | ----------: | ----------------------------- |
+| 100.0% | 32 KiB |           1 | `blib2to3/pgen2/parse.py:343` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 30.4% |  7.6 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:204`  |
-| 19.2% | 4.79 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:956`  |
-| 15.7% | 3.92 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:1587` |
-|  9.5% | 2.37 KiB |       3 | `/venv/lib/python3.11/site-packages/click/core.py:2057` |
-|  6.8% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/core.py:2050` |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 30.4% |  7.6 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:204`  |
+| 19.2% | 4.79 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:956`  |
+| 15.7% | 3.92 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:1587` |
+|  9.5% | 2.37 KiB |           3 | `/venv/lib/python3.11/site-packages/click/core.py:2057` |
+|  6.8% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/core.py:2050` |
 
 ##### `__new__` (`/usr/lib/python3.11/enum.py:488`)
 
-|      % |     Size | Samples | Location                          |
-| -----: | -------: | ------: | --------------------------------- |
-| 100.0% | 24.1 KiB |      27 | `/usr/lib/python3.11/enum.py:554` |
+|      % |     Size | Allocations | Location                          |
+| -----: | -------: | ----------: | --------------------------------- |
+| 100.0% | 24.1 KiB |          27 | `/usr/lib/python3.11/enum.py:554` |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|      % |     Size | Samples | Location                                  |
-| -----: | -------: | ------: | ----------------------------------------- |
-| 100.0% | 22.6 KiB |      12 | `/usr/lib/python3.11/re/_compiler.py:759` |
+|      % |     Size | Allocations | Location                                  |
+| -----: | -------: | ----------: | ----------------------------------------- |
+| 100.0% | 22.6 KiB |          12 | `/usr/lib/python3.11/re/_compiler.py:759` |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/_parser.py:1`)
 
-|     % |  Size | Samples | Location                                    |
-| ----: | ----: | ------: | ------------------------------------------- |
-| 20.2% | 4 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:37` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:26` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:22` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:38` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:27` |
+|     % |  Size | Allocations | Location                                    |
+| ----: | ----: | ----------: | ------------------------------------------- |
+| 20.2% | 4 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:37` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:26` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:22` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:38` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:27` |
 
 ##### `__new__` (`/usr/lib/python3.11/typing.py:2891`)
 
-|      % |     Size | Samples | Location                             |
-| -----: | -------: | ------: | ------------------------------------ |
-| 100.0% | 17.4 KiB |      21 | `/usr/lib/python3.11/typing.py:2909` |
+|      % |     Size | Allocations | Location                             |
+| -----: | -------: | ----------: | ------------------------------------ |
+| 100.0% | 17.4 KiB |          21 | `/usr/lib/python3.11/typing.py:2909` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/mypy_extensions.py:1`)
 
-|     % |     Size | Samples | Location                                                    |
-| ----: | -------: | ------: | ----------------------------------------------------------- |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:198` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:167` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:212` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:191` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:154` |
+|     % |     Size | Allocations | Location                                                    |
+| ----: | -------: | ----------: | ----------------------------------------------------------- |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:198` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:167` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:212` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:191` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:154` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/exceptions.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 18.4% | 2.45 KiB |       3 | `/venv/lib/python3.11/site-packages/click/exceptions.py:114` |
-| 11.5% | 1.53 KiB |       2 | `/venv/lib/python3.11/site-packages/click/exceptions.py:366` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:304` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:268` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:232` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 18.4% | 2.45 KiB |           3 | `/venv/lib/python3.11/site-packages/click/exceptions.py:114` |
+| 11.5% | 1.53 KiB |           2 | `/venv/lib/python3.11/site-packages/click/exceptions.py:366` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:304` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:268` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:232` |
 
 ##### `inner` (`/usr/lib/python3.11/typing.py:338`)
 
-|      % |   Size | Samples | Location                            |
-| -----: | -----: | ------: | ----------------------------------- |
-| 100.0% | 12 KiB |       3 | `/usr/lib/python3.11/typing.py:341` |
+|      % |   Size | Allocations | Location                            |
+| -----: | -----: | ----------: | ----------------------------------- |
+| 100.0% | 12 KiB |           3 | `/usr/lib/python3.11/typing.py:341` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/version.py:1`)
 
-|     % |     Size | Samples | Location                                                      |
-| ----: | -------: | ------: | ------------------------------------------------------------- |
-| 38.2% | 3.68 KiB |       3 | `/venv/lib/python3.11/site-packages/packaging/version.py:340` |
-| 15.5% | 1.49 KiB |       2 | `/venv/lib/python3.11/site-packages/packaging/version.py:124` |
-| 15.4% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:285` |
-| 11.3% | 1.09 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:228` |
-|  9.8% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:134` |
+|     % |     Size | Allocations | Location                                                      |
+| ----: | -------: | ----------: | ------------------------------------------------------------- |
+| 38.2% | 3.68 KiB |           3 | `/venv/lib/python3.11/site-packages/packaging/version.py:340` |
+| 15.5% | 1.49 KiB |           2 | `/venv/lib/python3.11/site-packages/packaging/version.py:124` |
+| 15.4% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:285` |
+| 11.3% | 1.09 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:228` |
+|  9.8% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:134` |
 
 ##### `_fill_cache` (`<frozen importlib._bootstrap_external>:1655`)
 
-|      % |  Size | Samples | Location                                      |
-| -----: | ----: | ------: | --------------------------------------------- |
-| 100.0% | 8 KiB |       4 | `<frozen importlib._bootstrap_external>:1667` |
+|      % |  Size | Allocations | Location                                      |
+| -----: | ----: | ----------: | --------------------------------------------- |
+| 100.0% | 8 KiB |           4 | `<frozen importlib._bootstrap_external>:1667` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|      % |     Size | Samples | Location                                |
-| -----: | -------: | ------: | --------------------------------------- |
-| 100.0% | 7.97 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:455` |
+|      % |     Size | Allocations | Location                                |
+| -----: | -------: | ----------: | --------------------------------------- |
+| 100.0% | 7.97 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:455` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/utils.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 44.8% | 3.17 KiB |       3 | `/venv/lib/python3.11/site-packages/click/utils.py:522` |
-| 31.4% | 2.22 KiB |       3 | `/venv/lib/python3.11/site-packages/click/utils.py:207` |
-| 23.8% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/utils.py:113` |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 44.8% | 3.17 KiB |           3 | `/venv/lib/python3.11/site-packages/click/utils.py:522` |
+| 31.4% | 2.22 KiB |           3 | `/venv/lib/python3.11/site-packages/click/utils.py:207` |
+| 23.8% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/utils.py:113` |
 
 ##### `__setattr__` (`/usr/lib/python3.11/enum.py:831`)
 
-|      % |     Size | Samples | Location                          |
-| -----: | -------: | ------: | --------------------------------- |
-| 100.0% | 6.73 KiB |       8 | `/usr/lib/python3.11/enum.py:842` |
+|      % |     Size | Allocations | Location                          |
+| -----: | -------: | ----------: | --------------------------------- |
+| 100.0% | 6.73 KiB |           8 | `/usr/lib/python3.11/enum.py:842` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/util.py:1`)
 
-|     % |     Size | Samples | Location                                                  |
-| ----: | -------: | ------: | --------------------------------------------------------- |
-| 22.9% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:254` |
-| 16.9% | 1.09 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:765` |
-| 16.3% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:710` |
-| 15.1% |   1000 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:741` |
-| 14.5% |    960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:651` |
+|     % |     Size | Allocations | Location                                                  |
+| ----: | -------: | ----------: | --------------------------------------------------------- |
+| 22.9% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:254` |
+| 16.9% | 1.09 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:765` |
+| 16.3% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:710` |
+| 15.1% |   1000 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:741` |
+| 14.5% |    960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:651` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|     % |     Size | Samples | Location                                                      |
-| ----: | -------: | ------: | ------------------------------------------------------------- |
-| 23.8% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:681` |
-| 23.0% | 1.43 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:44`  |
-| 19.4% | 1.21 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:63`  |
-| 16.9% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:179` |
-| 16.9% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:236` |
+|     % |     Size | Allocations | Location                                                      |
+| ----: | -------: | ----------: | ------------------------------------------------------------- |
+| 23.8% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:681` |
+| 23.0% | 1.43 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:44`  |
+| 19.4% | 1.21 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:63`  |
+| 16.9% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:179` |
+| 16.9% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:236` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/_compat.py:1`)
 
-|     % |     Size | Samples | Location                                                  |
-| ----: | -------: | ------: | --------------------------------------------------------- |
-| 29.1% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/_compat.py:452` |
-| 29.1% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/_compat.py:82`  |
-| 25.6% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/click/_compat.py:344` |
-| 16.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/_compat.py:56`  |
+|     % |     Size | Allocations | Location                                                  |
+| ----: | -------: | ----------: | --------------------------------------------------------- |
+| 29.1% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/_compat.py:452` |
+| 29.1% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/_compat.py:82`  |
+| 25.6% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/click/_compat.py:344` |
+| 16.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/_compat.py:56`  |
 
 ##### `namedtuple` (`/usr/lib/python3.11/collections/__init__.py:348`)
 
-|      % |     Size | Samples | Location                                          |
-| -----: | -------: | ------: | ------------------------------------------------- |
-| 100.0% | 5.63 KiB |       6 | `/usr/lib/python3.11/collections/__init__.py:501` |
+|      % |     Size | Allocations | Location                                          |
+| -----: | -------: | ----------: | ------------------------------------------------- |
+| 100.0% | 5.63 KiB |           6 | `/usr/lib/python3.11/collections/__init__.py:501` |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|     % |     Size | Samples | Location                                |
-| ----: | -------: | ------: | --------------------------------------- |
-| 43.4% | 2.43 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:539` |
-| 33.9% |  1.9 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:568` |
-| 22.7% | 1.28 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:838` |
+|     % |     Size | Allocations | Location                                |
+| ----: | -------: | ----------: | --------------------------------------- |
+| 43.4% | 2.43 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:539` |
+| 33.9% |  1.9 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:568` |
+| 22.7% | 1.28 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:838` |
 
 ##### `_code` (`/usr/lib/python3.11/re/_compiler.py:571`)
 
-|     % |     Size | Samples | Location                                  |
-| ----: | -------: | ------: | ----------------------------------------- |
-| 81.6% | 4.34 KiB |       1 | `/usr/lib/python3.11/re/_compiler.py:580` |
-| 18.4% |   1002 B |       1 | `/usr/lib/python3.11/re/_compiler.py:577` |
+|     % |     Size | Allocations | Location                                  |
+| ----: | -------: | ----------: | ----------------------------------------- |
+| 81.6% | 4.34 KiB |           1 | `/usr/lib/python3.11/re/_compiler.py:580` |
+| 18.4% |   1002 B |           1 | `/usr/lib/python3.11/re/_compiler.py:577` |
 
 ##### `<module>` (`/usr/lib/python3.11/pkgutil.py:1`)
 
-|     % |     Size | Samples | Location                             |
-| ----: | -------: | ------: | ------------------------------------ |
-| 35.7% | 1.69 KiB |       2 | `/usr/lib/python3.11/pkgutil.py:269` |
-| 35.7% | 1.69 KiB |       2 | `/usr/lib/python3.11/pkgutil.py:194` |
-| 15.9% |    768 B |       1 | `/usr/lib/python3.11/pkgutil.py:137` |
-| 12.8% |    620 B |       1 | `/usr/lib/python3.11/pkgutil.py:184` |
+|     % |     Size | Allocations | Location                             |
+| ----: | -------: | ----------: | ------------------------------------ |
+| 35.7% | 1.69 KiB |           2 | `/usr/lib/python3.11/pkgutil.py:269` |
+| 35.7% | 1.69 KiB |           2 | `/usr/lib/python3.11/pkgutil.py:194` |
+| 15.9% |    768 B |           1 | `/usr/lib/python3.11/pkgutil.py:137` |
+| 12.8% |    620 B |           1 | `/usr/lib/python3.11/pkgutil.py:184` |
 
 ##### `Specifier` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`)
 
-|      % |     Size | Samples | Location                                                         |
-| -----: | -------: | ------: | ---------------------------------------------------------------- |
-| 100.0% | 3.82 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:340` |
+|      % |     Size | Allocations | Location                                                         |
+| -----: | -------: | ----------: | ---------------------------------------------------------------- |
+| 100.0% | 3.82 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:340` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Location                                                    |
-| -----: | -------: | ------: | ----------------------------------------------------------- |
-| 100.0% | 3.79 KiB |       3 | `/venv/lib/python3.11/site-packages/click/decorators.py:34` |
+|      % |     Size | Allocations | Location                                                    |
+| -----: | -------: | ----------: | ----------------------------------------------------------- |
+| 100.0% | 3.79 KiB |           3 | `/venv/lib/python3.11/site-packages/click/decorators.py:34` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 46.4% | 1.73 KiB |       2 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:29`  |
-| 27.3% | 1.02 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:90`  |
-| 26.3% |   1000 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:245` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 46.4% | 1.73 KiB |           2 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:29`  |
+| 27.3% | 1.02 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:90`  |
+| 26.3% |   1000 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:245` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|     % |  Size | Samples | Location                                                   |
-| ----: | ----: | ------: | ---------------------------------------------------------- |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:62` |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:46` |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:54` |
-| 21.1% | 768 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:27` |
+|     % |  Size | Allocations | Location                                                   |
+| ----: | ----: | ----------: | ---------------------------------------------------------- |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:62` |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:46` |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:54` |
+| 21.1% | 768 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:27` |
 
 ##### `handle_parse_result` (`/venv/lib/python3.11/site-packages/click/core.py:2663`)
 
-|     % |    Size | Samples | Location                                                |
-| ----: | ------: | ------: | ------------------------------------------------------- |
-| 38.5% | 1.3 KiB |       2 | `/venv/lib/python3.11/site-packages/click/core.py:2686` |
-| 22.3% |   768 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2739` |
-| 22.3% |   768 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2740` |
-| 17.0% |   586 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2711` |
+|     % |    Size | Allocations | Location                                                |
+| ----: | ------: | ----------: | ------------------------------------------------------- |
+| 38.5% | 1.3 KiB |           2 | `/venv/lib/python3.11/site-packages/click/core.py:2686` |
+| 22.3% |   768 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2739` |
+| 22.3% |   768 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2740` |
+| 17.0% |   586 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2711` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|      % |     Size | Samples | Location                                                  |
-| -----: | -------: | ------: | --------------------------------------------------------- |
-| 100.0% | 3.19 KiB |       1 | `/venv/lib/python3.11/site-packages/click/__init__.py:74` |
+|      % |     Size | Allocations | Location                                                  |
+| -----: | -------: | ----------: | --------------------------------------------------------- |
+| 100.0% | 3.19 KiB |           1 | `/venv/lib/python3.11/site-packages/click/__init__.py:74` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 76.5% | 2.44 KiB |       3 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:55` |
-| 23.5% |    768 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:14` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 76.5% | 2.44 KiB |           3 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:55` |
+| 23.5% |    768 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:14` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|      % |     Size | Samples | Location                                  |
-| -----: | -------: | ------: | ----------------------------------------- |
-| 100.0% | 2.85 KiB |       1 | `/usr/lib/python3.11/dataclasses.py:1210` |
+|      % |     Size | Allocations | Location                                  |
+| -----: | -------: | ----------: | ----------------------------------------- |
+| 100.0% | 2.85 KiB |           1 | `/usr/lib/python3.11/dataclasses.py:1210` |
 
 ##### `_process_class` (`/usr/lib/python3.11/dataclasses.py:884`)
 
-|     % |     Size | Samples | Location                                  |
-| ----: | -------: | ------: | ----------------------------------------- |
-| 41.3% | 1.18 KiB |       1 | `/usr/lib/python3.11/dataclasses.py:958`  |
-| 21.0% |    612 B |       1 | `/usr/lib/python3.11/dataclasses.py:1027` |
-| 19.9% |    580 B |       1 | `/usr/lib/python3.11/dataclasses.py:1096` |
-| 17.8% |    518 B |       1 | `/usr/lib/python3.11/dataclasses.py:947`  |
+|     % |     Size | Allocations | Location                                  |
+| ----: | -------: | ----------: | ----------------------------------------- |
+| 41.3% | 1.18 KiB |           1 | `/usr/lib/python3.11/dataclasses.py:958`  |
+| 21.0% |    612 B |           1 | `/usr/lib/python3.11/dataclasses.py:1027` |
+| 19.9% |    580 B |           1 | `/usr/lib/python3.11/dataclasses.py:1096` |
+| 17.8% |    518 B |           1 | `/usr/lib/python3.11/dataclasses.py:947`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1`)
 
-|     % |  Size | Samples | Location                                                                     |
-| ----: | ----: | ------: | ---------------------------------------------------------------------------- |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:22`  |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:205` |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:197` |
+|     % |  Size | Allocations | Location                                                                     |
+| ----: | ----: | ----------: | ---------------------------------------------------------------------------- |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:22`  |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:205` |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:197` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 53.7% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/click/types.py:464` |
-| 46.3% | 1.28 KiB |       1 | `/venv/lib/python3.11/site-packages/click/types.py:37`  |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 53.7% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/click/types.py:464` |
+| 46.3% | 1.28 KiB |           1 | `/venv/lib/python3.11/site-packages/click/types.py:37`  |
 
 #### Callers
 
@@ -572,483 +572,483 @@ Callers ranked by contribution to each function's self size. Inlining can make c
 
 ##### `mark` (`black/brackets.py:70`)
 
-|     % |     Size | Samples | Caller                           | Location                |
-| ----: | -------: | ------: | -------------------------------- | ----------------------- |
-| 94.8% | 18.2 MiB |  20,790 | `append`                         | `black/lines.py:63`     |
-|  5.2% |    1 MiB |       1 | `max_delimiter_priority_in_atom` | `black/brackets.py:328` |
+|     % |     Size | Allocations | Caller                           | Location                |
+| ----: | -------: | ----------: | -------------------------------- | ----------------------- |
+| 94.8% | 18.2 MiB |      20,790 | `append`                         | `black/lines.py:63`     |
+|  5.2% |    1 MiB |           1 | `max_delimiter_priority_in_atom` | `black/brackets.py:328` |
 
 ##### `parse` (`/usr/lib/python3.11/ast.py:33`)
 
-|      % |   Size | Samples | Caller                  | Location               |
-| -----: | -----: | ------: | ----------------------- | ---------------------- |
-| 100.0% | 16 MiB |   1,014 | `_parse_single_version` | `black/parsing.py:117` |
+|      % |   Size | Allocations | Caller                  | Location               |
+| -----: | -----: | ----------: | ----------------------- | ---------------------- |
+| 100.0% | 16 MiB |       1,014 | `_parse_single_version` | `black/parsing.py:117` |
 
 ##### `changed` (`blib2to3/pytree.py:171`)
 
-|     % |  Size | Samples | Caller    | Location                 |
-| ----: | ----: | ------: | --------- | ------------------------ |
-| 71.4% | 5 MiB |       5 | `changed` | `blib2to3/pytree.py:171` |
-| 28.6% | 2 MiB |       2 | `prefix`  | `blib2to3/pytree.py:480` |
+|     % |  Size | Allocations | Caller    | Location                 |
+| ----: | ----: | ----------: | --------- | ------------------------ |
+| 71.4% | 5 MiB |           5 | `changed` | `blib2to3/pytree.py:171` |
+| 28.6% | 2 MiB |           2 | `prefix`  | `blib2to3/pytree.py:480` |
 
 ##### `__new__` (`blib2to3/pytree.py:81`)
 
-|      % |  Size | Samples | Caller    | Location                 |
-| -----: | ----: | ------: | --------- | ------------------------ |
-| 100.0% | 5 MiB |       5 | `convert` | `blib2to3/pytree.py:486` |
+|      % |  Size | Allocations | Caller    | Location                 |
+| -----: | ----: | ----------: | --------- | ------------------------ |
+| 100.0% | 5 MiB |           5 | `convert` | `blib2to3/pytree.py:486` |
 
 ##### `update_sibling_maps` (`blib2to3/pytree.py:369`)
 
-|      % |     Size | Samples | Caller         | Location                 |
-| -----: | -------: | ------: | -------------- | ------------------------ |
-| 100.0% | 3.14 MiB |     198 | `prev_sibling` | `blib2to3/pytree.py:207` |
+|      % |     Size | Allocations | Caller         | Location                 |
+| -----: | -------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 3.14 MiB |         198 | `prev_sibling` | `blib2to3/pytree.py:207` |
 
 ##### `transform_line` (`black/linegen.py:601`)
 
-|      % |  Size | Samples | Caller             | Location                 |
-| -----: | ----: | ------: | ------------------ | ------------------------ |
-| 100.0% | 3 MiB |       8 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |  Size | Allocations | Caller             | Location                 |
+| -----: | ----: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 3 MiB |           8 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`)
 
-|      % |     Size | Samples | Caller           | Location                                     |
-| -----: | -------: | ------: | ---------------- | -------------------------------------------- |
-| 100.0% | 2.27 MiB |     352 | `source_to_code` | `<frozen importlib._bootstrap_external>:999` |
+|      % |     Size | Allocations | Caller           | Location                                     |
+| -----: | -------: | ----------: | ---------------- | -------------------------------------------- |
+| 100.0% | 2.27 MiB |         352 | `source_to_code` | `<frozen importlib._bootstrap_external>:999` |
 
 ##### `convert` (`blib2to3/pytree.py:486`)
 
-|      % |  Size | Samples | Caller | Location                      |
-| -----: | ----: | ------: | ------ | ----------------------------- |
-| 100.0% | 2 MiB |       2 | `pop`  | `blib2to3/pgen2/parse.py:398` |
+|      % |  Size | Allocations | Caller | Location                      |
+| -----: | ----: | ----------: | ------ | ----------------------------- |
+| 100.0% | 2 MiB |           2 | `pop`  | `blib2to3/pgen2/parse.py:398` |
 
 ##### `_addtoken` (`blib2to3/pgen2/parse.py:290`)
 
-|      % |  Size | Samples | Caller     | Location                      |
-| -----: | ----: | ------: | ---------- | ----------------------------- |
-| 100.0% | 2 MiB |       2 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
+|      % |  Size | Allocations | Caller     | Location                      |
+| -----: | ----: | ----------: | ---------- | ----------------------------- |
+| 100.0% | 2 MiB |           2 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
 
 ##### `generate_comments` (`black/comments.py:52`)
 
-|      % |  Size | Samples | Caller          | Location               |
-| -----: | ----: | ------: | --------------- | ---------------------- |
-| 100.0% | 2 MiB |       2 | `visit_default` | `black/linegen.py:134` |
+|      % |  Size | Allocations | Caller          | Location               |
+| -----: | ----: | ----------: | --------------- | ---------------------- |
+| 100.0% | 2 MiB |           2 | `visit_default` | `black/linegen.py:134` |
 
 ##### `make_grammar` (`blib2to3/pgen2/pgen.py:49`)
 
-|      % |     Size | Samples | Caller             | Location                     |
-| -----: | -------: | ------: | ------------------ | ---------------------------- |
-| 100.0% | 1.01 MiB |       6 | `generate_grammar` | `blib2to3/pgen2/pgen.py:426` |
+|      % |     Size | Allocations | Caller             | Location                     |
+| -----: | -------: | ----------: | ------------------ | ---------------------------- |
+| 100.0% | 1.01 MiB |           6 | `generate_grammar` | `blib2to3/pgen2/pgen.py:426` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 1.01 MiB |      11 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 1.01 MiB |          11 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|     % |  Size | Samples | Caller             | Location                 |
-| ----: | ----: | ------: | ------------------ | ------------------------ |
-| 99.9% | 1 MiB |       4 | `visit_default`    | `black/nodes.py:187`     |
-|  0.1% | 690 B |       1 | `_format_str_once` | `black/__init__.py:1236` |
+|     % |  Size | Allocations | Caller             | Location                 |
+| ----: | ----: | ----------: | ------------------ | ------------------------ |
+| 99.9% | 1 MiB |           4 | `visit_default`    | `black/nodes.py:187`     |
+|  0.1% | 690 B |           1 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `addtoken` (`blib2to3/pgen2/parse.py:242`)
 
-|      % |  Size | Samples | Caller         | Location                       |
-| -----: | ----: | ------: | -------------- | ------------------------------ |
-| 100.0% | 1 MiB |       3 | `parse_tokens` | `blib2to3/pgen2/driver.py:114` |
+|      % |  Size | Allocations | Caller         | Location                       |
+| -----: | ----: | ----------: | -------------- | ------------------------------ |
+| 100.0% | 1 MiB |           3 | `parse_tokens` | `blib2to3/pgen2/driver.py:114` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|     % |  Size | Samples | Caller         | Location               |
-| ----: | ----: | ------: | -------------- | ---------------------- |
-| 99.9% | 1 MiB |       1 | `visit`        | `black/nodes.py:163`   |
-|  0.1% | 702 B |       1 | `visit_STRING` | `black/linegen.py:413` |
+|     % |  Size | Allocations | Caller         | Location               |
+| ----: | ----: | ----------: | -------------- | ---------------------- |
+| 99.9% | 1 MiB |           1 | `visit`        | `black/nodes.py:163`   |
+|  0.1% | 702 B |           1 | `visit_STRING` | `black/linegen.py:413` |
 
 ##### `pop` (`blib2to3/pgen2/parse.py:398`)
 
-|      % |  Size | Samples | Caller      | Location                      |
-| -----: | ----: | ------: | ----------- | ----------------------------- |
-| 100.0% | 1 MiB |       1 | `_addtoken` | `blib2to3/pgen2/parse.py:290` |
+|      % |  Size | Allocations | Caller      | Location                      |
+| -----: | ----: | ----------: | ----------- | ----------------------------- |
+| 100.0% | 1 MiB |           1 | `_addtoken` | `blib2to3/pgen2/parse.py:290` |
 
 ##### `lines_with_leading_tabs_expanded` (`black/strings.py:46`)
 
-|      % |  Size | Samples | Caller          | Location              |
-| -----: | ----: | ------: | --------------- | --------------------- |
-| 100.0% | 1 MiB |       1 | `fix_docstring` | `black/strings.py:65` |
+|      % |  Size | Allocations | Caller          | Location              |
+| -----: | ----: | ----------: | --------------- | --------------------- |
+| 100.0% | 1 MiB |           1 | `fix_docstring` | `black/strings.py:65` |
 
 ##### `is_import` (`black/lines.py:134`)
 
-|      % |  Size | Samples | Caller               | Location             |
-| -----: | ----: | ------: | -------------------- | -------------------- |
-| 100.0% | 1 MiB |       1 | `_maybe_empty_lines` | `black/lines.py:610` |
+|      % |  Size | Allocations | Caller               | Location             |
+| -----: | ----: | ----------: | -------------------- | -------------------- |
+| 100.0% | 1 MiB |           1 | `_maybe_empty_lines` | `black/lines.py:610` |
 
 ##### `__init__` (`<string>:2`)
 
-|      % |  Size | Samples | Caller | Location               |
-| -----: | ----: | ------: | ------ | ---------------------- |
-| 100.0% | 1 MiB |       1 | `line` | `black/linegen.py:109` |
+|      % |  Size | Allocations | Caller | Location               |
+| -----: | ----: | ----------: | ------ | ---------------------- |
+| 100.0% | 1 MiB |           1 | `line` | `black/linegen.py:109` |
 
 ##### `_compile_bytecode` (`<frozen importlib._bootstrap_external>:727`)
 
-|      % |    Size | Samples | Caller     | Location                                      |
-| -----: | ------: | ------: | ---------- | --------------------------------------------- |
-| 100.0% | 311 KiB |     341 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
+|      % |    Size | Allocations | Caller     | Location                                      |
+| -----: | ------: | ----------: | ---------- | --------------------------------------------- |
+| 100.0% | 311 KiB |         341 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `_format_str_once` (`black/__init__.py:1236`)
 
-|      % |    Size | Samples | Caller       | Location                 |
-| -----: | ------: | ------: | ------------ | ------------------------ |
-| 100.0% | 225 KiB |       5 | `format_str` | `black/__init__.py:1189` |
+|      % |    Size | Allocations | Caller       | Location                 |
+| -----: | ------: | ----------: | ------------ | ------------------------ |
+| 100.0% | 225 KiB |           5 | `format_str` | `black/__init__.py:1189` |
 
 ##### `decode` (`<frozen codecs>:319`)
 
-|      % |    Size | Samples | Caller         | Location                 |
-| -----: | ------: | ------: | -------------- | ------------------------ |
-| 100.0% | 222 KiB |       1 | `decode_bytes` | `black/__init__.py:1290` |
+|      % |    Size | Allocations | Caller         | Location                 |
+| -----: | ------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 222 KiB |           1 | `decode_bytes` | `black/__init__.py:1290` |
 
 ##### `_code_to_timestamp_pyc` (`<frozen importlib._bootstrap_external>:740`)
 
-|      % |    Size | Samples | Caller     | Location                                      |
-| -----: | ------: | ------: | ---------- | --------------------------------------------- |
-| 100.0% | 112 KiB |     108 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
+|      % |    Size | Allocations | Caller     | Location                                      |
+| -----: | ------: | ----------: | ---------- | --------------------------------------------- |
+| 100.0% | 112 KiB |         108 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `__new__` (`<frozen abc>:105`)
 
-|     % |     Size | Samples | Caller     | Location                                                       |
-| ----: | -------: | ------: | ---------- | -------------------------------------------------------------- |
-| 50.5% | 38.2 KiB |      45 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`          |
-| 23.1% | 17.5 KiB |      18 | `<module>` | `black/trans.py:1`                                             |
-| 18.3% | 13.9 KiB |       9 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`           |
-|  8.0% | 6.07 KiB |       7 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
+|     % |     Size | Allocations | Caller     | Location                                                       |
+| ----: | -------: | ----------: | ---------- | -------------------------------------------------------------- |
+| 50.5% | 38.2 KiB |          45 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`          |
+| 23.1% | 17.5 KiB |          18 | `<module>` | `black/trans.py:1`                                             |
+| 18.3% | 13.9 KiB |           9 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`           |
+|  8.0% | 6.07 KiB |           7 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
 
 ##### `normalize_string_prefix` (`black/strings.py:143`)
 
-|      % |     Size | Samples | Caller         | Location               |
-| -----: | -------: | ------: | -------------- | ---------------------- |
-| 100.0% | 57.2 KiB |      65 | `visit_STRING` | `black/linegen.py:413` |
+|      % |     Size | Allocations | Caller         | Location               |
+| -----: | -------: | ----------: | -------------- | ---------------------- |
+| 100.0% | 57.2 KiB |          65 | `visit_STRING` | `black/linegen.py:413` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|      % |     Size | Samples | Caller      | Location                                                     |
-| -----: | -------: | ------: | ----------- | ------------------------------------------------------------ |
-| 100.0% | 44.3 KiB |      31 | `decorator` | `/venv/lib/python3.11/site-packages/click/decorators.py:373` |
+|      % |     Size | Allocations | Caller      | Location                                                     |
+| -----: | -------: | ----------: | ----------- | ------------------------------------------------------------ |
+| 100.0% | 44.3 KiB |          31 | `decorator` | `/venv/lib/python3.11/site-packages/click/decorators.py:373` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 42 KiB |       7 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 42 KiB |           7 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `copy` (`blib2to3/pgen2/grammar.py:131`)
 
-|      % |     Size | Samples | Caller       | Location                 |
-| -----: | -------: | ------: | ------------ | ------------------------ |
-| 100.0% | 41.5 KiB |      16 | `initialize` | `blib2to3/pygram.py:165` |
+|      % |     Size | Allocations | Caller       | Location                 |
+| -----: | -------: | ----------: | ------------ | ------------------------ |
+| 100.0% | 41.5 KiB |          16 | `initialize` | `blib2to3/pygram.py:165` |
 
 ##### `classify` (`blib2to3/pgen2/parse.py:336`)
 
-|      % |   Size | Samples | Caller     | Location                      |
-| -----: | -----: | ------: | ---------- | ----------------------------- |
-| 100.0% | 32 KiB |       1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
+|      % |   Size | Allocations | Caller     | Location                      |
+| -----: | -----: | ----------: | ---------- | ----------------------------- |
+| 100.0% | 32 KiB |           1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 25 KiB |      22 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 25 KiB |          22 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__new__` (`/usr/lib/python3.11/enum.py:488`)
 
-|     % |     Size | Samples | Caller     | Location                                                     |
-| ----: | -------: | ------: | ---------- | ------------------------------------------------------------ |
-| 31.7% | 7.64 KiB |       9 | `<module>` | `black/mode.py:1`                                            |
-| 16.2% | 3.89 KiB |       4 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/_elffile.py:1` |
-| 13.7% |  3.3 KiB |       3 | `<module>` | `/venv/lib/python3.11/site-packages/click/_utils.py:1`       |
-| 10.1% | 2.44 KiB |       3 | `<module>` | `black/__init__.py:1`                                        |
-|  7.2% | 1.74 KiB |       2 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`         |
+|     % |     Size | Allocations | Caller     | Location                                                     |
+| ----: | -------: | ----------: | ---------- | ------------------------------------------------------------ |
+| 31.7% | 7.64 KiB |           9 | `<module>` | `black/mode.py:1`                                            |
+| 16.2% | 3.89 KiB |           4 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/_elffile.py:1` |
+| 13.7% |  3.3 KiB |           3 | `<module>` | `/venv/lib/python3.11/site-packages/click/_utils.py:1`       |
+| 10.1% | 2.44 KiB |           3 | `<module>` | `black/__init__.py:1`                                        |
+|  7.2% | 1.74 KiB |           2 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`         |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|      % |     Size | Samples | Caller     | Location                                 |
-| -----: | -------: | ------: | ---------- | ---------------------------------------- |
-| 100.0% | 22.6 KiB |      12 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
+|      % |     Size | Allocations | Caller     | Location                                 |
+| -----: | -------: | ----------: | ---------- | ---------------------------------------- |
+| 100.0% | 22.6 KiB |          12 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/_parser.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 19.8 KiB |      12 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 19.8 KiB |          12 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__new__` (`/usr/lib/python3.11/typing.py:2891`)
 
-|     % |     Size | Samples | Caller     | Location                                                    |
-| ----: | -------: | ------: | ---------- | ----------------------------------------------------------- |
-| 90.3% | 15.7 KiB |      19 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`       |
-|  9.7% | 1.69 KiB |       2 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/version.py:1` |
+|     % |     Size | Allocations | Caller     | Location                                                    |
+| ----: | -------: | ----------: | ---------- | ----------------------------------------------------------- |
+| 90.3% | 15.7 KiB |          19 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`       |
+|  9.7% | 1.69 KiB |           2 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/version.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/mypy_extensions.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 15 KiB |      18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 15 KiB |          18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/exceptions.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 13.4 KiB |      15 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 13.4 KiB |          15 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `inner` (`/usr/lib/python3.11/typing.py:338`)
 
-|     % |     Size | Samples | Caller        | Location                                              |
-| ----: | -------: | ------: | ------------- | ----------------------------------------------------- |
-| 75.3% | 9.02 KiB |       1 | `Line`        | `black/lines.py:49`                                   |
-| 17.9% | 2.15 KiB |       1 | `__getitem__` | `/usr/lib/python3.11/typing.py:467`                   |
-|  6.7% |    826 B |       1 | `<module>`    | `/venv/lib/python3.11/site-packages/click/types.py:1` |
+|     % |     Size | Allocations | Caller        | Location                                              |
+| ----: | -------: | ----------: | ------------- | ----------------------------------------------------- |
+| 75.3% | 9.02 KiB |           1 | `Line`        | `black/lines.py:49`                                   |
+| 17.9% | 2.15 KiB |           1 | `__getitem__` | `/usr/lib/python3.11/typing.py:467`                   |
+|  6.7% |    826 B |           1 | `<module>`    | `/venv/lib/python3.11/site-packages/click/types.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/version.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 9.61 KiB |       9 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 9.61 KiB |           9 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `_fill_cache` (`<frozen importlib._bootstrap_external>:1655`)
 
-|      % |  Size | Samples | Caller      | Location                                      |
-| -----: | ----: | ------: | ----------- | --------------------------------------------- |
-| 100.0% | 8 KiB |       4 | `find_spec` | `<frozen importlib._bootstrap_external>:1604` |
+|      % |  Size | Allocations | Caller      | Location                                      |
+| -----: | ----: | ----------: | ----------- | --------------------------------------------- |
+| 100.0% | 8 KiB |           4 | `find_spec` | `<frozen importlib._bootstrap_external>:1604` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|      % |     Size | Samples | Caller  | Location                                |
-| -----: | -------: | ------: | ------- | --------------------------------------- |
-| 100.0% | 7.97 KiB |       1 | `parse` | `/usr/lib/python3.11/re/_parser.py:970` |
+|      % |     Size | Allocations | Caller  | Location                                |
+| -----: | -------: | ----------: | ------- | --------------------------------------- |
+| 100.0% | 7.97 KiB |           1 | `parse` | `/usr/lib/python3.11/re/_parser.py:970` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/utils.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 7.08 KiB |       8 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 7.08 KiB |           8 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__setattr__` (`/usr/lib/python3.11/enum.py:831`)
 
-|     % |     Size | Samples | Caller         | Location                          |
-| ----: | -------: | ------: | -------------- | --------------------------------- |
-| 66.6% | 4.48 KiB |       5 | `__set_name__` | `/usr/lib/python3.11/enum.py:237` |
-| 33.4% | 2.25 KiB |       3 | `__new__`      | `/usr/lib/python3.11/enum.py:488` |
+|     % |     Size | Allocations | Caller         | Location                          |
+| ----: | -------: | ----------: | -------------- | --------------------------------- |
+| 66.6% | 4.48 KiB |           5 | `__set_name__` | `/usr/lib/python3.11/enum.py:237` |
+| 33.4% | 2.25 KiB |           3 | `__new__`      | `/usr/lib/python3.11/enum.py:488` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/util.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 6.48 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 6.48 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 6.24 KiB |       5 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 6.24 KiB |           5 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/_compat.py:1`)
 
-|      % |    Size | Samples | Caller                      | Location                            |
-| -----: | ------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 5.8 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |    Size | Allocations | Caller                      | Location                            |
+| -----: | ------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 5.8 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `namedtuple` (`/usr/lib/python3.11/collections/__init__.py:348`)
 
-|     % |     Size | Samples | Caller          | Location                             |
-| ----: | -------: | ------: | --------------- | ------------------------------------ |
-| 83.3% | 4.69 KiB |       5 | `_make_nmtuple` | `/usr/lib/python3.11/typing.py:2795` |
-| 16.7% |    960 B |       1 | `<module>`      | `/usr/lib/python3.11/pkgutil.py:1`   |
+|     % |     Size | Allocations | Caller          | Location                             |
+| ----: | -------: | ----------: | --------------- | ------------------------------------ |
+| 83.3% | 4.69 KiB |           5 | `_make_nmtuple` | `/usr/lib/python3.11/typing.py:2795` |
+| 16.7% |    960 B |           1 | `<module>`      | `/usr/lib/python3.11/pkgutil.py:1`   |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|      % |     Size | Samples | Caller       | Location                                |
-| -----: | -------: | ------: | ------------ | --------------------------------------- |
-| 100.0% | 5.61 KiB |       3 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
+|      % |     Size | Allocations | Caller       | Location                                |
+| -----: | -------: | ----------: | ------------ | --------------------------------------- |
+| 100.0% | 5.61 KiB |           3 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
 
 ##### `_code` (`/usr/lib/python3.11/re/_compiler.py:571`)
 
-|      % |     Size | Samples | Caller    | Location                                  |
-| -----: | -------: | ------: | --------- | ----------------------------------------- |
-| 100.0% | 5.32 KiB |       2 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
+|      % |     Size | Allocations | Caller    | Location                                  |
+| -----: | -------: | ----------: | --------- | ----------------------------------------- |
+| 100.0% | 5.32 KiB |           2 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
 
 ##### `<module>` (`/usr/lib/python3.11/pkgutil.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 4.73 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 4.73 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `Specifier` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`)
 
-|      % |     Size | Samples | Caller     | Location                                                       |
-| -----: | -------: | ------: | ---------- | -------------------------------------------------------------- |
-| 100.0% | 3.82 KiB |       1 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
+|      % |     Size | Allocations | Caller     | Location                                                       |
+| -----: | -------: | ----------: | ---------- | -------------------------------------------------------------- |
+| 100.0% | 3.82 KiB |           1 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Caller   | Location                                               |
-| -----: | -------: | ------: | -------- | ------------------------------------------------------ |
-| 100.0% | 3.79 KiB |       3 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
+|      % |     Size | Allocations | Caller   | Location                                               |
+| -----: | -------: | ----------: | -------- | ------------------------------------------------------ |
+| 100.0% | 3.79 KiB |           3 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.72 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.72 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.56 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.56 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `handle_parse_result` (`/venv/lib/python3.11/site-packages/click/core.py:2663`)
 
-|      % |     Size | Samples | Caller       | Location                                                |
-| -----: | -------: | ------: | ------------ | ------------------------------------------------------- |
-| 100.0% | 3.37 KiB |       5 | `parse_args` | `/venv/lib/python3.11/site-packages/click/core.py:1303` |
+|      % |     Size | Allocations | Caller       | Location                                                |
+| -----: | -------: | ----------: | ------------ | ------------------------------------------------------- |
+| 100.0% | 3.37 KiB |           5 | `parse_args` | `/venv/lib/python3.11/site-packages/click/core.py:1303` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.19 KiB |       1 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.19 KiB |           1 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.19 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.19 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|      % |     Size | Samples | Caller     | Location                                                   |
-| -----: | -------: | ------: | ---------- | ---------------------------------------------------------- |
-| 100.0% | 2.85 KiB |       1 | `<module>` | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1` |
+|      % |     Size | Allocations | Caller     | Location                                                   |
+| -----: | -------: | ----------: | ---------- | ---------------------------------------------------------- |
+| 100.0% | 2.85 KiB |           1 | `<module>` | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1` |
 
 ##### `_process_class` (`/usr/lib/python3.11/dataclasses.py:884`)
 
-|      % |     Size | Samples | Caller | Location                                  |
-| -----: | -------: | ------: | ------ | ----------------------------------------- |
-| 100.0% | 2.85 KiB |       4 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
+|      % |     Size | Allocations | Caller | Location                                  |
+| -----: | -------: | ----------: | ------ | ----------------------------------------- |
+| 100.0% | 2.85 KiB |           4 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.81 KiB |       3 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.81 KiB |           3 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.76 KiB |       2 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.76 KiB |           2 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ### Total size
 
 Functions ranked by total bytes held at peak memory in the function and all its callees.
 
-|      % |     Size | Samples | Function               | Location                                                       |
-| -----: | -------: | ------: | ---------------------- | -------------------------------------------------------------- |
-| 100.0% | 72.4 MiB |  23,696 | `_run_tracker`         | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
-| 100.0% | 72.4 MiB |  23,695 | `run_module`           | `<frozen runpy>:201`                                           |
-|  92.5% |   67 MiB |  22,200 | `__call__`             | `/venv/lib/python3.11/site-packages/click/core.py:1567`        |
-|  92.5% |   67 MiB |  22,200 | `patched_main`         | `black/__init__.py:1594`                                       |
-|  92.5% |   67 MiB |  22,200 | `<module>`             | `black/__main__.py:1`                                          |
-|  92.5% |   67 MiB |  22,200 | `_run_code`            | `<frozen runpy>:65`                                            |
-|  92.5% |   67 MiB |  22,200 | `_run_module_code`     | `<frozen runpy>:91`                                            |
-|  92.5% |   67 MiB |  22,199 | `main`                 | `/venv/lib/python3.11/site-packages/click/core.py:1422`        |
-|  92.4% | 66.9 MiB |  22,180 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:1339`        |
-|  92.4% | 66.9 MiB |  22,177 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:853`         |
-|  92.4% | 66.9 MiB |  22,175 | `new_func`             | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
-|  92.4% | 66.9 MiB |  22,172 | `main`                 | `black/__init__.py:244`                                        |
-|  92.4% | 66.9 MiB |  22,168 | `reformat_one`         | `black/__init__.py:860`                                        |
-|  92.4% | 66.9 MiB |  22,165 | `format_file_in_place` | `black/__init__.py:917`                                        |
-|  92.1% | 66.7 MiB |  22,162 | `format_file_contents` | `black/__init__.py:1054`                                       |
-|  70.1% | 50.8 MiB |  21,147 | `format_str`           | `black/__init__.py:1189`                                       |
-|  70.1% | 50.8 MiB |  21,146 | `_format_str_once`     | `black/__init__.py:1236`                                       |
-|  48.9% | 35.4 MiB |  21,086 | `visit`                | `black/nodes.py:163`                                           |
-|  48.9% | 35.4 MiB |  21,084 | `visit_default`        | `black/linegen.py:134`                                         |
-|  48.9% | 35.4 MiB |  21,084 | `visit_default`        | `black/nodes.py:187`                                           |
+|      % |     Size | Allocations | Function               | Location                                                       |
+| -----: | -------: | ----------: | ---------------------- | -------------------------------------------------------------- |
+| 100.0% | 72.4 MiB |      23,696 | `_run_tracker`         | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
+| 100.0% | 72.4 MiB |      23,695 | `run_module`           | `<frozen runpy>:201`                                           |
+|  92.5% |   67 MiB |      22,200 | `__call__`             | `/venv/lib/python3.11/site-packages/click/core.py:1567`        |
+|  92.5% |   67 MiB |      22,200 | `patched_main`         | `black/__init__.py:1594`                                       |
+|  92.5% |   67 MiB |      22,200 | `<module>`             | `black/__main__.py:1`                                          |
+|  92.5% |   67 MiB |      22,200 | `_run_code`            | `<frozen runpy>:65`                                            |
+|  92.5% |   67 MiB |      22,200 | `_run_module_code`     | `<frozen runpy>:91`                                            |
+|  92.5% |   67 MiB |      22,199 | `main`                 | `/venv/lib/python3.11/site-packages/click/core.py:1422`        |
+|  92.4% | 66.9 MiB |      22,180 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:1339`        |
+|  92.4% | 66.9 MiB |      22,177 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:853`         |
+|  92.4% | 66.9 MiB |      22,175 | `new_func`             | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
+|  92.4% | 66.9 MiB |      22,172 | `main`                 | `black/__init__.py:244`                                        |
+|  92.4% | 66.9 MiB |      22,168 | `reformat_one`         | `black/__init__.py:860`                                        |
+|  92.4% | 66.9 MiB |      22,165 | `format_file_in_place` | `black/__init__.py:917`                                        |
+|  92.1% | 66.7 MiB |      22,162 | `format_file_contents` | `black/__init__.py:1054`                                       |
+|  70.1% | 50.8 MiB |      21,147 | `format_str`           | `black/__init__.py:1189`                                       |
+|  70.1% | 50.8 MiB |      21,146 | `_format_str_once`     | `black/__init__.py:1236`                                       |
+|  48.9% | 35.4 MiB |      21,086 | `visit`                | `black/nodes.py:163`                                           |
+|  48.9% | 35.4 MiB |      21,084 | `visit_default`        | `black/linegen.py:134`                                         |
+|  48.9% | 35.4 MiB |      21,084 | `visit_default`        | `black/nodes.py:187`                                           |
 
 #### Categories
 
 ##### Ours
 
-|     % |     Size | Samples | Function                          | Location                 |
-| ----: | -------: | ------: | --------------------------------- | ------------------------ |
-| 92.5% |   67 MiB |  22,200 | `patched_main`                    | `black/__init__.py:1594` |
-| 92.5% |   67 MiB |  22,200 | `<module>`                        | `black/__main__.py:1`    |
-| 92.4% | 66.9 MiB |  22,172 | `main`                            | `black/__init__.py:244`  |
-| 92.4% | 66.9 MiB |  22,168 | `reformat_one`                    | `black/__init__.py:860`  |
-| 92.4% | 66.9 MiB |  22,165 | `format_file_in_place`            | `black/__init__.py:917`  |
-| 92.1% | 66.7 MiB |  22,162 | `format_file_contents`            | `black/__init__.py:1054` |
-| 70.1% | 50.8 MiB |  21,147 | `format_str`                      | `black/__init__.py:1189` |
-| 70.1% | 50.8 MiB |  21,146 | `_format_str_once`                | `black/__init__.py:1236` |
-| 48.9% | 35.4 MiB |  21,086 | `visit`                           | `black/nodes.py:163`     |
-| 48.9% | 35.4 MiB |  21,084 | `visit_default`                   | `black/linegen.py:134`   |
-| 48.9% | 35.4 MiB |  21,084 | `visit_default`                   | `black/nodes.py:187`     |
-| 48.6% | 35.2 MiB |  20,713 | `visit_stmt`                      | `black/linegen.py:199`   |
-| 48.1% | 34.8 MiB |  20,272 | `visit_funcdef`                   | `black/linegen.py:254`   |
-| 48.0% | 34.7 MiB |  20,146 | `visit_suite`                     | `black/linegen.py:288`   |
-| 32.9% | 23.8 MiB |  13,402 | `visit_simple_stmt`               | `black/linegen.py:295`   |
-| 29.4% | 21.3 MiB |  20,886 | `append`                          | `black/lines.py:63`      |
-| 26.5% | 19.2 MiB |  20,791 | `mark`                            | `black/brackets.py:70`   |
-| 22.0% |   16 MiB |   1,015 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
-| 22.0% |   16 MiB |   1,014 | `_parse_single_version`           | `black/parsing.py:117`   |
-| 22.0% |   16 MiB |   1,014 | `parse_ast`                       | `black/parsing.py:129`   |
+|     % |     Size | Allocations | Function                          | Location                 |
+| ----: | -------: | ----------: | --------------------------------- | ------------------------ |
+| 92.5% |   67 MiB |      22,200 | `patched_main`                    | `black/__init__.py:1594` |
+| 92.5% |   67 MiB |      22,200 | `<module>`                        | `black/__main__.py:1`    |
+| 92.4% | 66.9 MiB |      22,172 | `main`                            | `black/__init__.py:244`  |
+| 92.4% | 66.9 MiB |      22,168 | `reformat_one`                    | `black/__init__.py:860`  |
+| 92.4% | 66.9 MiB |      22,165 | `format_file_in_place`            | `black/__init__.py:917`  |
+| 92.1% | 66.7 MiB |      22,162 | `format_file_contents`            | `black/__init__.py:1054` |
+| 70.1% | 50.8 MiB |      21,147 | `format_str`                      | `black/__init__.py:1189` |
+| 70.1% | 50.8 MiB |      21,146 | `_format_str_once`                | `black/__init__.py:1236` |
+| 48.9% | 35.4 MiB |      21,086 | `visit`                           | `black/nodes.py:163`     |
+| 48.9% | 35.4 MiB |      21,084 | `visit_default`                   | `black/linegen.py:134`   |
+| 48.9% | 35.4 MiB |      21,084 | `visit_default`                   | `black/nodes.py:187`     |
+| 48.6% | 35.2 MiB |      20,713 | `visit_stmt`                      | `black/linegen.py:199`   |
+| 48.1% | 34.8 MiB |      20,272 | `visit_funcdef`                   | `black/linegen.py:254`   |
+| 48.0% | 34.7 MiB |      20,146 | `visit_suite`                     | `black/linegen.py:288`   |
+| 32.9% | 23.8 MiB |      13,402 | `visit_simple_stmt`               | `black/linegen.py:295`   |
+| 29.4% | 21.3 MiB |      20,886 | `append`                          | `black/lines.py:63`      |
+| 26.5% | 19.2 MiB |      20,791 | `mark`                            | `black/brackets.py:70`   |
+| 22.0% |   16 MiB |       1,015 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+| 22.0% |   16 MiB |       1,014 | `_parse_single_version`           | `black/parsing.py:117`   |
+| 22.0% |   16 MiB |       1,014 | `parse_ast`                       | `black/parsing.py:129`   |
 
 ##### Standard library
 
-|      % |     Size | Samples | Function                    | Location                                      |
-| -----: | -------: | ------: | --------------------------- | --------------------------------------------- |
-| 100.0% | 72.4 MiB |  23,695 | `run_module`                | `<frozen runpy>:201`                          |
-|  92.5% |   67 MiB |  22,200 | `_run_code`                 | `<frozen runpy>:65`                           |
-|  92.5% |   67 MiB |  22,200 | `_run_module_code`          | `<frozen runpy>:91`                           |
-|  22.0% |   16 MiB |   1,014 | `parse`                     | `/usr/lib/python3.11/ast.py:33`               |
-|   7.5% | 5.46 MiB |   1,494 | `_get_module_details`       | `<frozen runpy>:105`                          |
-|   7.5% | 5.45 MiB |   1,487 | `_find_and_load`            | `<frozen importlib._bootstrap>:1167`          |
-|   7.5% | 5.45 MiB |   1,485 | `_find_and_load_unlocked`   | `<frozen importlib._bootstrap>:1122`          |
-|   7.5% | 5.45 MiB |   1,484 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`           |
-|   7.5% | 5.45 MiB |   1,482 | `exec_module`               | `<frozen importlib._bootstrap_external>:934`  |
-|   7.5% | 5.43 MiB |   1,470 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
-|   3.7% | 2.69 MiB |     802 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
-|   3.1% | 2.27 MiB |     352 | `source_to_code`            | `<frozen importlib._bootstrap_external>:999`  |
-|   0.4% |  333 KiB |     341 | `_handle_fromlist`          | `<frozen importlib._bootstrap>:1209`          |
-|   0.4% |  311 KiB |     341 | `_compile_bytecode`         | `<frozen importlib._bootstrap_external>:727`  |
-|   0.3% |  222 KiB |       1 | `decode`                    | `<frozen codecs>:319`                         |
-|   0.2% |  112 KiB |     108 | `_code_to_timestamp_pyc`    | `<frozen importlib._bootstrap_external>:740`  |
-|   0.1% | 75.7 KiB |      79 | `__new__`                   | `<frozen abc>:105`                            |
-|   0.1% | 47.8 KiB |      25 | `compile`                   | `/usr/lib/python3.11/re/__init__.py:225`      |
-|   0.1% | 47.1 KiB |      24 | `_compile`                  | `/usr/lib/python3.11/re/__init__.py:272`      |
-|   0.1% | 46.5 KiB |      23 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`     |
+|      % |     Size | Allocations | Function                    | Location                                      |
+| -----: | -------: | ----------: | --------------------------- | --------------------------------------------- |
+| 100.0% | 72.4 MiB |      23,695 | `run_module`                | `<frozen runpy>:201`                          |
+|  92.5% |   67 MiB |      22,200 | `_run_code`                 | `<frozen runpy>:65`                           |
+|  92.5% |   67 MiB |      22,200 | `_run_module_code`          | `<frozen runpy>:91`                           |
+|  22.0% |   16 MiB |       1,014 | `parse`                     | `/usr/lib/python3.11/ast.py:33`               |
+|   7.5% | 5.46 MiB |       1,494 | `_get_module_details`       | `<frozen runpy>:105`                          |
+|   7.5% | 5.45 MiB |       1,487 | `_find_and_load`            | `<frozen importlib._bootstrap>:1167`          |
+|   7.5% | 5.45 MiB |       1,485 | `_find_and_load_unlocked`   | `<frozen importlib._bootstrap>:1122`          |
+|   7.5% | 5.45 MiB |       1,484 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`           |
+|   7.5% | 5.45 MiB |       1,482 | `exec_module`               | `<frozen importlib._bootstrap_external>:934`  |
+|   7.5% | 5.43 MiB |       1,470 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
+|   3.7% | 2.69 MiB |         802 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
+|   3.1% | 2.27 MiB |         352 | `source_to_code`            | `<frozen importlib._bootstrap_external>:999`  |
+|   0.4% |  333 KiB |         341 | `_handle_fromlist`          | `<frozen importlib._bootstrap>:1209`          |
+|   0.4% |  311 KiB |         341 | `_compile_bytecode`         | `<frozen importlib._bootstrap_external>:727`  |
+|   0.3% |  222 KiB |           1 | `decode`                    | `<frozen codecs>:319`                         |
+|   0.2% |  112 KiB |         108 | `_code_to_timestamp_pyc`    | `<frozen importlib._bootstrap_external>:740`  |
+|   0.1% | 75.7 KiB |          79 | `__new__`                   | `<frozen abc>:105`                            |
+|   0.1% | 47.8 KiB |          25 | `compile`                   | `/usr/lib/python3.11/re/__init__.py:225`      |
+|   0.1% | 47.1 KiB |          24 | `_compile`                  | `/usr/lib/python3.11/re/__init__.py:272`      |
+|   0.1% | 46.5 KiB |          23 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`     |
 
 ##### Third-party
 
-|      % |     Size | Samples | Function       | Location                                                                         |
-| -----: | -------: | ------: | -------------- | -------------------------------------------------------------------------------- |
-| 100.0% | 72.4 MiB |  23,696 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40`                   |
-|  92.5% |   67 MiB |  22,200 | `__call__`     | `/venv/lib/python3.11/site-packages/click/core.py:1567`                          |
-|  92.5% |   67 MiB |  22,199 | `main`         | `/venv/lib/python3.11/site-packages/click/core.py:1422`                          |
-|  92.4% | 66.9 MiB |  22,180 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339`                          |
-|  92.4% | 66.9 MiB |  22,177 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:853`                           |
-|  92.4% | 66.9 MiB |  22,175 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                      |
-|   1.8% | 1.31 MiB |     304 | `<module>`     | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                         |
-|   1.7% | 1.23 MiB |     233 | `<module>`     | `/venv/lib/python3.11/site-packages/click/core.py:1`                             |
-|   1.4% | 1.02 MiB |      24 | `<module>`     | `/venv/lib/python3.11/site-packages/click/formatting.py:1`                       |
-|   1.4% | 1.01 MiB |      11 | `<module>`     | `/venv/lib/python3.11/site-packages/click/parser.py:1`                           |
-|   0.2% |  173 KiB |     141 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`                   |
-|   0.2% |  125 KiB |     127 | `<module>`     | `/venv/lib/python3.11/site-packages/click/types.py:1`                            |
-|   0.1% | 99.6 KiB |      72 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                        |
-|   0.1% | 93.8 KiB |     119 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`                      |
-|   0.1% | 91.5 KiB |     115 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`                     |
-|   0.1% | 74.5 KiB |      43 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                         |
-|   0.1% | 65.5 KiB |      84 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`                 |
-|   0.1% | 47.3 KiB |      33 | `decorator`    | `/venv/lib/python3.11/site-packages/click/decorators.py:373`                     |
-|   0.1% | 46.9 KiB |      59 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1` |
-|   0.1% | 45.5 KiB |      32 | `__init__`     | `/venv/lib/python3.11/site-packages/click/core.py:2883`                          |
+|      % |     Size | Allocations | Function       | Location                                                                         |
+| -----: | -------: | ----------: | -------------- | -------------------------------------------------------------------------------- |
+| 100.0% | 72.4 MiB |      23,696 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40`                   |
+|  92.5% |   67 MiB |      22,200 | `__call__`     | `/venv/lib/python3.11/site-packages/click/core.py:1567`                          |
+|  92.5% |   67 MiB |      22,199 | `main`         | `/venv/lib/python3.11/site-packages/click/core.py:1422`                          |
+|  92.4% | 66.9 MiB |      22,180 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339`                          |
+|  92.4% | 66.9 MiB |      22,177 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:853`                           |
+|  92.4% | 66.9 MiB |      22,175 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                      |
+|   1.8% | 1.31 MiB |         304 | `<module>`     | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                         |
+|   1.7% | 1.23 MiB |         233 | `<module>`     | `/venv/lib/python3.11/site-packages/click/core.py:1`                             |
+|   1.4% | 1.02 MiB |          24 | `<module>`     | `/venv/lib/python3.11/site-packages/click/formatting.py:1`                       |
+|   1.4% | 1.01 MiB |          11 | `<module>`     | `/venv/lib/python3.11/site-packages/click/parser.py:1`                           |
+|   0.2% |  173 KiB |         141 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`                   |
+|   0.2% |  125 KiB |         127 | `<module>`     | `/venv/lib/python3.11/site-packages/click/types.py:1`                            |
+|   0.1% | 99.6 KiB |          72 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                        |
+|   0.1% | 93.8 KiB |         119 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`                      |
+|   0.1% | 91.5 KiB |         115 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`                     |
+|   0.1% | 74.5 KiB |          43 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                         |
+|   0.1% | 65.5 KiB |          84 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`                 |
+|   0.1% | 47.3 KiB |          33 | `decorator`    | `/venv/lib/python3.11/site-packages/click/decorators.py:373`                     |
+|   0.1% | 46.9 KiB |          59 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1` |
+|   0.1% | 45.5 KiB |          32 | `__init__`     | `/venv/lib/python3.11/site-packages/click/core.py:2883`                          |
 
 #### Callees
 
@@ -1056,367 +1056,367 @@ Callees ranked by contribution to each function's total size. Inlining can make 
 
 ##### `_run_tracker` (`/venv/lib/python3.11/site-packages/memray/commands/run.py:40`)
 
-|      % |     Size | Samples | Callee       | Location             |
-| -----: | -------: | ------: | ------------ | -------------------- |
-| 100.0% | 72.4 MiB |  23,695 | `run_module` | `<frozen runpy>:201` |
+|      % |     Size | Allocations | Callee       | Location             |
+| -----: | -------: | ----------: | ------------ | -------------------- |
+| 100.0% | 72.4 MiB |      23,695 | `run_module` | `<frozen runpy>:201` |
 
 ##### `run_module` (`<frozen runpy>:201`)
 
-|     % |     Size | Samples | Callee                | Location             |
-| ----: | -------: | ------: | --------------------- | -------------------- |
-| 92.5% |   67 MiB |  22,200 | `_run_module_code`    | `<frozen runpy>:91`  |
-|  7.5% | 5.46 MiB |   1,494 | `_get_module_details` | `<frozen runpy>:105` |
+|     % |     Size | Allocations | Callee                | Location             |
+| ----: | -------: | ----------: | --------------------- | -------------------- |
+| 92.5% |   67 MiB |      22,200 | `_run_module_code`    | `<frozen runpy>:91`  |
+|  7.5% | 5.46 MiB |       1,494 | `_get_module_details` | `<frozen runpy>:105` |
 
 ##### `__call__` (`/venv/lib/python3.11/site-packages/click/core.py:1567`)
 
-|      % |   Size | Samples | Callee | Location                                                |
-| -----: | -----: | ------: | ------ | ------------------------------------------------------- |
-| 100.0% | 67 MiB |  22,199 | `main` | `/venv/lib/python3.11/site-packages/click/core.py:1422` |
+|      % |   Size | Allocations | Callee | Location                                                |
+| -----: | -----: | ----------: | ------ | ------------------------------------------------------- |
+| 100.0% | 67 MiB |      22,199 | `main` | `/venv/lib/python3.11/site-packages/click/core.py:1422` |
 
 ##### `patched_main` (`black/__init__.py:1594`)
 
-|      % |   Size | Samples | Callee     | Location                                                |
-| -----: | -----: | ------: | ---------- | ------------------------------------------------------- |
-| 100.0% | 67 MiB |  22,200 | `__call__` | `/venv/lib/python3.11/site-packages/click/core.py:1567` |
+|      % |   Size | Allocations | Callee     | Location                                                |
+| -----: | -----: | ----------: | ---------- | ------------------------------------------------------- |
+| 100.0% | 67 MiB |      22,200 | `__call__` | `/venv/lib/python3.11/site-packages/click/core.py:1567` |
 
 ##### `<module>` (`black/__main__.py:1`)
 
-|      % |   Size | Samples | Callee         | Location                 |
-| -----: | -----: | ------: | -------------- | ------------------------ |
-| 100.0% | 67 MiB |  22,200 | `patched_main` | `black/__init__.py:1594` |
+|      % |   Size | Allocations | Callee         | Location                 |
+| -----: | -----: | ----------: | -------------- | ------------------------ |
+| 100.0% | 67 MiB |      22,200 | `patched_main` | `black/__init__.py:1594` |
 
 ##### `_run_code` (`<frozen runpy>:65`)
 
-|      % |   Size | Samples | Callee     | Location              |
-| -----: | -----: | ------: | ---------- | --------------------- |
-| 100.0% | 67 MiB |  22,200 | `<module>` | `black/__main__.py:1` |
+|      % |   Size | Allocations | Callee     | Location              |
+| -----: | -----: | ----------: | ---------- | --------------------- |
+| 100.0% | 67 MiB |      22,200 | `<module>` | `black/__main__.py:1` |
 
 ##### `_run_module_code` (`<frozen runpy>:91`)
 
-|      % |   Size | Samples | Callee      | Location            |
-| -----: | -----: | ------: | ----------- | ------------------- |
-| 100.0% | 67 MiB |  22,200 | `_run_code` | `<frozen runpy>:65` |
+|      % |   Size | Allocations | Callee      | Location            |
+| -----: | -----: | ----------: | ----------- | ------------------- |
+| 100.0% | 67 MiB |      22,200 | `_run_code` | `<frozen runpy>:65` |
 
 ##### `main` (`/venv/lib/python3.11/site-packages/click/core.py:1422`)
 
-|      % |     Size | Samples | Callee         | Location                                                |
-| -----: | -------: | ------: | -------------- | ------------------------------------------------------- |
-| 100.0% | 66.9 MiB |  22,180 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339` |
-|  <0.1% | 14.1 KiB |      17 | `make_context` | `/venv/lib/python3.11/site-packages/click/core.py:1266` |
-|  <0.1% |     32 B |       1 | `__enter__`    | `/venv/lib/python3.11/site-packages/click/core.py:545`  |
+|      % |     Size | Allocations | Callee         | Location                                                |
+| -----: | -------: | ----------: | -------------- | ------------------------------------------------------- |
+| 100.0% | 66.9 MiB |      22,180 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339` |
+|  <0.1% | 14.1 KiB |          17 | `make_context` | `/venv/lib/python3.11/site-packages/click/core.py:1266` |
+|  <0.1% |     32 B |           1 | `__enter__`    | `/venv/lib/python3.11/site-packages/click/core.py:545`  |
 
 ##### `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:1339`)
 
-|      % |     Size | Samples | Callee   | Location                                               |
-| -----: | -------: | ------: | -------- | ------------------------------------------------------ |
-| 100.0% | 66.9 MiB |  22,177 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
+|      % |     Size | Allocations | Callee   | Location                                               |
+| -----: | -------: | ----------: | -------- | ------------------------------------------------------ |
+| 100.0% | 66.9 MiB |      22,177 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
 
 ##### `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`)
 
-|      % |     Size | Samples | Callee     | Location                                                    |
-| -----: | -------: | ------: | ---------- | ----------------------------------------------------------- |
-| 100.0% | 66.9 MiB |  22,175 | `new_func` | `/venv/lib/python3.11/site-packages/click/decorators.py:33` |
+|      % |     Size | Allocations | Callee     | Location                                                    |
+| -----: | -------: | ----------: | ---------- | ----------------------------------------------------------- |
+| 100.0% | 66.9 MiB |      22,175 | `new_func` | `/venv/lib/python3.11/site-packages/click/decorators.py:33` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Callee | Location                |
-| -----: | -------: | ------: | ------ | ----------------------- |
-| 100.0% | 66.9 MiB |  22,172 | `main` | `black/__init__.py:244` |
+|      % |     Size | Allocations | Callee | Location                |
+| -----: | -------: | ----------: | ------ | ----------------------- |
+| 100.0% | 66.9 MiB |      22,172 | `main` | `black/__init__.py:244` |
 
 ##### `main` (`black/__init__.py:244`)
 
-|      % |     Size | Samples | Callee         | Location                |
-| -----: | -------: | ------: | -------------- | ----------------------- |
-| 100.0% | 66.9 MiB |  22,168 | `reformat_one` | `black/__init__.py:860` |
-|  <0.1% | 2.06 KiB |       2 | `get_sources`  | `black/__init__.py:724` |
+|      % |     Size | Allocations | Callee         | Location                |
+| -----: | -------: | ----------: | -------------- | ----------------------- |
+| 100.0% | 66.9 MiB |      22,168 | `reformat_one` | `black/__init__.py:860` |
+|  <0.1% | 2.06 KiB |           2 | `get_sources`  | `black/__init__.py:724` |
 
 ##### `reformat_one` (`black/__init__.py:860`)
 
-|      % |     Size | Samples | Callee                 | Location                |
-| -----: | -------: | ------: | ---------------------- | ----------------------- |
-| 100.0% | 66.9 MiB |  22,165 | `format_file_in_place` | `black/__init__.py:917` |
-|  <0.1% | 1.13 KiB |       1 | `read`                 | `black/cache.py:60`     |
+|      % |     Size | Allocations | Callee                 | Location                |
+| -----: | -------: | ----------: | ---------------------- | ----------------------- |
+| 100.0% | 66.9 MiB |      22,165 | `format_file_in_place` | `black/__init__.py:917` |
+|  <0.1% | 1.13 KiB |           1 | `read`                 | `black/cache.py:60`     |
 
 ##### `format_file_in_place` (`black/__init__.py:917`)
 
-|     % |     Size | Samples | Callee                 | Location                 |
-| ----: | -------: | ------: | ---------------------- | ------------------------ |
-| 99.7% | 66.7 MiB |  22,162 | `format_file_contents` | `black/__init__.py:1054` |
-|  0.3% |  223 KiB |       2 | `decode_bytes`         | `black/__init__.py:1290` |
+|     % |     Size | Allocations | Callee                 | Location                 |
+| ----: | -------: | ----------: | ---------------------- | ------------------------ |
+| 99.7% | 66.7 MiB |      22,162 | `format_file_contents` | `black/__init__.py:1054` |
+|  0.3% |  223 KiB |           2 | `decode_bytes`         | `black/__init__.py:1290` |
 
 ##### `format_file_contents` (`black/__init__.py:1054`)
 
-|     % |     Size | Samples | Callee                            | Location                 |
-| ----: | -------: | ------: | --------------------------------- | ------------------------ |
-| 76.1% | 50.8 MiB |  21,147 | `format_str`                      | `black/__init__.py:1189` |
-| 23.9% |   16 MiB |   1,015 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+|     % |     Size | Allocations | Callee                            | Location                 |
+| ----: | -------: | ----------: | --------------------------------- | ------------------------ |
+| 76.1% | 50.8 MiB |      21,147 | `format_str`                      | `black/__init__.py:1189` |
+| 23.9% |   16 MiB |       1,015 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
 
 ##### `format_str` (`black/__init__.py:1189`)
 
-|      % |     Size | Samples | Callee             | Location                 |
-| -----: | -------: | ------: | ------------------ | ------------------------ |
-| 100.0% | 50.8 MiB |  21,146 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |     Size | Allocations | Callee             | Location                 |
+| -----: | -------: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 50.8 MiB |      21,146 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `_format_str_once` (`black/__init__.py:1236`)
 
-|     % |     Size | Samples | Callee              | Location                |
-| ----: | -------: | ------: | ------------------- | ----------------------- |
-| 69.8% | 35.4 MiB |  21,086 | `visit`             | `black/nodes.py:163`    |
-| 21.8% |   11 MiB |      30 | `lib2to3_parse`     | `black/parsing.py:55`   |
-|  5.9% | 3.01 MiB |      17 | `transform_line`    | `black/linegen.py:601`  |
-|  2.0% |    1 MiB |       3 | `maybe_empty_lines` | `black/lines.py:560`    |
-| <0.1% | 19.9 KiB |       3 | `normalize_fmt_off` | `black/comments.py:168` |
+|     % |     Size | Allocations | Callee              | Location                |
+| ----: | -------: | ----------: | ------------------- | ----------------------- |
+| 69.8% | 35.4 MiB |      21,086 | `visit`             | `black/nodes.py:163`    |
+| 21.8% |   11 MiB |          30 | `lib2to3_parse`     | `black/parsing.py:55`   |
+|  5.9% | 3.01 MiB |          17 | `transform_line`    | `black/linegen.py:601`  |
+|  2.0% |    1 MiB |           3 | `maybe_empty_lines` | `black/lines.py:560`    |
+| <0.1% | 19.9 KiB |           3 | `normalize_fmt_off` | `black/comments.py:168` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|      % |     Size | Samples | Callee              | Location               |
-| -----: | -------: | ------: | ------------------- | ---------------------- |
-| 100.0% | 35.4 MiB |  21,084 | `visit_default`     | `black/linegen.py:134` |
-|  99.2% | 35.2 MiB |  20,713 | `visit_stmt`        | `black/linegen.py:199` |
-|  98.2% | 34.8 MiB |  20,272 | `visit_funcdef`     | `black/linegen.py:254` |
-|  98.0% | 34.7 MiB |  20,146 | `visit_suite`       | `black/linegen.py:288` |
-|  67.2% | 23.8 MiB |  13,402 | `visit_simple_stmt` | `black/linegen.py:295` |
+|      % |     Size | Allocations | Callee              | Location               |
+| -----: | -------: | ----------: | ------------------- | ---------------------- |
+| 100.0% | 35.4 MiB |      21,084 | `visit_default`     | `black/linegen.py:134` |
+|  99.2% | 35.2 MiB |      20,713 | `visit_stmt`        | `black/linegen.py:199` |
+|  98.2% | 34.8 MiB |      20,272 | `visit_funcdef`     | `black/linegen.py:254` |
+|  98.0% | 34.7 MiB |      20,146 | `visit_suite`       | `black/linegen.py:288` |
+|  67.2% | 23.8 MiB |      13,402 | `visit_simple_stmt` | `black/linegen.py:295` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|      % |     Size | Samples | Callee              | Location               |
-| -----: | -------: | ------: | ------------------- | ---------------------- |
-| 100.0% | 35.4 MiB |  21,084 | `visit_default`     | `black/nodes.py:187`   |
-|  60.1% | 21.3 MiB |  20,886 | `append`            | `black/lines.py:63`    |
-|  16.9% |    6 MiB |       6 | `generate_comments` | `black/comments.py:52` |
+|      % |     Size | Allocations | Callee              | Location               |
+| -----: | -------: | ----------: | ------------------- | ---------------------- |
+| 100.0% | 35.4 MiB |      21,084 | `visit_default`     | `black/nodes.py:187`   |
+|  60.1% | 21.3 MiB |      20,886 | `append`            | `black/lines.py:63`    |
+|  16.9% |    6 MiB |           6 | `generate_comments` | `black/comments.py:52` |
 
 ##### `visit_default` (`black/nodes.py:187`)
 
-|      % |     Size | Samples | Callee  | Location             |
-| -----: | -------: | ------: | ------- | -------------------- |
-| 100.0% | 35.4 MiB |  21,084 | `visit` | `black/nodes.py:163` |
+|      % |     Size | Allocations | Callee  | Location             |
+| -----: | -------: | ----------: | ------- | -------------------- |
+| 100.0% | 35.4 MiB |      21,084 | `visit` | `black/nodes.py:163` |
 
 ##### `visit_stmt` (`black/linegen.py:199`)
 
-|      % |     Size | Samples | Callee                       | Location                |
-| -----: | -------: | ------: | ---------------------------- | ----------------------- |
-| 100.0% | 35.2 MiB |  20,711 | `visit`                      | `black/nodes.py:163`    |
-|  11.4% |    4 MiB |       5 | `normalize_invisible_parens` | `black/linegen.py:1328` |
+|      % |     Size | Allocations | Callee                       | Location                |
+| -----: | -------: | ----------: | ---------------------------- | ----------------------- |
+| 100.0% | 35.2 MiB |      20,711 | `visit`                      | `black/nodes.py:163`    |
+|  11.4% |    4 MiB |           5 | `normalize_invisible_parens` | `black/linegen.py:1328` |
 
 ##### `visit_funcdef` (`black/linegen.py:254`)
 
-|      % |     Size | Samples | Callee  | Location             |
-| -----: | -------: | ------: | ------- | -------------------- |
-| 100.0% | 34.8 MiB |  20,272 | `visit` | `black/nodes.py:163` |
+|      % |     Size | Allocations | Callee  | Location             |
+| -----: | -------: | ----------: | ------- | -------------------- |
+| 100.0% | 34.8 MiB |      20,272 | `visit` | `black/nodes.py:163` |
 
 ##### `visit_suite` (`black/linegen.py:288`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 34.7 MiB |  20,146 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 34.7 MiB |      20,146 | `visit_default` | `black/linegen.py:134` |
 
 ##### `visit_simple_stmt` (`black/linegen.py:295`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 23.8 MiB |  13,402 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 23.8 MiB |      13,402 | `visit_default` | `black/linegen.py:134` |
 
 ##### `append` (`black/lines.py:63`)
 
-|     % |     Size | Samples | Callee       | Location               |
-| ----: | -------: | ------: | ------------ | ---------------------- |
-| 85.6% | 18.2 MiB |  20,790 | `mark`       | `black/brackets.py:70` |
-| 14.3% | 3.05 MiB |      92 | `whitespace` | `black/nodes.py:194`   |
+|     % |     Size | Allocations | Callee       | Location               |
+| ----: | -------: | ----------: | ------------ | ---------------------- |
+| 85.6% | 18.2 MiB |      20,790 | `mark`       | `black/brackets.py:70` |
+| 14.3% | 3.05 MiB |          92 | `whitespace` | `black/nodes.py:194`   |
 
 ##### `check_stability_and_equivalence` (`black/__init__.py:1037`)
 
-|      % |   Size | Samples | Callee              | Location                 |
-| -----: | -----: | ------: | ------------------- | ------------------------ |
-| 100.0% | 16 MiB |   1,014 | `assert_equivalent` | `black/__init__.py:1524` |
+|      % |   Size | Allocations | Callee              | Location                 |
+| -----: | -----: | ----------: | ------------------- | ------------------------ |
+| 100.0% | 16 MiB |       1,014 | `assert_equivalent` | `black/__init__.py:1524` |
 
 ##### `_parse_single_version` (`black/parsing.py:117`)
 
-|      % |   Size | Samples | Callee  | Location                        |
-| -----: | -----: | ------: | ------- | ------------------------------- |
-| 100.0% | 16 MiB |   1,014 | `parse` | `/usr/lib/python3.11/ast.py:33` |
+|      % |   Size | Allocations | Callee  | Location                        |
+| -----: | -----: | ----------: | ------- | ------------------------------- |
+| 100.0% | 16 MiB |       1,014 | `parse` | `/usr/lib/python3.11/ast.py:33` |
 
 ##### `parse_ast` (`black/parsing.py:129`)
 
-|      % |   Size | Samples | Callee                  | Location               |
-| -----: | -----: | ------: | ----------------------- | ---------------------- |
-| 100.0% | 16 MiB |   1,014 | `_parse_single_version` | `black/parsing.py:117` |
+|      % |   Size | Allocations | Callee                  | Location               |
+| -----: | -----: | ----------: | ----------------------- | ---------------------- |
+| 100.0% | 16 MiB |       1,014 | `_parse_single_version` | `black/parsing.py:117` |
 
 ##### `_get_module_details` (`<frozen runpy>:105`)
 
-|     % |     Size | Samples | Callee                | Location                             |
-| ----: | -------: | ------: | --------------------- | ------------------------------------ |
-| 99.9% | 5.45 MiB |   1,487 | `_find_and_load`      | `<frozen importlib._bootstrap>:1167` |
-| 99.9% | 5.45 MiB |   1,487 | `_get_module_details` | `<frozen runpy>:105`                 |
-|  0.1% | 5.66 KiB |       6 | `find_spec`           | `<frozen importlib.util>:73`         |
+|     % |     Size | Allocations | Callee                | Location                             |
+| ----: | -------: | ----------: | --------------------- | ------------------------------------ |
+| 99.9% | 5.45 MiB |       1,487 | `_find_and_load`      | `<frozen importlib._bootstrap>:1167` |
+| 99.9% | 5.45 MiB |       1,487 | `_get_module_details` | `<frozen runpy>:105`                 |
+|  0.1% | 5.66 KiB |           6 | `find_spec`           | `<frozen importlib.util>:73`         |
 
 ##### `_find_and_load` (`<frozen importlib._bootstrap>:1167`)
 
-|      % |     Size | Samples | Callee                    | Location                             |
-| -----: | -------: | ------: | ------------------------- | ------------------------------------ |
-| 100.0% | 5.45 MiB |   1,485 | `_find_and_load_unlocked` | `<frozen importlib._bootstrap>:1122` |
-|  <0.1% |    560 B |       1 | `__enter__`               | `<frozen importlib._bootstrap>:169`  |
+|      % |     Size | Allocations | Callee                    | Location                             |
+| -----: | -------: | ----------: | ------------------------- | ------------------------------------ |
+| 100.0% | 5.45 MiB |       1,485 | `_find_and_load_unlocked` | `<frozen importlib._bootstrap>:1122` |
+|  <0.1% |    560 B |           1 | `__enter__`               | `<frozen importlib._bootstrap>:169`  |
 
 ##### `_find_and_load_unlocked` (`<frozen importlib._bootstrap>:1122`)
 
-|      % |     Size | Samples | Callee                      | Location                             |
-| -----: | -------: | ------: | --------------------------- | ------------------------------------ |
-| 100.0% | 5.45 MiB |   1,484 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`  |
-|   0.7% | 37.2 KiB |      47 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`  |
-|   0.1% | 7.48 KiB |       4 | `_find_spec`                | `<frozen importlib._bootstrap>:1056` |
+|      % |     Size | Allocations | Callee                      | Location                             |
+| -----: | -------: | ----------: | --------------------------- | ------------------------------------ |
+| 100.0% | 5.45 MiB |       1,484 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`  |
+|   0.7% | 37.2 KiB |          47 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`  |
+|   0.1% | 7.48 KiB |           4 | `_find_spec`                | `<frozen importlib._bootstrap>:1056` |
 
 ##### `_load_unlocked` (`<frozen importlib._bootstrap>:666`)
 
-|      % |     Size | Samples | Callee             | Location                                     |
-| -----: | -------: | ------: | ------------------ | -------------------------------------------- |
-| 100.0% | 5.45 MiB |   1,482 | `exec_module`      | `<frozen importlib._bootstrap_external>:934` |
-|  <0.1% | 1.83 KiB |       2 | `module_from_spec` | `<frozen importlib._bootstrap>:566`          |
+|      % |     Size | Allocations | Callee             | Location                                     |
+| -----: | -------: | ----------: | ------------------ | -------------------------------------------- |
+| 100.0% | 5.45 MiB |       1,482 | `exec_module`      | `<frozen importlib._bootstrap_external>:934` |
+|  <0.1% | 1.83 KiB |           2 | `module_from_spec` | `<frozen importlib._bootstrap>:566`          |
 
 ##### `exec_module` (`<frozen importlib._bootstrap_external>:934`)
 
-|     % |     Size | Samples | Callee                      | Location                                      |
-| ----: | -------: | ------: | --------------------------- | --------------------------------------------- |
-| 99.1% |  5.4 MiB |   1,436 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
-| 49.3% | 2.69 MiB |     802 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
+|     % |     Size | Allocations | Callee                      | Location                                      |
+| ----: | -------: | ----------: | --------------------------- | --------------------------------------------- |
+| 99.1% |  5.4 MiB |       1,436 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
+| 49.3% | 2.69 MiB |         802 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`)
 
-|     % |     Size | Samples | Callee     | Location                                                 |
-| ----: | -------: | ------: | ---------- | -------------------------------------------------------- |
-| 99.4% |  5.4 MiB |   1,436 | `<module>` | `black/__init__.py:1`                                    |
-| 43.0% | 2.34 MiB |     316 | `<module>` | `black/comments.py:1`                                    |
-| 24.2% | 1.32 MiB |     295 | `<module>` | `black/nodes.py:1`                                       |
-| 24.1% | 1.31 MiB |     304 | `<module>` | `/venv/lib/python3.11/site-packages/click/__init__.py:1` |
-| 22.7% | 1.23 MiB |     233 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`     |
+|     % |     Size | Allocations | Callee     | Location                                                 |
+| ----: | -------: | ----------: | ---------- | -------------------------------------------------------- |
+| 99.4% |  5.4 MiB |       1,436 | `<module>` | `black/__init__.py:1`                                    |
+| 43.0% | 2.34 MiB |         316 | `<module>` | `black/comments.py:1`                                    |
+| 24.2% | 1.32 MiB |         295 | `<module>` | `black/nodes.py:1`                                       |
+| 24.1% | 1.31 MiB |         304 | `<module>` | `/venv/lib/python3.11/site-packages/click/__init__.py:1` |
+| 22.7% | 1.23 MiB |         233 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`     |
 
 ##### `get_code` (`<frozen importlib._bootstrap_external>:1007`)
 
-|     % |     Size | Samples | Callee                   | Location                                      |
-| ----: | -------: | ------: | ------------------------ | --------------------------------------------- |
-| 84.6% | 2.27 MiB |     352 | `source_to_code`         | `<frozen importlib._bootstrap_external>:999`  |
-| 11.3% |  311 KiB |     341 | `_compile_bytecode`      | `<frozen importlib._bootstrap_external>:727`  |
-|  4.1% |  112 KiB |     108 | `_code_to_timestamp_pyc` | `<frozen importlib._bootstrap_external>:740`  |
-| <0.1% |    624 B |       1 | `_cache_bytecode`        | `<frozen importlib._bootstrap_external>:1151` |
+|     % |     Size | Allocations | Callee                   | Location                                      |
+| ----: | -------: | ----------: | ------------------------ | --------------------------------------------- |
+| 84.6% | 2.27 MiB |         352 | `source_to_code`         | `<frozen importlib._bootstrap_external>:999`  |
+| 11.3% |  311 KiB |         341 | `_compile_bytecode`      | `<frozen importlib._bootstrap_external>:727`  |
+|  4.1% |  112 KiB |         108 | `_code_to_timestamp_pyc` | `<frozen importlib._bootstrap_external>:740`  |
+| <0.1% |    624 B |           1 | `_cache_bytecode`        | `<frozen importlib._bootstrap_external>:1151` |
 
 ##### `source_to_code` (`<frozen importlib._bootstrap_external>:999`)
 
-|      % |     Size | Samples | Callee                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.27 MiB |     352 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Callee                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.27 MiB |         352 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|     % |    Size | Samples | Callee           | Location                             |
-| ----: | ------: | ------: | ---------------- | ------------------------------------ |
-| 99.8% | 1.3 MiB |     303 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |    Size | Allocations | Callee           | Location                             |
+| ----: | ------: | ----------: | ---------------- | ------------------------------------ |
+| 99.8% | 1.3 MiB |         303 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|     % |     Size | Samples | Callee             | Location                                               |
-| ----: | -------: | ------: | ------------------ | ------------------------------------------------------ |
-| 85.5% | 1.05 MiB |      53 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167`                   |
-| 11.1% |  140 KiB |     145 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209`                   |
-|  1.1% | 13.9 KiB |       9 | `__new__`          | `<frozen abc>:105`                                     |
-|  0.2% | 2.49 KiB |       3 | `__new__`          | `/usr/lib/python3.11/enum.py:488`                      |
-|  0.1% |    768 B |       1 | `Context`          | `/venv/lib/python3.11/site-packages/click/core.py:204` |
+|     % |     Size | Allocations | Callee             | Location                                               |
+| ----: | -------: | ----------: | ------------------ | ------------------------------------------------------ |
+| 85.5% | 1.05 MiB |          53 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167`                   |
+| 11.1% |  140 KiB |         145 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209`                   |
+|  1.1% | 13.9 KiB |           9 | `__new__`          | `<frozen abc>:105`                                     |
+|  0.2% | 2.49 KiB |           3 | `__new__`          | `/usr/lib/python3.11/enum.py:488`                      |
+|  0.1% |    768 B |           1 | `Context`          | `/venv/lib/python3.11/site-packages/click/core.py:204` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 99.8% | 1.02 MiB |      22 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 99.8% | 1.02 MiB |          22 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `_handle_fromlist` (`<frozen importlib._bootstrap>:1209`)
 
-|      % |    Size | Samples | Callee                      | Location                            |
-| -----: | ------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 333 KiB |     341 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |    Size | Allocations | Callee                      | Location                            |
+| -----: | ------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 333 KiB |         341 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                                                         |
-| ----: | -------: | ------: | ---------------- | ---------------------------------------------------------------- |
-| 90.2% |  156 KiB |     130 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                             |
-|  4.9% |  8.5 KiB |       2 | `Specifier`      | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220` |
-|  3.5% | 6.07 KiB |       7 | `__new__`        | `<frozen abc>:105`                                               |
+|     % |     Size | Allocations | Callee           | Location                                                         |
+| ----: | -------: | ----------: | ---------------- | ---------------------------------------------------------------- |
+| 90.2% |  156 KiB |         130 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                             |
+|  4.9% |  8.5 KiB |           2 | `Specifier`      | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220` |
+|  3.5% | 6.07 KiB |           7 | `__new__`        | `<frozen abc>:105`                                               |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 53.0% | 66.2 KiB |      58 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
-| 30.6% | 38.2 KiB |      45 | `__new__`        | `<frozen abc>:105`                   |
-| 12.6% | 15.7 KiB |      19 | `__new__`        | `/usr/lib/python3.11/typing.py:2891` |
-|  1.1% | 1.42 KiB |       2 | `inner`          | `/usr/lib/python3.11/typing.py:338`  |
-|  0.4% |    542 B |       1 | `__init__`       | `/usr/lib/python3.11/typing.py:992`  |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 53.0% | 66.2 KiB |          58 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+| 30.6% | 38.2 KiB |          45 | `__new__`        | `<frozen abc>:105`                   |
+| 12.6% | 15.7 KiB |          19 | `__new__`        | `/usr/lib/python3.11/typing.py:2891` |
+|  1.1% | 1.42 KiB |           2 | `inner`          | `/usr/lib/python3.11/typing.py:338`  |
+|  0.4% |    542 B |           1 | `__init__`       | `/usr/lib/python3.11/typing.py:992`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 96.4% | 96.1 KiB |      68 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 96.4% | 96.1 KiB |          68 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 99.2% | 93.1 KiB |     118 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 99.2% | 93.1 KiB |         118 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`)
 
-|     % |   Size | Samples | Callee           | Location                             |
-| ----: | -----: | ------: | ---------------- | ------------------------------------ |
-| 97.3% | 89 KiB |     112 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |   Size | Allocations | Callee           | Location                             |
+| ----: | -----: | ----------: | ---------------- | ------------------------------------ |
+| 97.3% | 89 KiB |         112 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|     % |     Size | Samples | Callee             | Location                             |
-| ----: | -------: | ------: | ------------------ | ------------------------------------ |
-| 22.4% | 16.7 KiB |      17 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167` |
-| 21.2% | 15.8 KiB |      19 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209` |
+|     % |     Size | Allocations | Callee             | Location                             |
+| ----: | -------: | ----------: | ------------------ | ------------------------------------ |
+| 22.4% | 16.7 KiB |          17 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167` |
+| 21.2% | 15.8 KiB |          19 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 98.9% | 64.8 KiB |      83 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 98.9% | 64.8 KiB |          83 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `compile` (`/usr/lib/python3.11/re/__init__.py:225`)
 
-|     % |     Size | Samples | Callee     | Location                                 |
-| ----: | -------: | ------: | ---------- | ---------------------------------------- |
-| 98.6% | 47.1 KiB |      24 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
+|     % |     Size | Allocations | Callee     | Location                                 |
+| ----: | -------: | ----------: | ---------- | ---------------------------------------- |
+| 98.6% | 47.1 KiB |          24 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
 
 ##### `decorator` (`/venv/lib/python3.11/site-packages/click/decorators.py:373`)
 
-|     % |     Size | Samples | Callee     | Location                                                |
-| ----: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 96.2% | 45.5 KiB |      32 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2883` |
+|     % |     Size | Allocations | Callee     | Location                                                |
+| ----: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 96.2% | 45.5 KiB |          32 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2883` |
 
 ##### `_compile` (`/usr/lib/python3.11/re/__init__.py:272`)
 
-|     % |     Size | Samples | Callee    | Location                                  |
-| ----: | -------: | ------: | --------- | ----------------------------------------- |
-| 98.6% | 46.5 KiB |      23 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
-|  1.4% |    698 B |       1 | `__and__` | `/usr/lib/python3.11/enum.py:1504`        |
+|     % |     Size | Allocations | Callee    | Location                                  |
+| ----: | -------: | ----------: | --------- | ----------------------------------------- |
+| 98.6% | 46.5 KiB |          23 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
+|  1.4% |    698 B |           1 | `__and__` | `/usr/lib/python3.11/enum.py:1504`        |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 94.8% | 44.5 KiB |      56 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 94.8% | 44.5 KiB |          56 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|     % |     Size | Samples | Callee  | Location                                  |
-| ----: | -------: | ------: | ------- | ----------------------------------------- |
-| 31.0% | 14.4 KiB |       5 | `parse` | `/usr/lib/python3.11/re/_parser.py:970`   |
-| 20.4% |  9.5 KiB |       6 | `_code` | `/usr/lib/python3.11/re/_compiler.py:571` |
+|     % |     Size | Allocations | Callee  | Location                                  |
+| ----: | -------: | ----------: | ------- | ----------------------------------------- |
+| 31.0% | 14.4 KiB |           5 | `parse` | `/usr/lib/python3.11/re/_parser.py:970`   |
+| 20.4% |  9.5 KiB |           6 | `_code` | `/usr/lib/python3.11/re/_compiler.py:571` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|    % |     Size | Samples | Callee     | Location                                                |
-| ---: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 2.6% | 1.17 KiB |       1 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2237` |
+|    % |     Size | Allocations | Callee     | Location                                                |
+| ---: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 2.6% | 1.17 KiB |           1 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2237` |
 
 ## Hottest call stacks
 
@@ -1424,38 +1424,38 @@ Call stacks ranked by bytes held at peak memory in their leaf frame.
 
 Common call stack: `run_module` (`<frozen runpy>:201`) ← `_run_tracker` (`/venv/lib/python3.11/site-packages/memray/commands/run.py:40`)
 
-|     % |     Size | Samples | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| ----: | -------: | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 22.0% |   16 MiB |   1,014 | `parse` (`/usr/lib/python3.11/ast.py:33`) ← `_parse_single_version` (`black/parsing.py:117`) ← `parse_ast` (129) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-|  6.9% |    5 MiB |       5 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `shift` (`blib2to3/pgen2/parse.py:373`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-|  4.1% |    3 MiB |       8 | `transform_line` (`black/linegen.py:601`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-|  2.8% |    2 MiB |       2 | `_addtoken` (`blib2to3/pgen2/parse.py:290`) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-|  2.8% |    2 MiB |       2 | `convert` (`blib2to3/pytree.py:486`) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-|  1.7% | 1.21 MiB |     288 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-|  1.5% | 1.07 MiB |      96 | `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `source_to_code` (`<frozen importlib._bootstrap_external>:999`) ← `get_code` (1007) ← `exec_module` (934) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-|  1.4% | 1.04 MiB |      49 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-|  1.4% | 1.01 MiB |       6 | `make_grammar` (`blib2to3/pgen2/pgen.py:49`) ← `generate_grammar` (426) ← `load_grammar` (`blib2to3/pgen2/driver.py:246`) ← `load_packaged_grammar` (280) ← `initialize` (`blib2to3/pygram.py:165`) ← `<module>` (`black/nodes.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-|  1.4% | 1.01 MiB |      15 | `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `source_to_code` (`<frozen importlib._bootstrap_external>:999`) ← `get_code` (1007) ← `exec_module` (934) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-|  1.4% | 1.01 MiB |      11 | `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-|  1.4% | 1.01 MiB |      10 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-|  1.4% |    1 MiB |       4 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-|  1.4% |    1 MiB |       3 | `addtoken` (`blib2to3/pgen2/parse.py:242`) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-|  1.4% |    1 MiB |       1 | `lines_with_leading_tabs_expanded` (`black/strings.py:46`) ← `fix_docstring` (65) ← `visit_STRING` (`black/linegen.py:413`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-|  1.4% |    1 MiB |       1 | `is_import` (`black/lines.py:134`) ← `_maybe_empty_lines` (610) ← `maybe_empty_lines` (560) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-|  1.4% |    1 MiB |       1 | `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-|  1.4% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `preceding_leaf` (`black/nodes.py:441`) ← `whitespace` (194) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-|  1.4% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
-|  1.4% |    1 MiB |       1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_test` (160) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+|     % |     Size | Allocations | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ----: | -------: | ----------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 22.0% |   16 MiB |       1,014 | `parse` (`/usr/lib/python3.11/ast.py:33`) ← `_parse_single_version` (`black/parsing.py:117`) ← `parse_ast` (129) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+|  6.9% |    5 MiB |           5 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `shift` (`blib2to3/pgen2/parse.py:373`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+|  4.1% |    3 MiB |           8 | `transform_line` (`black/linegen.py:601`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+|  2.8% |    2 MiB |           2 | `_addtoken` (`blib2to3/pgen2/parse.py:290`) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+|  2.8% |    2 MiB |           2 | `convert` (`blib2to3/pytree.py:486`) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+|  1.7% | 1.21 MiB |         288 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+|  1.5% | 1.07 MiB |          96 | `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `source_to_code` (`<frozen importlib._bootstrap_external>:999`) ← `get_code` (1007) ← `exec_module` (934) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+|  1.4% | 1.04 MiB |          49 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+|  1.4% | 1.01 MiB |           6 | `make_grammar` (`blib2to3/pgen2/pgen.py:49`) ← `generate_grammar` (426) ← `load_grammar` (`blib2to3/pgen2/driver.py:246`) ← `load_packaged_grammar` (280) ← `initialize` (`blib2to3/pygram.py:165`) ← `<module>` (`black/nodes.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+|  1.4% | 1.01 MiB |          15 | `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `source_to_code` (`<frozen importlib._bootstrap_external>:999`) ← `get_code` (1007) ← `exec_module` (934) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+|  1.4% | 1.01 MiB |          11 | `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+|  1.4% | 1.01 MiB |          10 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+|  1.4% |    1 MiB |           4 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+|  1.4% |    1 MiB |           3 | `addtoken` (`blib2to3/pgen2/parse.py:242`) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+|  1.4% |    1 MiB |           1 | `lines_with_leading_tabs_expanded` (`black/strings.py:46`) ← `fix_docstring` (65) ← `visit_STRING` (`black/linegen.py:413`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+|  1.4% |    1 MiB |           1 | `is_import` (`black/lines.py:134`) ← `_maybe_empty_lines` (610) ← `maybe_empty_lines` (560) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+|  1.4% |    1 MiB |           1 | `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+|  1.4% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `preceding_leaf` (`black/nodes.py:441`) ← `whitespace` (194) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+|  1.4% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
+|  1.4% |    1 MiB |           1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_test` (160) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 
 # Leaked memory profile
 
-Leaked 58.1 MiB over 22,685 samples (2.62 KiB per sample).
+Leaked 58.1 MiB over 22,685 allocations (2.62 KiB per allocation).
 
-| Category         |     % |     Size | Samples |
-| ---------------- | ----: | -------: | ------: |
-| Ours             | 89.3% | 51.9 MiB |  21,387 |
-| Standard library |  8.6% | 4.97 MiB |   1,068 |
-| Third-party      |  2.1% | 1.23 MiB |     230 |
+| Category         |     % |     Size | Allocations |
+| ---------------- | ----: | -------: | ----------: |
+| Ours             | 89.3% | 51.9 MiB |      21,387 |
+| Standard library |  8.6% | 4.97 MiB |       1,068 |
+| Third-party      |  2.1% | 1.23 MiB |         230 |
 
 ## Hottest functions
 
@@ -1463,105 +1463,105 @@ Leaked 58.1 MiB over 22,685 samples (2.62 KiB per sample).
 
 Functions ranked by bytes never freed directly in the function body, excluding callees.
 
-|     % |     Size | Samples | Function                           | Location                                               |
-| ----: | -------: | ------: | ---------------------------------- | ------------------------------------------------------ |
-| 33.1% | 19.2 MiB |  20,791 | `mark`                             | `black/brackets.py:70`                                 |
-| 12.1% |    7 MiB |       7 | `changed`                          | `blib2to3/pytree.py:171`                               |
-|  8.6% |    5 MiB |       5 | `__new__`                          | `blib2to3/pytree.py:81`                                |
-|  5.4% | 3.14 MiB |     198 | `update_sibling_maps`              | `blib2to3/pytree.py:369`                               |
-|  5.3% | 3.07 MiB |       9 | `transform_line`                   | `black/linegen.py:601`                                 |
-|  3.9% | 2.27 MiB |     352 | `_call_with_frames_removed`        | `<frozen importlib._bootstrap>:233`                    |
-|  3.5% | 2.01 MiB |       3 | `parse`                            | `/usr/lib/python3.11/ast.py:33`                        |
-|  3.4% |    2 MiB |       2 | `generate_comments`                | `black/comments.py:52`                                 |
-|  3.4% |    2 MiB |       2 | `convert`                          | `blib2to3/pytree.py:486`                               |
-|  3.4% |    2 MiB |       2 | `_addtoken`                        | `blib2to3/pgen2/parse.py:290`                          |
-|  1.7% | 1.01 MiB |       6 | `make_grammar`                     | `blib2to3/pgen2/pgen.py:49`                            |
-|  1.7% | 1.01 MiB |      11 | `<module>`                         | `/venv/lib/python3.11/site-packages/click/parser.py:1` |
-|  1.7% |    1 MiB |       5 | `visit`                            | `black/nodes.py:163`                                   |
-|  1.7% |    1 MiB |       3 | `addtoken`                         | `blib2to3/pgen2/parse.py:242`                          |
-|  1.7% |    1 MiB |       2 | `visit_default`                    | `black/linegen.py:134`                                 |
-|  1.7% |    1 MiB |       1 | `lines_with_leading_tabs_expanded` | `black/strings.py:46`                                  |
-|  1.7% |    1 MiB |       1 | `is_import`                        | `black/lines.py:134`                                   |
-|  1.7% |    1 MiB |       1 | `__init__`                         | `<string>:2`                                           |
-|  1.7% |    1 MiB |       1 | `pop`                              | `blib2to3/pgen2/parse.py:398`                          |
-|  0.5% |  311 KiB |     341 | `_compile_bytecode`                | `<frozen importlib._bootstrap_external>:727`           |
+|     % |     Size | Allocations | Function                           | Location                                               |
+| ----: | -------: | ----------: | ---------------------------------- | ------------------------------------------------------ |
+| 33.1% | 19.2 MiB |      20,791 | `mark`                             | `black/brackets.py:70`                                 |
+| 12.1% |    7 MiB |           7 | `changed`                          | `blib2to3/pytree.py:171`                               |
+|  8.6% |    5 MiB |           5 | `__new__`                          | `blib2to3/pytree.py:81`                                |
+|  5.4% | 3.14 MiB |         198 | `update_sibling_maps`              | `blib2to3/pytree.py:369`                               |
+|  5.3% | 3.07 MiB |           9 | `transform_line`                   | `black/linegen.py:601`                                 |
+|  3.9% | 2.27 MiB |         352 | `_call_with_frames_removed`        | `<frozen importlib._bootstrap>:233`                    |
+|  3.5% | 2.01 MiB |           3 | `parse`                            | `/usr/lib/python3.11/ast.py:33`                        |
+|  3.4% |    2 MiB |           2 | `generate_comments`                | `black/comments.py:52`                                 |
+|  3.4% |    2 MiB |           2 | `convert`                          | `blib2to3/pytree.py:486`                               |
+|  3.4% |    2 MiB |           2 | `_addtoken`                        | `blib2to3/pgen2/parse.py:290`                          |
+|  1.7% | 1.01 MiB |           6 | `make_grammar`                     | `blib2to3/pgen2/pgen.py:49`                            |
+|  1.7% | 1.01 MiB |          11 | `<module>`                         | `/venv/lib/python3.11/site-packages/click/parser.py:1` |
+|  1.7% |    1 MiB |           5 | `visit`                            | `black/nodes.py:163`                                   |
+|  1.7% |    1 MiB |           3 | `addtoken`                         | `blib2to3/pgen2/parse.py:242`                          |
+|  1.7% |    1 MiB |           2 | `visit_default`                    | `black/linegen.py:134`                                 |
+|  1.7% |    1 MiB |           1 | `lines_with_leading_tabs_expanded` | `black/strings.py:46`                                  |
+|  1.7% |    1 MiB |           1 | `is_import`                        | `black/lines.py:134`                                   |
+|  1.7% |    1 MiB |           1 | `__init__`                         | `<string>:2`                                           |
+|  1.7% |    1 MiB |           1 | `pop`                              | `blib2to3/pgen2/parse.py:398`                          |
+|  0.5% |  311 KiB |         341 | `_compile_bytecode`                | `<frozen importlib._bootstrap_external>:727`           |
 
 #### Categories
 
 ##### Ours
 
-|     % |     Size | Samples | Function                           | Location                        |
-| ----: | -------: | ------: | ---------------------------------- | ------------------------------- |
-| 33.1% | 19.2 MiB |  20,791 | `mark`                             | `black/brackets.py:70`          |
-| 12.1% |    7 MiB |       7 | `changed`                          | `blib2to3/pytree.py:171`        |
-|  8.6% |    5 MiB |       5 | `__new__`                          | `blib2to3/pytree.py:81`         |
-|  5.4% | 3.14 MiB |     198 | `update_sibling_maps`              | `blib2to3/pytree.py:369`        |
-|  5.3% | 3.07 MiB |       9 | `transform_line`                   | `black/linegen.py:601`          |
-|  3.4% |    2 MiB |       2 | `generate_comments`                | `black/comments.py:52`          |
-|  3.4% |    2 MiB |       2 | `convert`                          | `blib2to3/pytree.py:486`        |
-|  3.4% |    2 MiB |       2 | `_addtoken`                        | `blib2to3/pgen2/parse.py:290`   |
-|  1.7% | 1.01 MiB |       6 | `make_grammar`                     | `blib2to3/pgen2/pgen.py:49`     |
-|  1.7% |    1 MiB |       5 | `visit`                            | `black/nodes.py:163`            |
-|  1.7% |    1 MiB |       3 | `addtoken`                         | `blib2to3/pgen2/parse.py:242`   |
-|  1.7% |    1 MiB |       2 | `visit_default`                    | `black/linegen.py:134`          |
-|  1.7% |    1 MiB |       1 | `lines_with_leading_tabs_expanded` | `black/strings.py:46`           |
-|  1.7% |    1 MiB |       1 | `is_import`                        | `black/lines.py:134`            |
-|  1.7% |    1 MiB |       1 | `__init__`                         | `<string>:2`                    |
-|  1.7% |    1 MiB |       1 | `pop`                              | `blib2to3/pgen2/parse.py:398`   |
-|  0.1% | 57.2 KiB |      65 | `normalize_string_prefix`          | `black/strings.py:143`          |
-|  0.1% | 41.5 KiB |      16 | `copy`                             | `blib2to3/pgen2/grammar.py:131` |
-|  0.1% |   32 KiB |       1 | `classify`                         | `blib2to3/pgen2/parse.py:336`   |
-| <0.1% | 25.3 KiB |      40 | `make_first`                       | `blib2to3/pgen2/pgen.py:74`     |
+|     % |     Size | Allocations | Function                           | Location                        |
+| ----: | -------: | ----------: | ---------------------------------- | ------------------------------- |
+| 33.1% | 19.2 MiB |      20,791 | `mark`                             | `black/brackets.py:70`          |
+| 12.1% |    7 MiB |           7 | `changed`                          | `blib2to3/pytree.py:171`        |
+|  8.6% |    5 MiB |           5 | `__new__`                          | `blib2to3/pytree.py:81`         |
+|  5.4% | 3.14 MiB |         198 | `update_sibling_maps`              | `blib2to3/pytree.py:369`        |
+|  5.3% | 3.07 MiB |           9 | `transform_line`                   | `black/linegen.py:601`          |
+|  3.4% |    2 MiB |           2 | `generate_comments`                | `black/comments.py:52`          |
+|  3.4% |    2 MiB |           2 | `convert`                          | `blib2to3/pytree.py:486`        |
+|  3.4% |    2 MiB |           2 | `_addtoken`                        | `blib2to3/pgen2/parse.py:290`   |
+|  1.7% | 1.01 MiB |           6 | `make_grammar`                     | `blib2to3/pgen2/pgen.py:49`     |
+|  1.7% |    1 MiB |           5 | `visit`                            | `black/nodes.py:163`            |
+|  1.7% |    1 MiB |           3 | `addtoken`                         | `blib2to3/pgen2/parse.py:242`   |
+|  1.7% |    1 MiB |           2 | `visit_default`                    | `black/linegen.py:134`          |
+|  1.7% |    1 MiB |           1 | `lines_with_leading_tabs_expanded` | `black/strings.py:46`           |
+|  1.7% |    1 MiB |           1 | `is_import`                        | `black/lines.py:134`            |
+|  1.7% |    1 MiB |           1 | `__init__`                         | `<string>:2`                    |
+|  1.7% |    1 MiB |           1 | `pop`                              | `blib2to3/pgen2/parse.py:398`   |
+|  0.1% | 57.2 KiB |          65 | `normalize_string_prefix`          | `black/strings.py:143`          |
+|  0.1% | 41.5 KiB |          16 | `copy`                             | `blib2to3/pgen2/grammar.py:131` |
+|  0.1% |   32 KiB |           1 | `classify`                         | `blib2to3/pgen2/parse.py:336`   |
+| <0.1% | 25.3 KiB |          40 | `make_first`                       | `blib2to3/pgen2/pgen.py:74`     |
 
 ##### Standard library
 
-|     % |     Size | Samples | Function                    | Location                                          |
-| ----: | -------: | ------: | --------------------------- | ------------------------------------------------- |
-|  3.9% | 2.27 MiB |     352 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`               |
-|  3.5% | 2.01 MiB |       3 | `parse`                     | `/usr/lib/python3.11/ast.py:33`                   |
-|  0.5% |  311 KiB |     341 | `_compile_bytecode`         | `<frozen importlib._bootstrap_external>:727`      |
-|  0.2% |  112 KiB |     108 | `_code_to_timestamp_pyc`    | `<frozen importlib._bootstrap_external>:740`      |
-|  0.1% | 75.7 KiB |      79 | `__new__`                   | `<frozen abc>:105`                                |
-| <0.1% | 24.1 KiB |      27 | `__new__`                   | `/usr/lib/python3.11/enum.py:488`                 |
-| <0.1% | 22.6 KiB |      12 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`         |
-| <0.1% | 19.8 KiB |      12 | `<module>`                  | `/usr/lib/python3.11/tomllib/_parser.py:1`        |
-| <0.1% | 17.4 KiB |      21 | `__new__`                   | `/usr/lib/python3.11/typing.py:2891`              |
-| <0.1% |   12 KiB |       3 | `inner`                     | `/usr/lib/python3.11/typing.py:338`               |
-| <0.1% |    8 KiB |       4 | `_fill_cache`               | `<frozen importlib._bootstrap_external>:1655`     |
-| <0.1% | 7.97 KiB |       1 | `_parse_sub`                | `/usr/lib/python3.11/re/_parser.py:447`           |
-| <0.1% | 6.73 KiB |       8 | `__setattr__`               | `/usr/lib/python3.11/enum.py:831`                 |
-| <0.1% | 5.63 KiB |       6 | `namedtuple`                | `/usr/lib/python3.11/collections/__init__.py:348` |
-| <0.1% | 5.61 KiB |       3 | `_parse`                    | `/usr/lib/python3.11/re/_parser.py:507`           |
-| <0.1% | 5.32 KiB |       2 | `_code`                     | `/usr/lib/python3.11/re/_compiler.py:571`         |
-| <0.1% | 4.73 KiB |       6 | `<module>`                  | `/usr/lib/python3.11/pkgutil.py:1`                |
-| <0.1% | 2.85 KiB |       1 | `wrap`                      | `/usr/lib/python3.11/dataclasses.py:1209`         |
-| <0.1% | 2.85 KiB |       4 | `_process_class`            | `/usr/lib/python3.11/dataclasses.py:884`          |
-| <0.1% | 2.56 KiB |       3 | `_signature_from_function`  | `/usr/lib/python3.11/inspect.py:2331`             |
+|     % |     Size | Allocations | Function                    | Location                                          |
+| ----: | -------: | ----------: | --------------------------- | ------------------------------------------------- |
+|  3.9% | 2.27 MiB |         352 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`               |
+|  3.5% | 2.01 MiB |           3 | `parse`                     | `/usr/lib/python3.11/ast.py:33`                   |
+|  0.5% |  311 KiB |         341 | `_compile_bytecode`         | `<frozen importlib._bootstrap_external>:727`      |
+|  0.2% |  112 KiB |         108 | `_code_to_timestamp_pyc`    | `<frozen importlib._bootstrap_external>:740`      |
+|  0.1% | 75.7 KiB |          79 | `__new__`                   | `<frozen abc>:105`                                |
+| <0.1% | 24.1 KiB |          27 | `__new__`                   | `/usr/lib/python3.11/enum.py:488`                 |
+| <0.1% | 22.6 KiB |          12 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`         |
+| <0.1% | 19.8 KiB |          12 | `<module>`                  | `/usr/lib/python3.11/tomllib/_parser.py:1`        |
+| <0.1% | 17.4 KiB |          21 | `__new__`                   | `/usr/lib/python3.11/typing.py:2891`              |
+| <0.1% |   12 KiB |           3 | `inner`                     | `/usr/lib/python3.11/typing.py:338`               |
+| <0.1% |    8 KiB |           4 | `_fill_cache`               | `<frozen importlib._bootstrap_external>:1655`     |
+| <0.1% | 7.97 KiB |           1 | `_parse_sub`                | `/usr/lib/python3.11/re/_parser.py:447`           |
+| <0.1% | 6.73 KiB |           8 | `__setattr__`               | `/usr/lib/python3.11/enum.py:831`                 |
+| <0.1% | 5.63 KiB |           6 | `namedtuple`                | `/usr/lib/python3.11/collections/__init__.py:348` |
+| <0.1% | 5.61 KiB |           3 | `_parse`                    | `/usr/lib/python3.11/re/_parser.py:507`           |
+| <0.1% | 5.32 KiB |           2 | `_code`                     | `/usr/lib/python3.11/re/_compiler.py:571`         |
+| <0.1% | 4.73 KiB |           6 | `<module>`                  | `/usr/lib/python3.11/pkgutil.py:1`                |
+| <0.1% | 2.85 KiB |           1 | `wrap`                      | `/usr/lib/python3.11/dataclasses.py:1209`         |
+| <0.1% | 2.85 KiB |           4 | `_process_class`            | `/usr/lib/python3.11/dataclasses.py:884`          |
+| <0.1% | 2.56 KiB |           3 | `_signature_from_function`  | `/usr/lib/python3.11/inspect.py:2331`             |
 
 ##### Third-party
 
-|     % |     Size | Samples | Function              | Location                                                                   |
-| ----: | -------: | ------: | --------------------- | -------------------------------------------------------------------------- |
-|  1.7% | 1.01 MiB |      11 | `<module>`            | `/venv/lib/python3.11/site-packages/click/parser.py:1`                     |
-|  0.1% | 44.3 KiB |      31 | `__init__`            | `/venv/lib/python3.11/site-packages/click/core.py:2883`                    |
-| <0.1% |   25 KiB |      22 | `<module>`            | `/venv/lib/python3.11/site-packages/click/core.py:1`                       |
-| <0.1% |   15 KiB |      18 | `<module>`            | `/venv/lib/python3.11/site-packages/mypy_extensions.py:1`                  |
-| <0.1% | 13.4 KiB |      15 | `<module>`            | `/venv/lib/python3.11/site-packages/click/exceptions.py:1`                 |
-| <0.1% | 9.61 KiB |       9 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/version.py:1`                |
-| <0.1% | 7.08 KiB |       8 | `<module>`            | `/venv/lib/python3.11/site-packages/click/utils.py:1`                      |
-| <0.1% | 6.48 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/util.py:1`                    |
-| <0.1% | 6.24 KiB |       5 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                |
-| <0.1% | 5.97 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                   |
-| <0.1% |  5.8 KiB |       6 | `<module>`            | `/venv/lib/python3.11/site-packages/click/_compat.py:1`                    |
-| <0.1% | 3.82 KiB |       1 | `Specifier`           | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`           |
-| <0.1% | 3.72 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`                 |
-| <0.1% | 3.56 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                  |
-| <0.1% | 3.37 KiB |       5 | `handle_parse_result` | `/venv/lib/python3.11/site-packages/click/core.py:2663`                    |
-| <0.1% | 3.19 KiB |       1 | `<module>`            | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                   |
-| <0.1% | 3.19 KiB |       4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`                |
-| <0.1% | 3.04 KiB |       2 | `new_func`            | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                |
-| <0.1% | 2.81 KiB |       3 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1` |
-| <0.1% | 2.76 KiB |       2 | `<module>`            | `/venv/lib/python3.11/site-packages/click/types.py:1`                      |
+|     % |     Size | Allocations | Function              | Location                                                                   |
+| ----: | -------: | ----------: | --------------------- | -------------------------------------------------------------------------- |
+|  1.7% | 1.01 MiB |          11 | `<module>`            | `/venv/lib/python3.11/site-packages/click/parser.py:1`                     |
+|  0.1% | 44.3 KiB |          31 | `__init__`            | `/venv/lib/python3.11/site-packages/click/core.py:2883`                    |
+| <0.1% |   25 KiB |          22 | `<module>`            | `/venv/lib/python3.11/site-packages/click/core.py:1`                       |
+| <0.1% |   15 KiB |          18 | `<module>`            | `/venv/lib/python3.11/site-packages/mypy_extensions.py:1`                  |
+| <0.1% | 13.4 KiB |          15 | `<module>`            | `/venv/lib/python3.11/site-packages/click/exceptions.py:1`                 |
+| <0.1% | 9.61 KiB |           9 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/version.py:1`                |
+| <0.1% | 7.08 KiB |           8 | `<module>`            | `/venv/lib/python3.11/site-packages/click/utils.py:1`                      |
+| <0.1% | 6.48 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/util.py:1`                    |
+| <0.1% | 6.24 KiB |           5 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                |
+| <0.1% | 5.97 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/tags.py:1`                   |
+| <0.1% |  5.8 KiB |           6 | `<module>`            | `/venv/lib/python3.11/site-packages/click/_compat.py:1`                    |
+| <0.1% | 3.82 KiB |           1 | `Specifier`           | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`           |
+| <0.1% | 3.72 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`                 |
+| <0.1% | 3.56 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                  |
+| <0.1% | 3.37 KiB |           5 | `handle_parse_result` | `/venv/lib/python3.11/site-packages/click/core.py:2663`                    |
+| <0.1% | 3.19 KiB |           1 | `<module>`            | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                   |
+| <0.1% | 3.19 KiB |           4 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`                |
+| <0.1% | 3.04 KiB |           2 | `new_func`            | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                |
+| <0.1% | 2.81 KiB |           3 | `<module>`            | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1` |
+| <0.1% | 2.76 KiB |           2 | `<module>`            | `/venv/lib/python3.11/site-packages/click/types.py:1`                      |
 
 #### Lines
 
@@ -1569,449 +1569,449 @@ Lines ranked by contribution to each function's self size.
 
 ##### `mark` (`black/brackets.py:70`)
 
-|     % |     Size | Samples | Location                |
-| ----: | -------: | ------: | ----------------------- |
-| 94.8% | 18.2 MiB |  20,789 | `black/brackets.py:112` |
-|  5.2% |    1 MiB |       1 | `black/brackets.py:118` |
-| <0.1% | 1.49 KiB |       1 | `black/brackets.py:114` |
+|     % |     Size | Allocations | Location                |
+| ----: | -------: | ----------: | ----------------------- |
+| 94.8% | 18.2 MiB |      20,789 | `black/brackets.py:112` |
+|  5.2% |    1 MiB |           1 | `black/brackets.py:118` |
+| <0.1% | 1.49 KiB |           1 | `black/brackets.py:114` |
 
 ##### `changed` (`blib2to3/pytree.py:171`)
 
-|     % |  Size | Samples | Location                 |
-| ----: | ----: | ------: | ------------------------ |
-| 57.1% | 4 MiB |       4 | `blib2to3/pytree.py:175` |
-| 42.9% | 3 MiB |       3 | `blib2to3/pytree.py:176` |
+|     % |  Size | Allocations | Location                 |
+| ----: | ----: | ----------: | ------------------------ |
+| 57.1% | 4 MiB |           4 | `blib2to3/pytree.py:175` |
+| 42.9% | 3 MiB |           3 | `blib2to3/pytree.py:176` |
 
 ##### `__new__` (`blib2to3/pytree.py:81`)
 
-|      % |  Size | Samples | Location                |
-| -----: | ----: | ------: | ----------------------- |
-| 100.0% | 5 MiB |       5 | `blib2to3/pytree.py:84` |
+|      % |  Size | Allocations | Location                |
+| -----: | ----: | ----------: | ----------------------- |
+| 100.0% | 5 MiB |           5 | `blib2to3/pytree.py:84` |
 
 ##### `update_sibling_maps` (`blib2to3/pytree.py:369`)
 
-|     % |     Size | Samples | Location                 |
-| ----: | -------: | ------: | ------------------------ |
-| 34.0% | 1.07 MiB |      94 | `blib2to3/pytree.py:377` |
-| 34.0% | 1.07 MiB |      94 | `blib2to3/pytree.py:376` |
-| 32.0% |    1 MiB |      10 | `blib2to3/pytree.py:379` |
+|     % |     Size | Allocations | Location                 |
+| ----: | -------: | ----------: | ------------------------ |
+| 34.0% | 1.07 MiB |          94 | `blib2to3/pytree.py:377` |
+| 34.0% | 1.07 MiB |          94 | `blib2to3/pytree.py:376` |
+| 32.0% |    1 MiB |          10 | `blib2to3/pytree.py:379` |
 
 ##### `transform_line` (`black/linegen.py:601`)
 
-|     % |     Size | Samples | Location               |
-| ----: | -------: | ------: | ---------------------- |
-| 32.6% |    1 MiB |       2 | `black/linegen.py:714` |
-| 32.5% |    1 MiB |       1 | `black/linegen.py:627` |
-| 32.5% |    1 MiB |       1 | `black/linegen.py:626` |
-|  2.3% | 73.7 KiB |       3 | `black/linegen.py:679` |
-| <0.1% | 1.39 KiB |       1 | `black/linegen.py:635` |
+|     % |     Size | Allocations | Location               |
+| ----: | -------: | ----------: | ---------------------- |
+| 32.6% |    1 MiB |           2 | `black/linegen.py:714` |
+| 32.5% |    1 MiB |           1 | `black/linegen.py:627` |
+| 32.5% |    1 MiB |           1 | `black/linegen.py:626` |
+|  2.3% | 73.7 KiB |           3 | `black/linegen.py:679` |
+| <0.1% | 1.39 KiB |           1 | `black/linegen.py:635` |
 
 ##### `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`)
 
-|      % |     Size | Samples | Location                            |
-| -----: | -------: | ------: | ----------------------------------- |
-| 100.0% | 2.27 MiB |     352 | `<frozen importlib._bootstrap>:241` |
+|      % |     Size | Allocations | Location                            |
+| -----: | -------: | ----------: | ----------------------------------- |
+| 100.0% | 2.27 MiB |         352 | `<frozen importlib._bootstrap>:241` |
 
 ##### `parse` (`/usr/lib/python3.11/ast.py:33`)
 
-|      % |     Size | Samples | Location                        |
-| -----: | -------: | ------: | ------------------------------- |
-| 100.0% | 2.01 MiB |       3 | `/usr/lib/python3.11/ast.py:50` |
+|      % |     Size | Allocations | Location                        |
+| -----: | -------: | ----------: | ------------------------------- |
+| 100.0% | 2.01 MiB |           3 | `/usr/lib/python3.11/ast.py:50` |
 
 ##### `generate_comments` (`black/comments.py:52`)
 
-|     % |  Size | Samples | Location               |
-| ----: | ----: | ------: | ---------------------- |
-| 50.0% | 1 MiB |       1 | `black/comments.py:76` |
-| 50.0% | 1 MiB |       1 | `black/comments.py:72` |
+|     % |  Size | Allocations | Location               |
+| ----: | ----: | ----------: | ---------------------- |
+| 50.0% | 1 MiB |           1 | `black/comments.py:76` |
+| 50.0% | 1 MiB |           1 | `black/comments.py:72` |
 
 ##### `convert` (`blib2to3/pytree.py:486`)
 
-|      % |  Size | Samples | Location                 |
-| -----: | ----: | ------: | ------------------------ |
-| 100.0% | 2 MiB |       2 | `blib2to3/pytree.py:501` |
+|      % |  Size | Allocations | Location                 |
+| -----: | ----: | ----------: | ------------------------ |
+| 100.0% | 2 MiB |           2 | `blib2to3/pytree.py:501` |
 
 ##### `_addtoken` (`blib2to3/pgen2/parse.py:290`)
 
-|     % |  Size | Samples | Location                      |
-| ----: | ----: | ------: | ----------------------------- |
-| 50.0% | 1 MiB |       1 | `blib2to3/pgen2/parse.py:315` |
-| 50.0% | 1 MiB |       1 | `blib2to3/pgen2/parse.py:314` |
+|     % |  Size | Allocations | Location                      |
+| ----: | ----: | ----------: | ----------------------------- |
+| 50.0% | 1 MiB |           1 | `blib2to3/pgen2/parse.py:315` |
+| 50.0% | 1 MiB |           1 | `blib2to3/pgen2/parse.py:314` |
 
 ##### `make_grammar` (`blib2to3/pgen2/pgen.py:49`)
 
-|     % |     Size | Samples | Location                    |
-| ----: | -------: | ------: | --------------------------- |
-| 98.6% |    1 MiB |       1 | `blib2to3/pgen2/pgen.py:56` |
-|  0.4% | 4.52 KiB |       1 | `blib2to3/pgen2/pgen.py:70` |
-|  0.4% | 4.52 KiB |       1 | `blib2to3/pgen2/pgen.py:58` |
-|  0.3% | 3.19 KiB |       1 | `blib2to3/pgen2/pgen.py:57` |
-|  0.1% |    1 KiB |       1 | `blib2to3/pgen2/pgen.py:69` |
+|     % |     Size | Allocations | Location                    |
+| ----: | -------: | ----------: | --------------------------- |
+| 98.6% |    1 MiB |           1 | `blib2to3/pgen2/pgen.py:56` |
+|  0.4% | 4.52 KiB |           1 | `blib2to3/pgen2/pgen.py:70` |
+|  0.4% | 4.52 KiB |           1 | `blib2to3/pgen2/pgen.py:58` |
+|  0.3% | 3.19 KiB |           1 | `blib2to3/pgen2/pgen.py:57` |
+|  0.1% |    1 KiB |           1 | `blib2to3/pgen2/pgen.py:69` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`)
 
-|     % |     Size | Samples | Location                                                 |
-| ----: | -------: | ------: | -------------------------------------------------------- |
-| 99.2% |    1 MiB |       1 | `/venv/lib/python3.11/site-packages/click/parser.py:25`  |
-|  0.2% | 2.29 KiB |       3 | `/venv/lib/python3.11/site-packages/click/parser.py:224` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:185` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:127` |
-|  0.2% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/parser.py:216` |
+|     % |     Size | Allocations | Location                                                 |
+| ----: | -------: | ----------: | -------------------------------------------------------- |
+| 99.2% |    1 MiB |           1 | `/venv/lib/python3.11/site-packages/click/parser.py:25`  |
+|  0.2% | 2.29 KiB |           3 | `/venv/lib/python3.11/site-packages/click/parser.py:224` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:185` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:127` |
+|  0.2% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/parser.py:216` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|     % |     Size | Samples | Location             |
-| ----: | -------: | ------: | -------------------- |
-| 99.7% |    1 MiB |       2 | `black/nodes.py:185` |
-|  0.3% | 2.68 KiB |       3 | `black/nodes.py:183` |
+|     % |     Size | Allocations | Location             |
+| ----: | -------: | ----------: | -------------------- |
+| 99.7% |    1 MiB |           2 | `black/nodes.py:185` |
+|  0.3% | 2.68 KiB |           3 | `black/nodes.py:183` |
 
 ##### `addtoken` (`blib2to3/pgen2/parse.py:242`)
 
-|     % |  Size | Samples | Location                      |
-| ----: | ----: | ------: | ----------------------------- |
-| 99.9% | 1 MiB |       2 | `blib2to3/pgen2/parse.py:252` |
-|  0.1% | 560 B |       1 | `blib2to3/pgen2/parse.py:245` |
+|     % |  Size | Allocations | Location                      |
+| ----: | ----: | ----------: | ----------------------------- |
+| 99.9% | 1 MiB |           2 | `blib2to3/pgen2/parse.py:252` |
+|  0.1% | 560 B |           1 | `blib2to3/pgen2/parse.py:245` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|     % |  Size | Samples | Location               |
-| ----: | ----: | ------: | ---------------------- |
-| 99.9% | 1 MiB |       1 | `black/linegen.py:158` |
-|  0.1% | 702 B |       1 | `black/linegen.py:144` |
+|     % |  Size | Allocations | Location               |
+| ----: | ----: | ----------: | ---------------------- |
+| 99.9% | 1 MiB |           1 | `black/linegen.py:158` |
+|  0.1% | 702 B |           1 | `black/linegen.py:144` |
 
 ##### `lines_with_leading_tabs_expanded` (`black/strings.py:46`)
 
-|      % |  Size | Samples | Location              |
-| -----: | ----: | ------: | --------------------- |
-| 100.0% | 1 MiB |       1 | `black/strings.py:58` |
+|      % |  Size | Allocations | Location              |
+| -----: | ----: | ----------: | --------------------- |
+| 100.0% | 1 MiB |           1 | `black/strings.py:58` |
 
 ##### `is_import` (`black/lines.py:134`)
 
-|      % |  Size | Samples | Location             |
-| -----: | ----: | ------: | -------------------- |
-| 100.0% | 1 MiB |       1 | `black/lines.py:137` |
+|      % |  Size | Allocations | Location             |
+| -----: | ----: | ----------: | -------------------- |
+| 100.0% | 1 MiB |           1 | `black/lines.py:137` |
 
 ##### `__init__` (`<string>:2`)
 
-|      % |  Size | Samples | Location     |
-| -----: | ----: | ------: | ------------ |
-| 100.0% | 1 MiB |       1 | `<string>:6` |
+|      % |  Size | Allocations | Location     |
+| -----: | ----: | ----------: | ------------ |
+| 100.0% | 1 MiB |           1 | `<string>:6` |
 
 ##### `pop` (`blib2to3/pgen2/parse.py:398`)
 
-|      % |  Size | Samples | Location                      |
-| -----: | ----: | ------: | ----------------------------- |
-| 100.0% | 1 MiB |       1 | `blib2to3/pgen2/parse.py:408` |
+|      % |  Size | Allocations | Location                      |
+| -----: | ----: | ----------: | ----------------------------- |
+| 100.0% | 1 MiB |           1 | `blib2to3/pgen2/parse.py:408` |
 
 ##### `_compile_bytecode` (`<frozen importlib._bootstrap_external>:727`)
 
-|      % |    Size | Samples | Location                                     |
-| -----: | ------: | ------: | -------------------------------------------- |
-| 100.0% | 311 KiB |     341 | `<frozen importlib._bootstrap_external>:729` |
+|      % |    Size | Allocations | Location                                     |
+| -----: | ------: | ----------: | -------------------------------------------- |
+| 100.0% | 311 KiB |         341 | `<frozen importlib._bootstrap_external>:729` |
 
 ##### `_code_to_timestamp_pyc` (`<frozen importlib._bootstrap_external>:740`)
 
-|      % |    Size | Samples | Location                                     |
-| -----: | ------: | ------: | -------------------------------------------- |
-| 100.0% | 112 KiB |     108 | `<frozen importlib._bootstrap_external>:746` |
+|      % |    Size | Allocations | Location                                     |
+| -----: | ------: | ----------: | -------------------------------------------- |
+| 100.0% | 112 KiB |         108 | `<frozen importlib._bootstrap_external>:746` |
 
 ##### `__new__` (`<frozen abc>:105`)
 
-|      % |     Size | Samples | Location           |
-| -----: | -------: | ------: | ------------------ |
-| 100.0% | 75.7 KiB |      79 | `<frozen abc>:106` |
+|      % |     Size | Allocations | Location           |
+| -----: | -------: | ----------: | ------------------ |
+| 100.0% | 75.7 KiB |          79 | `<frozen abc>:106` |
 
 ##### `normalize_string_prefix` (`black/strings.py:143`)
 
-|      % |     Size | Samples | Location               |
-| -----: | -------: | ------: | ---------------------- |
-| 100.0% | 57.2 KiB |      65 | `black/strings.py:158` |
+|      % |     Size | Allocations | Location               |
+| -----: | -------: | ----------: | ---------------------- |
+| 100.0% | 57.2 KiB |          65 | `black/strings.py:158` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|     % |   Size | Samples | Location                                                |
-| ----: | -----: | ------: | ------------------------------------------------------- |
-| 97.1% | 43 KiB |      29 | `/venv/lib/python3.11/site-packages/click/core.py:3023` |
-|  1.6% |  704 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2905` |
-|  1.4% |  614 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2907` |
+|     % |   Size | Allocations | Location                                                |
+| ----: | -----: | ----------: | ------------------------------------------------------- |
+| 97.1% | 43 KiB |          29 | `/venv/lib/python3.11/site-packages/click/core.py:3023` |
+|  1.6% |  704 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2905` |
+|  1.4% |  614 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2907` |
 
 ##### `copy` (`blib2to3/pgen2/grammar.py:131`)
 
-|     % |     Size | Samples | Location                        |
-| ----: | -------: | ------: | ------------------------------- |
-| 88.2% | 36.6 KiB |      12 | `blib2to3/pgen2/grammar.py:145` |
-|  7.6% | 3.16 KiB |       2 | `blib2to3/pgen2/grammar.py:146` |
-|  4.2% | 1.75 KiB |       2 | `blib2to3/pgen2/grammar.py:147` |
+|     % |     Size | Allocations | Location                        |
+| ----: | -------: | ----------: | ------------------------------- |
+| 88.2% | 36.6 KiB |          12 | `blib2to3/pgen2/grammar.py:145` |
+|  7.6% | 3.16 KiB |           2 | `blib2to3/pgen2/grammar.py:146` |
+|  4.2% | 1.75 KiB |           2 | `blib2to3/pgen2/grammar.py:147` |
 
 ##### `classify` (`blib2to3/pgen2/parse.py:336`)
 
-|      % |   Size | Samples | Location                      |
-| -----: | -----: | ------: | ----------------------------- |
-| 100.0% | 32 KiB |       1 | `blib2to3/pgen2/parse.py:343` |
+|      % |   Size | Allocations | Location                      |
+| -----: | -----: | ----------: | ----------------------------- |
+| 100.0% | 32 KiB |           1 | `blib2to3/pgen2/parse.py:343` |
 
 ##### `make_first` (`blib2to3/pgen2/pgen.py:74`)
 
-|      % |     Size | Samples | Location                    |
-| -----: | -------: | ------: | --------------------------- |
-| 100.0% | 25.3 KiB |      40 | `blib2to3/pgen2/pgen.py:81` |
+|      % |     Size | Allocations | Location                    |
+| -----: | -------: | ----------: | --------------------------- |
+| 100.0% | 25.3 KiB |          40 | `blib2to3/pgen2/pgen.py:81` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 30.4% |  7.6 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:204`  |
-| 19.2% | 4.79 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:956`  |
-| 15.7% | 3.92 KiB |       4 | `/venv/lib/python3.11/site-packages/click/core.py:1587` |
-|  9.5% | 2.37 KiB |       3 | `/venv/lib/python3.11/site-packages/click/core.py:2057` |
-|  6.8% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/core.py:2050` |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 30.4% |  7.6 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:204`  |
+| 19.2% | 4.79 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:956`  |
+| 15.7% | 3.92 KiB |           4 | `/venv/lib/python3.11/site-packages/click/core.py:1587` |
+|  9.5% | 2.37 KiB |           3 | `/venv/lib/python3.11/site-packages/click/core.py:2057` |
+|  6.8% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/core.py:2050` |
 
 ##### `__new__` (`/usr/lib/python3.11/enum.py:488`)
 
-|      % |     Size | Samples | Location                          |
-| -----: | -------: | ------: | --------------------------------- |
-| 100.0% | 24.1 KiB |      27 | `/usr/lib/python3.11/enum.py:554` |
+|      % |     Size | Allocations | Location                          |
+| -----: | -------: | ----------: | --------------------------------- |
+| 100.0% | 24.1 KiB |          27 | `/usr/lib/python3.11/enum.py:554` |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|      % |     Size | Samples | Location                                  |
-| -----: | -------: | ------: | ----------------------------------------- |
-| 100.0% | 22.6 KiB |      12 | `/usr/lib/python3.11/re/_compiler.py:759` |
+|      % |     Size | Allocations | Location                                  |
+| -----: | -------: | ----------: | ----------------------------------------- |
+| 100.0% | 22.6 KiB |          12 | `/usr/lib/python3.11/re/_compiler.py:759` |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/_parser.py:1`)
 
-|     % |  Size | Samples | Location                                    |
-| ----: | ----: | ------: | ------------------------------------------- |
-| 20.2% | 4 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:37` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:26` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:22` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:38` |
-| 10.1% | 2 KiB |       1 | `/usr/lib/python3.11/tomllib/_parser.py:27` |
+|     % |  Size | Allocations | Location                                    |
+| ----: | ----: | ----------: | ------------------------------------------- |
+| 20.2% | 4 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:37` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:26` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:22` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:38` |
+| 10.1% | 2 KiB |           1 | `/usr/lib/python3.11/tomllib/_parser.py:27` |
 
 ##### `__new__` (`/usr/lib/python3.11/typing.py:2891`)
 
-|      % |     Size | Samples | Location                             |
-| -----: | -------: | ------: | ------------------------------------ |
-| 100.0% | 17.4 KiB |      21 | `/usr/lib/python3.11/typing.py:2909` |
+|      % |     Size | Allocations | Location                             |
+| -----: | -------: | ----------: | ------------------------------------ |
+| 100.0% | 17.4 KiB |          21 | `/usr/lib/python3.11/typing.py:2909` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/mypy_extensions.py:1`)
 
-|     % |     Size | Samples | Location                                                    |
-| ----: | -------: | ------: | ----------------------------------------------------------- |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:198` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:167` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:212` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:191` |
-| 11.3% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:154` |
+|     % |     Size | Allocations | Location                                                    |
+| ----: | -------: | ----------: | ----------------------------------------------------------- |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:198` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:167` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:212` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:191` |
+| 11.3% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/mypy_extensions.py:154` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/exceptions.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 18.4% | 2.45 KiB |       3 | `/venv/lib/python3.11/site-packages/click/exceptions.py:114` |
-| 11.5% | 1.53 KiB |       2 | `/venv/lib/python3.11/site-packages/click/exceptions.py:366` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:304` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:268` |
-|  7.0% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:232` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 18.4% | 2.45 KiB |           3 | `/venv/lib/python3.11/site-packages/click/exceptions.py:114` |
+| 11.5% | 1.53 KiB |           2 | `/venv/lib/python3.11/site-packages/click/exceptions.py:366` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:304` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:268` |
+|  7.0% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/exceptions.py:232` |
 
 ##### `inner` (`/usr/lib/python3.11/typing.py:338`)
 
-|      % |   Size | Samples | Location                            |
-| -----: | -----: | ------: | ----------------------------------- |
-| 100.0% | 12 KiB |       3 | `/usr/lib/python3.11/typing.py:341` |
+|      % |   Size | Allocations | Location                            |
+| -----: | -----: | ----------: | ----------------------------------- |
+| 100.0% | 12 KiB |           3 | `/usr/lib/python3.11/typing.py:341` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/version.py:1`)
 
-|     % |     Size | Samples | Location                                                      |
-| ----: | -------: | ------: | ------------------------------------------------------------- |
-| 38.2% | 3.68 KiB |       3 | `/venv/lib/python3.11/site-packages/packaging/version.py:340` |
-| 15.5% | 1.49 KiB |       2 | `/venv/lib/python3.11/site-packages/packaging/version.py:124` |
-| 15.4% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:285` |
-| 11.3% | 1.09 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:228` |
-|  9.8% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/version.py:134` |
+|     % |     Size | Allocations | Location                                                      |
+| ----: | -------: | ----------: | ------------------------------------------------------------- |
+| 38.2% | 3.68 KiB |           3 | `/venv/lib/python3.11/site-packages/packaging/version.py:340` |
+| 15.5% | 1.49 KiB |           2 | `/venv/lib/python3.11/site-packages/packaging/version.py:124` |
+| 15.4% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:285` |
+| 11.3% | 1.09 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:228` |
+|  9.8% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/version.py:134` |
 
 ##### `_fill_cache` (`<frozen importlib._bootstrap_external>:1655`)
 
-|      % |  Size | Samples | Location                                      |
-| -----: | ----: | ------: | --------------------------------------------- |
-| 100.0% | 8 KiB |       4 | `<frozen importlib._bootstrap_external>:1667` |
+|      % |  Size | Allocations | Location                                      |
+| -----: | ----: | ----------: | --------------------------------------------- |
+| 100.0% | 8 KiB |           4 | `<frozen importlib._bootstrap_external>:1667` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|      % |     Size | Samples | Location                                |
-| -----: | -------: | ------: | --------------------------------------- |
-| 100.0% | 7.97 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:455` |
+|      % |     Size | Allocations | Location                                |
+| -----: | -------: | ----------: | --------------------------------------- |
+| 100.0% | 7.97 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:455` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/utils.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 44.8% | 3.17 KiB |       3 | `/venv/lib/python3.11/site-packages/click/utils.py:522` |
-| 31.4% | 2.22 KiB |       3 | `/venv/lib/python3.11/site-packages/click/utils.py:207` |
-| 23.8% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/utils.py:113` |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 44.8% | 3.17 KiB |           3 | `/venv/lib/python3.11/site-packages/click/utils.py:522` |
+| 31.4% | 2.22 KiB |           3 | `/venv/lib/python3.11/site-packages/click/utils.py:207` |
+| 23.8% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/utils.py:113` |
 
 ##### `__setattr__` (`/usr/lib/python3.11/enum.py:831`)
 
-|      % |     Size | Samples | Location                          |
-| -----: | -------: | ------: | --------------------------------- |
-| 100.0% | 6.73 KiB |       8 | `/usr/lib/python3.11/enum.py:842` |
+|      % |     Size | Allocations | Location                          |
+| -----: | -------: | ----------: | --------------------------------- |
+| 100.0% | 6.73 KiB |           8 | `/usr/lib/python3.11/enum.py:842` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/util.py:1`)
 
-|     % |     Size | Samples | Location                                                  |
-| ----: | -------: | ------: | --------------------------------------------------------- |
-| 22.9% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:254` |
-| 16.9% | 1.09 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:765` |
-| 16.3% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:710` |
-| 15.1% |   1000 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:741` |
-| 14.5% |    960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:651` |
+|     % |     Size | Allocations | Location                                                  |
+| ----: | -------: | ----------: | --------------------------------------------------------- |
+| 22.9% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:254` |
+| 16.9% | 1.09 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:765` |
+| 16.3% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:710` |
+| 15.1% |   1000 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:741` |
+| 14.5% |    960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/util.py:651` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|     % |     Size | Samples | Location                                                      |
-| ----: | -------: | ------: | ------------------------------------------------------------- |
-| 23.8% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:681` |
-| 23.0% | 1.43 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:44`  |
-| 19.4% | 1.21 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:63`  |
-| 16.9% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:179` |
-| 16.9% | 1.05 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:236` |
+|     % |     Size | Allocations | Location                                                      |
+| ----: | -------: | ----------: | ------------------------------------------------------------- |
+| 23.8% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:681` |
+| 23.0% | 1.43 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:44`  |
+| 19.4% | 1.21 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:63`  |
+| 16.9% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:179` |
+| 16.9% | 1.05 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:236` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|     % |     Size | Samples | Location                                                   |
-| ----: | -------: | ------: | ---------------------------------------------------------- |
-| 28.0% | 1.67 KiB |       2 | `/venv/lib/python3.11/site-packages/packaging/tags.py:118` |
-| 24.9% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:322` |
-| 15.7% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:110` |
-| 15.7% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:101` |
-| 15.7% |    960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:93`  |
+|     % |     Size | Allocations | Location                                                   |
+| ----: | -------: | ----------: | ---------------------------------------------------------- |
+| 28.0% | 1.67 KiB |           2 | `/venv/lib/python3.11/site-packages/packaging/tags.py:118` |
+| 24.9% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:322` |
+| 15.7% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:110` |
+| 15.7% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:101` |
+| 15.7% |    960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/tags.py:93`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/_compat.py:1`)
 
-|     % |     Size | Samples | Location                                                  |
-| ----: | -------: | ------: | --------------------------------------------------------- |
-| 29.1% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/_compat.py:452` |
-| 29.1% | 1.69 KiB |       2 | `/venv/lib/python3.11/site-packages/click/_compat.py:82`  |
-| 25.6% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/click/_compat.py:344` |
-| 16.2% |    960 B |       1 | `/venv/lib/python3.11/site-packages/click/_compat.py:56`  |
+|     % |     Size | Allocations | Location                                                  |
+| ----: | -------: | ----------: | --------------------------------------------------------- |
+| 29.1% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/_compat.py:452` |
+| 29.1% | 1.69 KiB |           2 | `/venv/lib/python3.11/site-packages/click/_compat.py:82`  |
+| 25.6% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/click/_compat.py:344` |
+| 16.2% |    960 B |           1 | `/venv/lib/python3.11/site-packages/click/_compat.py:56`  |
 
 ##### `namedtuple` (`/usr/lib/python3.11/collections/__init__.py:348`)
 
-|      % |     Size | Samples | Location                                          |
-| -----: | -------: | ------: | ------------------------------------------------- |
-| 100.0% | 5.63 KiB |       6 | `/usr/lib/python3.11/collections/__init__.py:501` |
+|      % |     Size | Allocations | Location                                          |
+| -----: | -------: | ----------: | ------------------------------------------------- |
+| 100.0% | 5.63 KiB |           6 | `/usr/lib/python3.11/collections/__init__.py:501` |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|     % |     Size | Samples | Location                                |
-| ----: | -------: | ------: | --------------------------------------- |
-| 43.4% | 2.43 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:539` |
-| 33.9% |  1.9 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:568` |
-| 22.7% | 1.28 KiB |       1 | `/usr/lib/python3.11/re/_parser.py:838` |
+|     % |     Size | Allocations | Location                                |
+| ----: | -------: | ----------: | --------------------------------------- |
+| 43.4% | 2.43 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:539` |
+| 33.9% |  1.9 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:568` |
+| 22.7% | 1.28 KiB |           1 | `/usr/lib/python3.11/re/_parser.py:838` |
 
 ##### `_code` (`/usr/lib/python3.11/re/_compiler.py:571`)
 
-|     % |     Size | Samples | Location                                  |
-| ----: | -------: | ------: | ----------------------------------------- |
-| 81.6% | 4.34 KiB |       1 | `/usr/lib/python3.11/re/_compiler.py:580` |
-| 18.4% |   1002 B |       1 | `/usr/lib/python3.11/re/_compiler.py:577` |
+|     % |     Size | Allocations | Location                                  |
+| ----: | -------: | ----------: | ----------------------------------------- |
+| 81.6% | 4.34 KiB |           1 | `/usr/lib/python3.11/re/_compiler.py:580` |
+| 18.4% |   1002 B |           1 | `/usr/lib/python3.11/re/_compiler.py:577` |
 
 ##### `<module>` (`/usr/lib/python3.11/pkgutil.py:1`)
 
-|     % |     Size | Samples | Location                             |
-| ----: | -------: | ------: | ------------------------------------ |
-| 35.7% | 1.69 KiB |       2 | `/usr/lib/python3.11/pkgutil.py:269` |
-| 35.7% | 1.69 KiB |       2 | `/usr/lib/python3.11/pkgutil.py:194` |
-| 15.9% |    768 B |       1 | `/usr/lib/python3.11/pkgutil.py:137` |
-| 12.8% |    620 B |       1 | `/usr/lib/python3.11/pkgutil.py:184` |
+|     % |     Size | Allocations | Location                             |
+| ----: | -------: | ----------: | ------------------------------------ |
+| 35.7% | 1.69 KiB |           2 | `/usr/lib/python3.11/pkgutil.py:269` |
+| 35.7% | 1.69 KiB |           2 | `/usr/lib/python3.11/pkgutil.py:194` |
+| 15.9% |    768 B |           1 | `/usr/lib/python3.11/pkgutil.py:137` |
+| 12.8% |    620 B |           1 | `/usr/lib/python3.11/pkgutil.py:184` |
 
 ##### `Specifier` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`)
 
-|      % |     Size | Samples | Location                                                         |
-| -----: | -------: | ------: | ---------------------------------------------------------------- |
-| 100.0% | 3.82 KiB |       1 | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:340` |
+|      % |     Size | Allocations | Location                                                         |
+| -----: | -------: | ----------: | ---------------------------------------------------------------- |
+| 100.0% | 3.82 KiB |           1 | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:340` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 46.4% | 1.73 KiB |       2 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:29`  |
-| 27.3% | 1.02 KiB |       1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:90`  |
-| 26.3% |   1000 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:245` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 46.4% | 1.73 KiB |           2 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:29`  |
+| 27.3% | 1.02 KiB |           1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:90`  |
+| 26.3% |   1000 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:245` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|     % |  Size | Samples | Location                                                   |
-| ----: | ----: | ------: | ---------------------------------------------------------- |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:62` |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:46` |
-| 26.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:54` |
-| 21.1% | 768 B |       1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:27` |
+|     % |  Size | Allocations | Location                                                   |
+| ----: | ----: | ----------: | ---------------------------------------------------------- |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:62` |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:46` |
+| 26.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:54` |
+| 21.1% | 768 B |           1 | `/venv/lib/python3.11/site-packages/packaging/utils.py:27` |
 
 ##### `handle_parse_result` (`/venv/lib/python3.11/site-packages/click/core.py:2663`)
 
-|     % |    Size | Samples | Location                                                |
-| ----: | ------: | ------: | ------------------------------------------------------- |
-| 38.5% | 1.3 KiB |       2 | `/venv/lib/python3.11/site-packages/click/core.py:2686` |
-| 22.3% |   768 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2739` |
-| 22.3% |   768 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2740` |
-| 17.0% |   586 B |       1 | `/venv/lib/python3.11/site-packages/click/core.py:2711` |
+|     % |    Size | Allocations | Location                                                |
+| ----: | ------: | ----------: | ------------------------------------------------------- |
+| 38.5% | 1.3 KiB |           2 | `/venv/lib/python3.11/site-packages/click/core.py:2686` |
+| 22.3% |   768 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2739` |
+| 22.3% |   768 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2740` |
+| 17.0% |   586 B |           1 | `/venv/lib/python3.11/site-packages/click/core.py:2711` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|      % |     Size | Samples | Location                                                  |
-| -----: | -------: | ------: | --------------------------------------------------------- |
-| 100.0% | 3.19 KiB |       1 | `/venv/lib/python3.11/site-packages/click/__init__.py:74` |
+|      % |     Size | Allocations | Location                                                  |
+| -----: | -------: | ----------: | --------------------------------------------------------- |
+| 100.0% | 3.19 KiB |           1 | `/venv/lib/python3.11/site-packages/click/__init__.py:74` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`)
 
-|     % |     Size | Samples | Location                                                     |
-| ----: | -------: | ------: | ------------------------------------------------------------ |
-| 76.5% | 2.44 KiB |       3 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:55` |
-| 23.5% |    768 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:14` |
+|     % |     Size | Allocations | Location                                                     |
+| ----: | -------: | ----------: | ------------------------------------------------------------ |
+| 76.5% | 2.44 KiB |           3 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:55` |
+| 23.5% |    768 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/pathspec.py:14` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Location                                                    |
-| -----: | -------: | ------: | ----------------------------------------------------------- |
-| 100.0% | 3.04 KiB |       2 | `/venv/lib/python3.11/site-packages/click/decorators.py:34` |
+|      % |     Size | Allocations | Location                                                    |
+| -----: | -------: | ----------: | ----------------------------------------------------------- |
+| 100.0% | 3.04 KiB |           2 | `/venv/lib/python3.11/site-packages/click/decorators.py:34` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|      % |     Size | Samples | Location                                  |
-| -----: | -------: | ------: | ----------------------------------------- |
-| 100.0% | 2.85 KiB |       1 | `/usr/lib/python3.11/dataclasses.py:1210` |
+|      % |     Size | Allocations | Location                                  |
+| -----: | -------: | ----------: | ----------------------------------------- |
+| 100.0% | 2.85 KiB |           1 | `/usr/lib/python3.11/dataclasses.py:1210` |
 
 ##### `_process_class` (`/usr/lib/python3.11/dataclasses.py:884`)
 
-|     % |     Size | Samples | Location                                  |
-| ----: | -------: | ------: | ----------------------------------------- |
-| 41.3% | 1.18 KiB |       1 | `/usr/lib/python3.11/dataclasses.py:958`  |
-| 21.0% |    612 B |       1 | `/usr/lib/python3.11/dataclasses.py:1027` |
-| 19.9% |    580 B |       1 | `/usr/lib/python3.11/dataclasses.py:1096` |
-| 17.8% |    518 B |       1 | `/usr/lib/python3.11/dataclasses.py:947`  |
+|     % |     Size | Allocations | Location                                  |
+| ----: | -------: | ----------: | ----------------------------------------- |
+| 41.3% | 1.18 KiB |           1 | `/usr/lib/python3.11/dataclasses.py:958`  |
+| 21.0% |    612 B |           1 | `/usr/lib/python3.11/dataclasses.py:1027` |
+| 19.9% |    580 B |           1 | `/usr/lib/python3.11/dataclasses.py:1096` |
+| 17.8% |    518 B |           1 | `/usr/lib/python3.11/dataclasses.py:947`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1`)
 
-|     % |  Size | Samples | Location                                                                     |
-| ----: | ----: | ------: | ---------------------------------------------------------------------------- |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:22`  |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:205` |
-| 33.3% | 960 B |       1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:197` |
+|     % |  Size | Allocations | Location                                                                     |
+| ----: | ----: | ----------: | ---------------------------------------------------------------------------- |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:22`  |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:205` |
+| 33.3% | 960 B |           1 | `/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:197` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|     % |     Size | Samples | Location                                                |
-| ----: | -------: | ------: | ------------------------------------------------------- |
-| 53.7% | 1.48 KiB |       1 | `/venv/lib/python3.11/site-packages/click/types.py:464` |
-| 46.3% | 1.28 KiB |       1 | `/venv/lib/python3.11/site-packages/click/types.py:37`  |
+|     % |     Size | Allocations | Location                                                |
+| ----: | -------: | ----------: | ------------------------------------------------------- |
+| 53.7% | 1.48 KiB |           1 | `/venv/lib/python3.11/site-packages/click/types.py:464` |
+| 46.3% | 1.28 KiB |           1 | `/venv/lib/python3.11/site-packages/click/types.py:37`  |
 
 ##### `_signature_from_function` (`/usr/lib/python3.11/inspect.py:2331`)
 
-|     % |     Size | Samples | Location                              |
-| ----: | -------: | ------: | ------------------------------------- |
-| 41.4% | 1.06 KiB |       1 | `/usr/lib/python3.11/inspect.py:2358` |
-| 37.0% |    972 B |       1 | `/usr/lib/python3.11/inspect.py:2376` |
-| 21.6% |    568 B |       1 | `/usr/lib/python3.11/inspect.py:2421` |
+|     % |     Size | Allocations | Location                              |
+| ----: | -------: | ----------: | ------------------------------------- |
+| 41.4% | 1.06 KiB |           1 | `/usr/lib/python3.11/inspect.py:2358` |
+| 37.0% |    972 B |           1 | `/usr/lib/python3.11/inspect.py:2376` |
+| 21.6% |    568 B |           1 | `/usr/lib/python3.11/inspect.py:2421` |
 
 #### Callers
 
@@ -2019,483 +2019,483 @@ Callers ranked by contribution to each function's self size. Inlining can make c
 
 ##### `mark` (`black/brackets.py:70`)
 
-|     % |     Size | Samples | Caller                           | Location                |
-| ----: | -------: | ------: | -------------------------------- | ----------------------- |
-| 94.8% | 18.2 MiB |  20,790 | `append`                         | `black/lines.py:63`     |
-|  5.2% |    1 MiB |       1 | `max_delimiter_priority_in_atom` | `black/brackets.py:328` |
+|     % |     Size | Allocations | Caller                           | Location                |
+| ----: | -------: | ----------: | -------------------------------- | ----------------------- |
+| 94.8% | 18.2 MiB |      20,790 | `append`                         | `black/lines.py:63`     |
+|  5.2% |    1 MiB |           1 | `max_delimiter_priority_in_atom` | `black/brackets.py:328` |
 
 ##### `changed` (`blib2to3/pytree.py:171`)
 
-|     % |  Size | Samples | Caller    | Location                 |
-| ----: | ----: | ------: | --------- | ------------------------ |
-| 71.4% | 5 MiB |       5 | `changed` | `blib2to3/pytree.py:171` |
-| 28.6% | 2 MiB |       2 | `prefix`  | `blib2to3/pytree.py:480` |
+|     % |  Size | Allocations | Caller    | Location                 |
+| ----: | ----: | ----------: | --------- | ------------------------ |
+| 71.4% | 5 MiB |           5 | `changed` | `blib2to3/pytree.py:171` |
+| 28.6% | 2 MiB |           2 | `prefix`  | `blib2to3/pytree.py:480` |
 
 ##### `__new__` (`blib2to3/pytree.py:81`)
 
-|      % |  Size | Samples | Caller    | Location                 |
-| -----: | ----: | ------: | --------- | ------------------------ |
-| 100.0% | 5 MiB |       5 | `convert` | `blib2to3/pytree.py:486` |
+|      % |  Size | Allocations | Caller    | Location                 |
+| -----: | ----: | ----------: | --------- | ------------------------ |
+| 100.0% | 5 MiB |           5 | `convert` | `blib2to3/pytree.py:486` |
 
 ##### `update_sibling_maps` (`blib2to3/pytree.py:369`)
 
-|      % |     Size | Samples | Caller         | Location                 |
-| -----: | -------: | ------: | -------------- | ------------------------ |
-| 100.0% | 3.14 MiB |     198 | `prev_sibling` | `blib2to3/pytree.py:207` |
+|      % |     Size | Allocations | Caller         | Location                 |
+| -----: | -------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 3.14 MiB |         198 | `prev_sibling` | `blib2to3/pytree.py:207` |
 
 ##### `transform_line` (`black/linegen.py:601`)
 
-|      % |     Size | Samples | Caller             | Location                 |
-| -----: | -------: | ------: | ------------------ | ------------------------ |
-| 100.0% | 3.07 MiB |       9 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |     Size | Allocations | Caller             | Location                 |
+| -----: | -------: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 3.07 MiB |           9 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`)
 
-|      % |     Size | Samples | Caller           | Location                                     |
-| -----: | -------: | ------: | ---------------- | -------------------------------------------- |
-| 100.0% | 2.27 MiB |     352 | `source_to_code` | `<frozen importlib._bootstrap_external>:999` |
+|      % |     Size | Allocations | Caller           | Location                                     |
+| -----: | -------: | ----------: | ---------------- | -------------------------------------------- |
+| 100.0% | 2.27 MiB |         352 | `source_to_code` | `<frozen importlib._bootstrap_external>:999` |
 
 ##### `parse` (`/usr/lib/python3.11/ast.py:33`)
 
-|      % |     Size | Samples | Caller                  | Location               |
-| -----: | -------: | ------: | ----------------------- | ---------------------- |
-| 100.0% | 2.01 MiB |       3 | `_parse_single_version` | `black/parsing.py:117` |
+|      % |     Size | Allocations | Caller                  | Location               |
+| -----: | -------: | ----------: | ----------------------- | ---------------------- |
+| 100.0% | 2.01 MiB |           3 | `_parse_single_version` | `black/parsing.py:117` |
 
 ##### `generate_comments` (`black/comments.py:52`)
 
-|      % |  Size | Samples | Caller          | Location               |
-| -----: | ----: | ------: | --------------- | ---------------------- |
-| 100.0% | 2 MiB |       2 | `visit_default` | `black/linegen.py:134` |
+|      % |  Size | Allocations | Caller          | Location               |
+| -----: | ----: | ----------: | --------------- | ---------------------- |
+| 100.0% | 2 MiB |           2 | `visit_default` | `black/linegen.py:134` |
 
 ##### `convert` (`blib2to3/pytree.py:486`)
 
-|      % |  Size | Samples | Caller | Location                      |
-| -----: | ----: | ------: | ------ | ----------------------------- |
-| 100.0% | 2 MiB |       2 | `pop`  | `blib2to3/pgen2/parse.py:398` |
+|      % |  Size | Allocations | Caller | Location                      |
+| -----: | ----: | ----------: | ------ | ----------------------------- |
+| 100.0% | 2 MiB |           2 | `pop`  | `blib2to3/pgen2/parse.py:398` |
 
 ##### `_addtoken` (`blib2to3/pgen2/parse.py:290`)
 
-|      % |  Size | Samples | Caller     | Location                      |
-| -----: | ----: | ------: | ---------- | ----------------------------- |
-| 100.0% | 2 MiB |       2 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
+|      % |  Size | Allocations | Caller     | Location                      |
+| -----: | ----: | ----------: | ---------- | ----------------------------- |
+| 100.0% | 2 MiB |           2 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
 
 ##### `make_grammar` (`blib2to3/pgen2/pgen.py:49`)
 
-|      % |     Size | Samples | Caller             | Location                     |
-| -----: | -------: | ------: | ------------------ | ---------------------------- |
-| 100.0% | 1.01 MiB |       6 | `generate_grammar` | `blib2to3/pgen2/pgen.py:426` |
+|      % |     Size | Allocations | Caller             | Location                     |
+| -----: | -------: | ----------: | ------------------ | ---------------------------- |
+| 100.0% | 1.01 MiB |           6 | `generate_grammar` | `blib2to3/pgen2/pgen.py:426` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 1.01 MiB |      11 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 1.01 MiB |          11 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|     % |  Size | Samples | Caller             | Location                 |
-| ----: | ----: | ------: | ------------------ | ------------------------ |
-| 99.9% | 1 MiB |       4 | `visit_default`    | `black/nodes.py:187`     |
-|  0.1% | 690 B |       1 | `_format_str_once` | `black/__init__.py:1236` |
+|     % |  Size | Allocations | Caller             | Location                 |
+| ----: | ----: | ----------: | ------------------ | ------------------------ |
+| 99.9% | 1 MiB |           4 | `visit_default`    | `black/nodes.py:187`     |
+|  0.1% | 690 B |           1 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `addtoken` (`blib2to3/pgen2/parse.py:242`)
 
-|      % |  Size | Samples | Caller         | Location                       |
-| -----: | ----: | ------: | -------------- | ------------------------------ |
-| 100.0% | 1 MiB |       3 | `parse_tokens` | `blib2to3/pgen2/driver.py:114` |
+|      % |  Size | Allocations | Caller         | Location                       |
+| -----: | ----: | ----------: | -------------- | ------------------------------ |
+| 100.0% | 1 MiB |           3 | `parse_tokens` | `blib2to3/pgen2/driver.py:114` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|     % |  Size | Samples | Caller         | Location               |
-| ----: | ----: | ------: | -------------- | ---------------------- |
-| 99.9% | 1 MiB |       1 | `visit`        | `black/nodes.py:163`   |
-|  0.1% | 702 B |       1 | `visit_STRING` | `black/linegen.py:413` |
+|     % |  Size | Allocations | Caller         | Location               |
+| ----: | ----: | ----------: | -------------- | ---------------------- |
+| 99.9% | 1 MiB |           1 | `visit`        | `black/nodes.py:163`   |
+|  0.1% | 702 B |           1 | `visit_STRING` | `black/linegen.py:413` |
 
 ##### `lines_with_leading_tabs_expanded` (`black/strings.py:46`)
 
-|      % |  Size | Samples | Caller          | Location              |
-| -----: | ----: | ------: | --------------- | --------------------- |
-| 100.0% | 1 MiB |       1 | `fix_docstring` | `black/strings.py:65` |
+|      % |  Size | Allocations | Caller          | Location              |
+| -----: | ----: | ----------: | --------------- | --------------------- |
+| 100.0% | 1 MiB |           1 | `fix_docstring` | `black/strings.py:65` |
 
 ##### `is_import` (`black/lines.py:134`)
 
-|      % |  Size | Samples | Caller               | Location             |
-| -----: | ----: | ------: | -------------------- | -------------------- |
-| 100.0% | 1 MiB |       1 | `_maybe_empty_lines` | `black/lines.py:610` |
+|      % |  Size | Allocations | Caller               | Location             |
+| -----: | ----: | ----------: | -------------------- | -------------------- |
+| 100.0% | 1 MiB |           1 | `_maybe_empty_lines` | `black/lines.py:610` |
 
 ##### `__init__` (`<string>:2`)
 
-|      % |  Size | Samples | Caller | Location               |
-| -----: | ----: | ------: | ------ | ---------------------- |
-| 100.0% | 1 MiB |       1 | `line` | `black/linegen.py:109` |
+|      % |  Size | Allocations | Caller | Location               |
+| -----: | ----: | ----------: | ------ | ---------------------- |
+| 100.0% | 1 MiB |           1 | `line` | `black/linegen.py:109` |
 
 ##### `pop` (`blib2to3/pgen2/parse.py:398`)
 
-|      % |  Size | Samples | Caller      | Location                      |
-| -----: | ----: | ------: | ----------- | ----------------------------- |
-| 100.0% | 1 MiB |       1 | `_addtoken` | `blib2to3/pgen2/parse.py:290` |
+|      % |  Size | Allocations | Caller      | Location                      |
+| -----: | ----: | ----------: | ----------- | ----------------------------- |
+| 100.0% | 1 MiB |           1 | `_addtoken` | `blib2to3/pgen2/parse.py:290` |
 
 ##### `_compile_bytecode` (`<frozen importlib._bootstrap_external>:727`)
 
-|      % |    Size | Samples | Caller     | Location                                      |
-| -----: | ------: | ------: | ---------- | --------------------------------------------- |
-| 100.0% | 311 KiB |     341 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
+|      % |    Size | Allocations | Caller     | Location                                      |
+| -----: | ------: | ----------: | ---------- | --------------------------------------------- |
+| 100.0% | 311 KiB |         341 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `_code_to_timestamp_pyc` (`<frozen importlib._bootstrap_external>:740`)
 
-|      % |    Size | Samples | Caller     | Location                                      |
-| -----: | ------: | ------: | ---------- | --------------------------------------------- |
-| 100.0% | 112 KiB |     108 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
+|      % |    Size | Allocations | Caller     | Location                                      |
+| -----: | ------: | ----------: | ---------- | --------------------------------------------- |
+| 100.0% | 112 KiB |         108 | `get_code` | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `__new__` (`<frozen abc>:105`)
 
-|     % |     Size | Samples | Caller     | Location                                                       |
-| ----: | -------: | ------: | ---------- | -------------------------------------------------------------- |
-| 50.5% | 38.2 KiB |      45 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`          |
-| 23.1% | 17.5 KiB |      18 | `<module>` | `black/trans.py:1`                                             |
-| 18.3% | 13.9 KiB |       9 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`           |
-|  8.0% | 6.07 KiB |       7 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
+|     % |     Size | Allocations | Caller     | Location                                                       |
+| ----: | -------: | ----------: | ---------- | -------------------------------------------------------------- |
+| 50.5% | 38.2 KiB |          45 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`          |
+| 23.1% | 17.5 KiB |          18 | `<module>` | `black/trans.py:1`                                             |
+| 18.3% | 13.9 KiB |           9 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`           |
+|  8.0% | 6.07 KiB |           7 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
 
 ##### `normalize_string_prefix` (`black/strings.py:143`)
 
-|      % |     Size | Samples | Caller         | Location               |
-| -----: | -------: | ------: | -------------- | ---------------------- |
-| 100.0% | 57.2 KiB |      65 | `visit_STRING` | `black/linegen.py:413` |
+|      % |     Size | Allocations | Caller         | Location               |
+| -----: | -------: | ----------: | -------------- | ---------------------- |
+| 100.0% | 57.2 KiB |          65 | `visit_STRING` | `black/linegen.py:413` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|      % |     Size | Samples | Caller      | Location                                                     |
-| -----: | -------: | ------: | ----------- | ------------------------------------------------------------ |
-| 100.0% | 44.3 KiB |      31 | `decorator` | `/venv/lib/python3.11/site-packages/click/decorators.py:373` |
+|      % |     Size | Allocations | Caller      | Location                                                     |
+| -----: | -------: | ----------: | ----------- | ------------------------------------------------------------ |
+| 100.0% | 44.3 KiB |          31 | `decorator` | `/venv/lib/python3.11/site-packages/click/decorators.py:373` |
 
 ##### `copy` (`blib2to3/pgen2/grammar.py:131`)
 
-|      % |     Size | Samples | Caller       | Location                 |
-| -----: | -------: | ------: | ------------ | ------------------------ |
-| 100.0% | 41.5 KiB |      16 | `initialize` | `blib2to3/pygram.py:165` |
+|      % |     Size | Allocations | Caller       | Location                 |
+| -----: | -------: | ----------: | ------------ | ------------------------ |
+| 100.0% | 41.5 KiB |          16 | `initialize` | `blib2to3/pygram.py:165` |
 
 ##### `classify` (`blib2to3/pgen2/parse.py:336`)
 
-|      % |   Size | Samples | Caller     | Location                      |
-| -----: | -----: | ------: | ---------- | ----------------------------- |
-| 100.0% | 32 KiB |       1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
+|      % |   Size | Allocations | Caller     | Location                      |
+| -----: | -----: | ----------: | ---------- | ----------------------------- |
+| 100.0% | 32 KiB |           1 | `addtoken` | `blib2to3/pgen2/parse.py:242` |
 
 ##### `make_first` (`blib2to3/pgen2/pgen.py:74`)
 
-|      % |     Size | Samples | Caller         | Location                    |
-| -----: | -------: | ------: | -------------- | --------------------------- |
-| 100.0% | 25.3 KiB |      40 | `make_grammar` | `blib2to3/pgen2/pgen.py:49` |
+|      % |     Size | Allocations | Caller         | Location                    |
+| -----: | -------: | ----------: | -------------- | --------------------------- |
+| 100.0% | 25.3 KiB |          40 | `make_grammar` | `blib2to3/pgen2/pgen.py:49` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 25 KiB |      22 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 25 KiB |          22 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__new__` (`/usr/lib/python3.11/enum.py:488`)
 
-|     % |     Size | Samples | Caller     | Location                                                     |
-| ----: | -------: | ------: | ---------- | ------------------------------------------------------------ |
-| 31.7% | 7.64 KiB |       9 | `<module>` | `black/mode.py:1`                                            |
-| 16.2% | 3.89 KiB |       4 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/_elffile.py:1` |
-| 13.7% |  3.3 KiB |       3 | `<module>` | `/venv/lib/python3.11/site-packages/click/_utils.py:1`       |
-| 10.1% | 2.44 KiB |       3 | `<module>` | `black/__init__.py:1`                                        |
-|  7.2% | 1.74 KiB |       2 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`         |
+|     % |     Size | Allocations | Caller     | Location                                                     |
+| ----: | -------: | ----------: | ---------- | ------------------------------------------------------------ |
+| 31.7% | 7.64 KiB |           9 | `<module>` | `black/mode.py:1`                                            |
+| 16.2% | 3.89 KiB |           4 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/_elffile.py:1` |
+| 13.7% |  3.3 KiB |           3 | `<module>` | `/venv/lib/python3.11/site-packages/click/_utils.py:1`       |
+| 10.1% | 2.44 KiB |           3 | `<module>` | `black/__init__.py:1`                                        |
+|  7.2% | 1.74 KiB |           2 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`         |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|      % |     Size | Samples | Caller     | Location                                 |
-| -----: | -------: | ------: | ---------- | ---------------------------------------- |
-| 100.0% | 22.6 KiB |      12 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
+|      % |     Size | Allocations | Caller     | Location                                 |
+| -----: | -------: | ----------: | ---------- | ---------------------------------------- |
+| 100.0% | 22.6 KiB |          12 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/_parser.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 19.8 KiB |      12 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 19.8 KiB |          12 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__new__` (`/usr/lib/python3.11/typing.py:2891`)
 
-|     % |     Size | Samples | Caller     | Location                                                    |
-| ----: | -------: | ------: | ---------- | ----------------------------------------------------------- |
-| 90.3% | 15.7 KiB |      19 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`       |
-|  9.7% | 1.69 KiB |       2 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/version.py:1` |
+|     % |     Size | Allocations | Caller     | Location                                                    |
+| ----: | -------: | ----------: | ---------- | ----------------------------------------------------------- |
+| 90.3% | 15.7 KiB |          19 | `<module>` | `/venv/lib/python3.11/site-packages/click/types.py:1`       |
+|  9.7% | 1.69 KiB |           2 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/version.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/mypy_extensions.py:1`)
 
-|      % |   Size | Samples | Caller                      | Location                            |
-| -----: | -----: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 15 KiB |      18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |   Size | Allocations | Caller                      | Location                            |
+| -----: | -----: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 15 KiB |          18 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/exceptions.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 13.4 KiB |      15 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 13.4 KiB |          15 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `inner` (`/usr/lib/python3.11/typing.py:338`)
 
-|     % |     Size | Samples | Caller        | Location                                              |
-| ----: | -------: | ------: | ------------- | ----------------------------------------------------- |
-| 75.3% | 9.02 KiB |       1 | `Line`        | `black/lines.py:49`                                   |
-| 17.9% | 2.15 KiB |       1 | `__getitem__` | `/usr/lib/python3.11/typing.py:467`                   |
-|  6.7% |    826 B |       1 | `<module>`    | `/venv/lib/python3.11/site-packages/click/types.py:1` |
+|     % |     Size | Allocations | Caller        | Location                                              |
+| ----: | -------: | ----------: | ------------- | ----------------------------------------------------- |
+| 75.3% | 9.02 KiB |           1 | `Line`        | `black/lines.py:49`                                   |
+| 17.9% | 2.15 KiB |           1 | `__getitem__` | `/usr/lib/python3.11/typing.py:467`                   |
+|  6.7% |    826 B |           1 | `<module>`    | `/venv/lib/python3.11/site-packages/click/types.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/version.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 9.61 KiB |       9 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 9.61 KiB |           9 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `_fill_cache` (`<frozen importlib._bootstrap_external>:1655`)
 
-|      % |  Size | Samples | Caller      | Location                                      |
-| -----: | ----: | ------: | ----------- | --------------------------------------------- |
-| 100.0% | 8 KiB |       4 | `find_spec` | `<frozen importlib._bootstrap_external>:1604` |
+|      % |  Size | Allocations | Caller      | Location                                      |
+| -----: | ----: | ----------: | ----------- | --------------------------------------------- |
+| 100.0% | 8 KiB |           4 | `find_spec` | `<frozen importlib._bootstrap_external>:1604` |
 
 ##### `_parse_sub` (`/usr/lib/python3.11/re/_parser.py:447`)
 
-|      % |     Size | Samples | Caller  | Location                                |
-| -----: | -------: | ------: | ------- | --------------------------------------- |
-| 100.0% | 7.97 KiB |       1 | `parse` | `/usr/lib/python3.11/re/_parser.py:970` |
+|      % |     Size | Allocations | Caller  | Location                                |
+| -----: | -------: | ----------: | ------- | --------------------------------------- |
+| 100.0% | 7.97 KiB |           1 | `parse` | `/usr/lib/python3.11/re/_parser.py:970` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/utils.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 7.08 KiB |       8 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 7.08 KiB |           8 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `__setattr__` (`/usr/lib/python3.11/enum.py:831`)
 
-|     % |     Size | Samples | Caller         | Location                          |
-| ----: | -------: | ------: | -------------- | --------------------------------- |
-| 66.6% | 4.48 KiB |       5 | `__set_name__` | `/usr/lib/python3.11/enum.py:237` |
-| 33.4% | 2.25 KiB |       3 | `__new__`      | `/usr/lib/python3.11/enum.py:488` |
+|     % |     Size | Allocations | Caller         | Location                          |
+| ----: | -------: | ----------: | -------------- | --------------------------------- |
+| 66.6% | 4.48 KiB |           5 | `__set_name__` | `/usr/lib/python3.11/enum.py:237` |
+| 33.4% | 2.25 KiB |           3 | `__new__`      | `/usr/lib/python3.11/enum.py:488` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/util.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 6.48 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 6.48 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 6.24 KiB |       5 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 6.24 KiB |           5 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/tags.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 5.97 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 5.97 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/_compat.py:1`)
 
-|      % |    Size | Samples | Caller                      | Location                            |
-| -----: | ------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 5.8 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |    Size | Allocations | Caller                      | Location                            |
+| -----: | ------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 5.8 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `namedtuple` (`/usr/lib/python3.11/collections/__init__.py:348`)
 
-|     % |     Size | Samples | Caller          | Location                             |
-| ----: | -------: | ------: | --------------- | ------------------------------------ |
-| 83.3% | 4.69 KiB |       5 | `_make_nmtuple` | `/usr/lib/python3.11/typing.py:2795` |
-| 16.7% |    960 B |       1 | `<module>`      | `/usr/lib/python3.11/pkgutil.py:1`   |
+|     % |     Size | Allocations | Caller          | Location                             |
+| ----: | -------: | ----------: | --------------- | ------------------------------------ |
+| 83.3% | 4.69 KiB |           5 | `_make_nmtuple` | `/usr/lib/python3.11/typing.py:2795` |
+| 16.7% |    960 B |           1 | `<module>`      | `/usr/lib/python3.11/pkgutil.py:1`   |
 
 ##### `_parse` (`/usr/lib/python3.11/re/_parser.py:507`)
 
-|      % |     Size | Samples | Caller       | Location                                |
-| -----: | -------: | ------: | ------------ | --------------------------------------- |
-| 100.0% | 5.61 KiB |       3 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
+|      % |     Size | Allocations | Caller       | Location                                |
+| -----: | -------: | ----------: | ------------ | --------------------------------------- |
+| 100.0% | 5.61 KiB |           3 | `_parse_sub` | `/usr/lib/python3.11/re/_parser.py:447` |
 
 ##### `_code` (`/usr/lib/python3.11/re/_compiler.py:571`)
 
-|      % |     Size | Samples | Caller    | Location                                  |
-| -----: | -------: | ------: | --------- | ----------------------------------------- |
-| 100.0% | 5.32 KiB |       2 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
+|      % |     Size | Allocations | Caller    | Location                                  |
+| -----: | -------: | ----------: | --------- | ----------------------------------------- |
+| 100.0% | 5.32 KiB |           2 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
 
 ##### `<module>` (`/usr/lib/python3.11/pkgutil.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 4.73 KiB |       6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 4.73 KiB |           6 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `Specifier` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:220`)
 
-|      % |     Size | Samples | Caller     | Location                                                       |
-| -----: | -------: | ------: | ---------- | -------------------------------------------------------------- |
-| 100.0% | 3.82 KiB |       1 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
+|      % |     Size | Allocations | Caller     | Location                                                       |
+| -----: | -------: | ----------: | ---------- | -------------------------------------------------------------- |
+| 100.0% | 3.82 KiB |           1 | `<module>` | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pattern.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.72 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.72 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.56 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.56 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `handle_parse_result` (`/venv/lib/python3.11/site-packages/click/core.py:2663`)
 
-|      % |     Size | Samples | Caller       | Location                                                |
-| -----: | -------: | ------: | ------------ | ------------------------------------------------------- |
-| 100.0% | 3.37 KiB |       5 | `parse_args` | `/venv/lib/python3.11/site-packages/click/core.py:1303` |
+|      % |     Size | Allocations | Caller       | Location                                                |
+| -----: | -------: | ----------: | ------------ | ------------------------------------------------------- |
+| 100.0% | 3.37 KiB |           5 | `parse_args` | `/venv/lib/python3.11/site-packages/click/core.py:1303` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.19 KiB |       1 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.19 KiB |           1 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/pathspec.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 3.19 KiB |       4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 3.19 KiB |           4 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Caller   | Location                                               |
-| -----: | -------: | ------: | -------- | ------------------------------------------------------ |
-| 100.0% | 3.04 KiB |       2 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
+|      % |     Size | Allocations | Caller   | Location                                               |
+| -----: | -------: | ----------: | -------- | ------------------------------------------------------ |
+| 100.0% | 3.04 KiB |           2 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
 
 ##### `wrap` (`/usr/lib/python3.11/dataclasses.py:1209`)
 
-|      % |     Size | Samples | Caller     | Location                                                   |
-| -----: | -------: | ------: | ---------- | ---------------------------------------------------------- |
-| 100.0% | 2.85 KiB |       1 | `<module>` | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1` |
+|      % |     Size | Allocations | Caller     | Location                                                   |
+| -----: | -------: | ----------: | ---------- | ---------------------------------------------------------- |
+| 100.0% | 2.85 KiB |           1 | `<module>` | `/venv/lib/python3.11/site-packages/pathspec/pattern.py:1` |
 
 ##### `_process_class` (`/usr/lib/python3.11/dataclasses.py:884`)
 
-|      % |     Size | Samples | Caller | Location                                  |
-| -----: | -------: | ------: | ------ | ----------------------------------------- |
-| 100.0% | 2.85 KiB |       4 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
+|      % |     Size | Allocations | Caller | Location                                  |
+| -----: | -------: | ----------: | ------ | ----------------------------------------- |
+| 100.0% | 2.85 KiB |           4 | `wrap` | `/usr/lib/python3.11/dataclasses.py:1209` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/patterns/gitignore/base.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.81 KiB |       3 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.81 KiB |           3 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|      % |     Size | Samples | Caller                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.76 KiB |       2 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Caller                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.76 KiB |           2 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `_signature_from_function` (`/usr/lib/python3.11/inspect.py:2331`)
 
-|      % |     Size | Samples | Caller                     | Location                              |
-| -----: | -------: | ------: | -------------------------- | ------------------------------------- |
-| 100.0% | 2.56 KiB |       3 | `_signature_from_callable` | `/usr/lib/python3.11/inspect.py:2426` |
+|      % |     Size | Allocations | Caller                     | Location                              |
+| -----: | -------: | ----------: | -------------------------- | ------------------------------------- |
+| 100.0% | 2.56 KiB |           3 | `_signature_from_callable` | `/usr/lib/python3.11/inspect.py:2426` |
 
 ### Total size
 
 Functions ranked by total bytes never freed in the function and all its callees.
 
-|      % |     Size | Samples | Function               | Location                                                       |
-| -----: | -------: | ------: | ---------------------- | -------------------------------------------------------------- |
-| 100.0% | 58.1 MiB |  22,685 | `_run_tracker`         | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
-| 100.0% | 58.1 MiB |  22,684 | `run_module`           | `<frozen runpy>:201`                                           |
-|  90.7% | 52.6 MiB |  21,190 | `__call__`             | `/venv/lib/python3.11/site-packages/click/core.py:1567`        |
-|  90.7% | 52.6 MiB |  21,190 | `patched_main`         | `black/__init__.py:1594`                                       |
-|  90.7% | 52.6 MiB |  21,190 | `<module>`             | `black/__main__.py:1`                                          |
-|  90.7% | 52.6 MiB |  21,190 | `_run_code`            | `<frozen runpy>:65`                                            |
-|  90.7% | 52.6 MiB |  21,190 | `_run_module_code`     | `<frozen runpy>:91`                                            |
-|  90.7% | 52.6 MiB |  21,189 | `main`                 | `/venv/lib/python3.11/site-packages/click/core.py:1422`        |
-|  90.6% | 52.6 MiB |  21,170 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:1339`        |
-|  90.6% | 52.6 MiB |  21,168 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:853`         |
-|  90.6% | 52.6 MiB |  21,167 | `new_func`             | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
-|  90.6% | 52.6 MiB |  21,165 | `main`                 | `black/__init__.py:244`                                        |
-|  90.6% | 52.6 MiB |  21,160 | `reformat_one`         | `black/__init__.py:860`                                        |
-|  90.6% | 52.6 MiB |  21,153 | `format_file_in_place` | `black/__init__.py:917`                                        |
-|  90.6% | 52.6 MiB |  21,152 | `format_file_contents` | `black/__init__.py:1054`                                       |
-|  87.1% | 50.6 MiB |  21,146 | `_format_str_once`     | `black/__init__.py:1236`                                       |
-|  61.0% | 35.4 MiB |  21,086 | `visit`                | `black/nodes.py:163`                                           |
-|  61.0% | 35.4 MiB |  21,084 | `visit_default`        | `black/nodes.py:187`                                           |
-|  61.0% | 35.4 MiB |  21,084 | `visit_default`        | `black/linegen.py:134`                                         |
-|  60.6% | 35.2 MiB |  20,713 | `visit_stmt`           | `black/linegen.py:199`                                         |
+|      % |     Size | Allocations | Function               | Location                                                       |
+| -----: | -------: | ----------: | ---------------------- | -------------------------------------------------------------- |
+| 100.0% | 58.1 MiB |      22,685 | `_run_tracker`         | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
+| 100.0% | 58.1 MiB |      22,684 | `run_module`           | `<frozen runpy>:201`                                           |
+|  90.7% | 52.6 MiB |      21,190 | `__call__`             | `/venv/lib/python3.11/site-packages/click/core.py:1567`        |
+|  90.7% | 52.6 MiB |      21,190 | `patched_main`         | `black/__init__.py:1594`                                       |
+|  90.7% | 52.6 MiB |      21,190 | `<module>`             | `black/__main__.py:1`                                          |
+|  90.7% | 52.6 MiB |      21,190 | `_run_code`            | `<frozen runpy>:65`                                            |
+|  90.7% | 52.6 MiB |      21,190 | `_run_module_code`     | `<frozen runpy>:91`                                            |
+|  90.7% | 52.6 MiB |      21,189 | `main`                 | `/venv/lib/python3.11/site-packages/click/core.py:1422`        |
+|  90.6% | 52.6 MiB |      21,170 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:1339`        |
+|  90.6% | 52.6 MiB |      21,168 | `invoke`               | `/venv/lib/python3.11/site-packages/click/core.py:853`         |
+|  90.6% | 52.6 MiB |      21,167 | `new_func`             | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
+|  90.6% | 52.6 MiB |      21,165 | `main`                 | `black/__init__.py:244`                                        |
+|  90.6% | 52.6 MiB |      21,160 | `reformat_one`         | `black/__init__.py:860`                                        |
+|  90.6% | 52.6 MiB |      21,153 | `format_file_in_place` | `black/__init__.py:917`                                        |
+|  90.6% | 52.6 MiB |      21,152 | `format_file_contents` | `black/__init__.py:1054`                                       |
+|  87.1% | 50.6 MiB |      21,146 | `_format_str_once`     | `black/__init__.py:1236`                                       |
+|  61.0% | 35.4 MiB |      21,086 | `visit`                | `black/nodes.py:163`                                           |
+|  61.0% | 35.4 MiB |      21,084 | `visit_default`        | `black/nodes.py:187`                                           |
+|  61.0% | 35.4 MiB |      21,084 | `visit_default`        | `black/linegen.py:134`                                         |
+|  60.6% | 35.2 MiB |      20,713 | `visit_stmt`           | `black/linegen.py:199`                                         |
 
 #### Categories
 
 ##### Ours
 
-|     % |     Size | Samples | Function                          | Location                 |
-| ----: | -------: | ------: | --------------------------------- | ------------------------ |
-| 90.7% | 52.6 MiB |  21,190 | `patched_main`                    | `black/__init__.py:1594` |
-| 90.7% | 52.6 MiB |  21,190 | `<module>`                        | `black/__main__.py:1`    |
-| 90.6% | 52.6 MiB |  21,165 | `main`                            | `black/__init__.py:244`  |
-| 90.6% | 52.6 MiB |  21,160 | `reformat_one`                    | `black/__init__.py:860`  |
-| 90.6% | 52.6 MiB |  21,153 | `format_file_in_place`            | `black/__init__.py:917`  |
-| 90.6% | 52.6 MiB |  21,152 | `format_file_contents`            | `black/__init__.py:1054` |
-| 87.1% | 50.6 MiB |  21,146 | `_format_str_once`                | `black/__init__.py:1236` |
-| 61.0% | 35.4 MiB |  21,086 | `visit`                           | `black/nodes.py:163`     |
-| 61.0% | 35.4 MiB |  21,084 | `visit_default`                   | `black/nodes.py:187`     |
-| 61.0% | 35.4 MiB |  21,084 | `visit_default`                   | `black/linegen.py:134`   |
-| 60.6% | 35.2 MiB |  20,713 | `visit_stmt`                      | `black/linegen.py:199`   |
-| 60.4% | 35.1 MiB |      93 | `format_str`                      | `black/__init__.py:1189` |
-| 60.0% | 34.8 MiB |  20,272 | `visit_funcdef`                   | `black/linegen.py:254`   |
-| 59.8% | 34.7 MiB |  20,146 | `visit_suite`                     | `black/linegen.py:288`   |
-| 41.0% | 23.8 MiB |  13,402 | `visit_simple_stmt`               | `black/linegen.py:295`   |
-| 36.7% | 21.3 MiB |  20,886 | `append`                          | `black/lines.py:63`      |
-| 33.1% | 19.2 MiB |  20,791 | `mark`                            | `black/brackets.py:70`   |
-| 30.2% | 17.5 MiB |  21,059 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
-| 27.4% | 15.9 MiB |  10,807 | `visit_power`                     | `black/linegen.py:341`   |
-| 26.7% | 15.5 MiB |  21,054 | `assert_stable`                   | `black/__init__.py:1557` |
+|     % |     Size | Allocations | Function                          | Location                 |
+| ----: | -------: | ----------: | --------------------------------- | ------------------------ |
+| 90.7% | 52.6 MiB |      21,190 | `patched_main`                    | `black/__init__.py:1594` |
+| 90.7% | 52.6 MiB |      21,190 | `<module>`                        | `black/__main__.py:1`    |
+| 90.6% | 52.6 MiB |      21,165 | `main`                            | `black/__init__.py:244`  |
+| 90.6% | 52.6 MiB |      21,160 | `reformat_one`                    | `black/__init__.py:860`  |
+| 90.6% | 52.6 MiB |      21,153 | `format_file_in_place`            | `black/__init__.py:917`  |
+| 90.6% | 52.6 MiB |      21,152 | `format_file_contents`            | `black/__init__.py:1054` |
+| 87.1% | 50.6 MiB |      21,146 | `_format_str_once`                | `black/__init__.py:1236` |
+| 61.0% | 35.4 MiB |      21,086 | `visit`                           | `black/nodes.py:163`     |
+| 61.0% | 35.4 MiB |      21,084 | `visit_default`                   | `black/nodes.py:187`     |
+| 61.0% | 35.4 MiB |      21,084 | `visit_default`                   | `black/linegen.py:134`   |
+| 60.6% | 35.2 MiB |      20,713 | `visit_stmt`                      | `black/linegen.py:199`   |
+| 60.4% | 35.1 MiB |          93 | `format_str`                      | `black/__init__.py:1189` |
+| 60.0% | 34.8 MiB |      20,272 | `visit_funcdef`                   | `black/linegen.py:254`   |
+| 59.8% | 34.7 MiB |      20,146 | `visit_suite`                     | `black/linegen.py:288`   |
+| 41.0% | 23.8 MiB |      13,402 | `visit_simple_stmt`               | `black/linegen.py:295`   |
+| 36.7% | 21.3 MiB |      20,886 | `append`                          | `black/lines.py:63`      |
+| 33.1% | 19.2 MiB |      20,791 | `mark`                            | `black/brackets.py:70`   |
+| 30.2% | 17.5 MiB |      21,059 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+| 27.4% | 15.9 MiB |      10,807 | `visit_power`                     | `black/linegen.py:341`   |
+| 26.7% | 15.5 MiB |      21,054 | `assert_stable`                   | `black/__init__.py:1557` |
 
 ##### Standard library
 
-|      % |     Size | Samples | Function                    | Location                                      |
-| -----: | -------: | ------: | --------------------------- | --------------------------------------------- |
-| 100.0% | 58.1 MiB |  22,684 | `run_module`                | `<frozen runpy>:201`                          |
-|  90.7% | 52.6 MiB |  21,190 | `_run_code`                 | `<frozen runpy>:65`                           |
-|  90.7% | 52.6 MiB |  21,190 | `_run_module_code`          | `<frozen runpy>:91`                           |
-|   9.3% | 5.42 MiB |   1,493 | `_get_module_details`       | `<frozen runpy>:105`                          |
-|   9.3% | 5.42 MiB |   1,486 | `_find_and_load`            | `<frozen importlib._bootstrap>:1167`          |
-|   9.3% | 5.42 MiB |   1,484 | `_find_and_load_unlocked`   | `<frozen importlib._bootstrap>:1122`          |
-|   9.3% | 5.42 MiB |   1,483 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`           |
-|   9.3% | 5.41 MiB |   1,481 | `exec_module`               | `<frozen importlib._bootstrap_external>:934`  |
-|   9.3% |  5.4 MiB |   1,469 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
-|   4.6% | 2.69 MiB |     802 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
-|   3.9% | 2.27 MiB |     352 | `source_to_code`            | `<frozen importlib._bootstrap_external>:999`  |
-|   3.5% | 2.01 MiB |       3 | `parse`                     | `/usr/lib/python3.11/ast.py:33`               |
-|   0.6% |  333 KiB |     341 | `_handle_fromlist`          | `<frozen importlib._bootstrap>:1209`          |
-|   0.5% |  311 KiB |     341 | `_compile_bytecode`         | `<frozen importlib._bootstrap_external>:727`  |
-|   0.2% |  112 KiB |     108 | `_code_to_timestamp_pyc`    | `<frozen importlib._bootstrap_external>:740`  |
-|   0.1% | 75.7 KiB |      79 | `__new__`                   | `<frozen abc>:105`                            |
-|   0.1% | 47.8 KiB |      25 | `compile`                   | `/usr/lib/python3.11/re/__init__.py:225`      |
-|   0.1% | 47.1 KiB |      24 | `_compile`                  | `/usr/lib/python3.11/re/__init__.py:272`      |
-|   0.1% | 46.5 KiB |      23 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`     |
-|   0.1% |   35 KiB |      32 | `<module>`                  | `/usr/lib/python3.11/tomllib/__init__.py:1`   |
+|      % |     Size | Allocations | Function                    | Location                                      |
+| -----: | -------: | ----------: | --------------------------- | --------------------------------------------- |
+| 100.0% | 58.1 MiB |      22,684 | `run_module`                | `<frozen runpy>:201`                          |
+|  90.7% | 52.6 MiB |      21,190 | `_run_code`                 | `<frozen runpy>:65`                           |
+|  90.7% | 52.6 MiB |      21,190 | `_run_module_code`          | `<frozen runpy>:91`                           |
+|   9.3% | 5.42 MiB |       1,493 | `_get_module_details`       | `<frozen runpy>:105`                          |
+|   9.3% | 5.42 MiB |       1,486 | `_find_and_load`            | `<frozen importlib._bootstrap>:1167`          |
+|   9.3% | 5.42 MiB |       1,484 | `_find_and_load_unlocked`   | `<frozen importlib._bootstrap>:1122`          |
+|   9.3% | 5.42 MiB |       1,483 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`           |
+|   9.3% | 5.41 MiB |       1,481 | `exec_module`               | `<frozen importlib._bootstrap_external>:934`  |
+|   9.3% |  5.4 MiB |       1,469 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
+|   4.6% | 2.69 MiB |         802 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
+|   3.9% | 2.27 MiB |         352 | `source_to_code`            | `<frozen importlib._bootstrap_external>:999`  |
+|   3.5% | 2.01 MiB |           3 | `parse`                     | `/usr/lib/python3.11/ast.py:33`               |
+|   0.6% |  333 KiB |         341 | `_handle_fromlist`          | `<frozen importlib._bootstrap>:1209`          |
+|   0.5% |  311 KiB |         341 | `_compile_bytecode`         | `<frozen importlib._bootstrap_external>:727`  |
+|   0.2% |  112 KiB |         108 | `_code_to_timestamp_pyc`    | `<frozen importlib._bootstrap_external>:740`  |
+|   0.1% | 75.7 KiB |          79 | `__new__`                   | `<frozen abc>:105`                            |
+|   0.1% | 47.8 KiB |          25 | `compile`                   | `/usr/lib/python3.11/re/__init__.py:225`      |
+|   0.1% | 47.1 KiB |          24 | `_compile`                  | `/usr/lib/python3.11/re/__init__.py:272`      |
+|   0.1% | 46.5 KiB |          23 | `compile`                   | `/usr/lib/python3.11/re/_compiler.py:738`     |
+|   0.1% |   35 KiB |          32 | `<module>`                  | `/usr/lib/python3.11/tomllib/__init__.py:1`   |
 
 ##### Third-party
 
-|      % |     Size | Samples | Function       | Location                                                                         |
-| -----: | -------: | ------: | -------------- | -------------------------------------------------------------------------------- |
-| 100.0% | 58.1 MiB |  22,685 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40`                   |
-|  90.7% | 52.6 MiB |  21,190 | `__call__`     | `/venv/lib/python3.11/site-packages/click/core.py:1567`                          |
-|  90.7% | 52.6 MiB |  21,189 | `main`         | `/venv/lib/python3.11/site-packages/click/core.py:1422`                          |
-|  90.6% | 52.6 MiB |  21,170 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339`                          |
-|  90.6% | 52.6 MiB |  21,168 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:853`                           |
-|  90.6% | 52.6 MiB |  21,167 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                      |
-|   2.3% | 1.31 MiB |     304 | `<module>`     | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                         |
-|   2.1% | 1.23 MiB |     233 | `<module>`     | `/venv/lib/python3.11/site-packages/click/core.py:1`                             |
-|   1.8% | 1.02 MiB |      24 | `<module>`     | `/venv/lib/python3.11/site-packages/click/formatting.py:1`                       |
-|   1.7% | 1.01 MiB |      11 | `<module>`     | `/venv/lib/python3.11/site-packages/click/parser.py:1`                           |
-|   0.2% |  137 KiB |     140 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`                   |
-|   0.2% |  125 KiB |     127 | `<module>`     | `/venv/lib/python3.11/site-packages/click/types.py:1`                            |
-|   0.2% | 93.8 KiB |     119 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`                      |
-|   0.2% | 91.5 KiB |     115 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`                     |
-|   0.1% | 65.5 KiB |      84 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`                 |
-|   0.1% | 63.6 KiB |      71 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                        |
-|   0.1% | 47.3 KiB |      33 | `decorator`    | `/venv/lib/python3.11/site-packages/click/decorators.py:373`                     |
-|   0.1% | 46.9 KiB |      59 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1` |
-|   0.1% | 45.5 KiB |      32 | `__init__`     | `/venv/lib/python3.11/site-packages/click/core.py:2883`                          |
-|   0.1% | 40.8 KiB |      42 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                      |
+|      % |     Size | Allocations | Function       | Location                                                                         |
+| -----: | -------: | ----------: | -------------- | -------------------------------------------------------------------------------- |
+| 100.0% | 58.1 MiB |      22,685 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40`                   |
+|  90.7% | 52.6 MiB |      21,190 | `__call__`     | `/venv/lib/python3.11/site-packages/click/core.py:1567`                          |
+|  90.7% | 52.6 MiB |      21,189 | `main`         | `/venv/lib/python3.11/site-packages/click/core.py:1422`                          |
+|  90.6% | 52.6 MiB |      21,170 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339`                          |
+|  90.6% | 52.6 MiB |      21,168 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:853`                           |
+|  90.6% | 52.6 MiB |      21,167 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`                      |
+|   2.3% | 1.31 MiB |         304 | `<module>`     | `/venv/lib/python3.11/site-packages/click/__init__.py:1`                         |
+|   2.1% | 1.23 MiB |         233 | `<module>`     | `/venv/lib/python3.11/site-packages/click/core.py:1`                             |
+|   1.8% | 1.02 MiB |          24 | `<module>`     | `/venv/lib/python3.11/site-packages/click/formatting.py:1`                       |
+|   1.7% | 1.01 MiB |          11 | `<module>`     | `/venv/lib/python3.11/site-packages/click/parser.py:1`                           |
+|   0.2% |  137 KiB |         140 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`                   |
+|   0.2% |  125 KiB |         127 | `<module>`     | `/venv/lib/python3.11/site-packages/click/types.py:1`                            |
+|   0.2% | 93.8 KiB |         119 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`                      |
+|   0.2% | 91.5 KiB |         115 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`                     |
+|   0.1% | 65.5 KiB |          84 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`                 |
+|   0.1% | 63.6 KiB |          71 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/utils.py:1`                        |
+|   0.1% | 47.3 KiB |          33 | `decorator`    | `/venv/lib/python3.11/site-packages/click/decorators.py:373`                     |
+|   0.1% | 46.9 KiB |          59 | `<module>`     | `/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1` |
+|   0.1% | 45.5 KiB |          32 | `__init__`     | `/venv/lib/python3.11/site-packages/click/core.py:2883`                          |
+|   0.1% | 40.8 KiB |          42 | `<module>`     | `/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`                      |
 
 #### Callees
 
@@ -2503,376 +2503,376 @@ Callees ranked by contribution to each function's total size. Inlining can make 
 
 ##### `_run_tracker` (`/venv/lib/python3.11/site-packages/memray/commands/run.py:40`)
 
-|      % |     Size | Samples | Callee       | Location             |
-| -----: | -------: | ------: | ------------ | -------------------- |
-| 100.0% | 58.1 MiB |  22,684 | `run_module` | `<frozen runpy>:201` |
+|      % |     Size | Allocations | Callee       | Location             |
+| -----: | -------: | ----------: | ------------ | -------------------- |
+| 100.0% | 58.1 MiB |      22,684 | `run_module` | `<frozen runpy>:201` |
 
 ##### `run_module` (`<frozen runpy>:201`)
 
-|     % |     Size | Samples | Callee                | Location             |
-| ----: | -------: | ------: | --------------------- | -------------------- |
-| 90.7% | 52.6 MiB |  21,190 | `_run_module_code`    | `<frozen runpy>:91`  |
-|  9.3% | 5.42 MiB |   1,493 | `_get_module_details` | `<frozen runpy>:105` |
+|     % |     Size | Allocations | Callee                | Location             |
+| ----: | -------: | ----------: | --------------------- | -------------------- |
+| 90.7% | 52.6 MiB |      21,190 | `_run_module_code`    | `<frozen runpy>:91`  |
+|  9.3% | 5.42 MiB |       1,493 | `_get_module_details` | `<frozen runpy>:105` |
 
 ##### `__call__` (`/venv/lib/python3.11/site-packages/click/core.py:1567`)
 
-|      % |     Size | Samples | Callee | Location                                                |
-| -----: | -------: | ------: | ------ | ------------------------------------------------------- |
-| 100.0% | 52.6 MiB |  21,189 | `main` | `/venv/lib/python3.11/site-packages/click/core.py:1422` |
+|      % |     Size | Allocations | Callee | Location                                                |
+| -----: | -------: | ----------: | ------ | ------------------------------------------------------- |
+| 100.0% | 52.6 MiB |      21,189 | `main` | `/venv/lib/python3.11/site-packages/click/core.py:1422` |
 
 ##### `patched_main` (`black/__init__.py:1594`)
 
-|      % |     Size | Samples | Callee     | Location                                                |
-| -----: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 100.0% | 52.6 MiB |  21,190 | `__call__` | `/venv/lib/python3.11/site-packages/click/core.py:1567` |
+|      % |     Size | Allocations | Callee     | Location                                                |
+| -----: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 100.0% | 52.6 MiB |      21,190 | `__call__` | `/venv/lib/python3.11/site-packages/click/core.py:1567` |
 
 ##### `<module>` (`black/__main__.py:1`)
 
-|      % |     Size | Samples | Callee         | Location                 |
-| -----: | -------: | ------: | -------------- | ------------------------ |
-| 100.0% | 52.6 MiB |  21,190 | `patched_main` | `black/__init__.py:1594` |
+|      % |     Size | Allocations | Callee         | Location                 |
+| -----: | -------: | ----------: | -------------- | ------------------------ |
+| 100.0% | 52.6 MiB |      21,190 | `patched_main` | `black/__init__.py:1594` |
 
 ##### `_run_code` (`<frozen runpy>:65`)
 
-|      % |     Size | Samples | Callee     | Location              |
-| -----: | -------: | ------: | ---------- | --------------------- |
-| 100.0% | 52.6 MiB |  21,190 | `<module>` | `black/__main__.py:1` |
+|      % |     Size | Allocations | Callee     | Location              |
+| -----: | -------: | ----------: | ---------- | --------------------- |
+| 100.0% | 52.6 MiB |      21,190 | `<module>` | `black/__main__.py:1` |
 
 ##### `_run_module_code` (`<frozen runpy>:91`)
 
-|      % |     Size | Samples | Callee      | Location            |
-| -----: | -------: | ------: | ----------- | ------------------- |
-| 100.0% | 52.6 MiB |  21,190 | `_run_code` | `<frozen runpy>:65` |
+|      % |     Size | Allocations | Callee      | Location            |
+| -----: | -------: | ----------: | ----------- | ------------------- |
+| 100.0% | 52.6 MiB |      21,190 | `_run_code` | `<frozen runpy>:65` |
 
 ##### `main` (`/venv/lib/python3.11/site-packages/click/core.py:1422`)
 
-|      % |     Size | Samples | Callee         | Location                                                |
-| -----: | -------: | ------: | -------------- | ------------------------------------------------------- |
-| 100.0% | 52.6 MiB |  21,170 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339` |
-|  <0.1% | 13.6 KiB |      16 | `make_context` | `/venv/lib/python3.11/site-packages/click/core.py:1266` |
-|  <0.1% |    529 B |       2 | `__exit__`     | `/venv/lib/python3.11/site-packages/click/core.py:550`  |
+|      % |     Size | Allocations | Callee         | Location                                                |
+| -----: | -------: | ----------: | -------------- | ------------------------------------------------------- |
+| 100.0% | 52.6 MiB |      21,170 | `invoke`       | `/venv/lib/python3.11/site-packages/click/core.py:1339` |
+|  <0.1% | 13.6 KiB |          16 | `make_context` | `/venv/lib/python3.11/site-packages/click/core.py:1266` |
+|  <0.1% |    529 B |           2 | `__exit__`     | `/venv/lib/python3.11/site-packages/click/core.py:550`  |
 
 ##### `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:1339`)
 
-|      % |     Size | Samples | Callee   | Location                                               |
-| -----: | -------: | ------: | -------- | ------------------------------------------------------ |
-| 100.0% | 52.6 MiB |  21,168 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
+|      % |     Size | Allocations | Callee   | Location                                               |
+| -----: | -------: | ----------: | -------- | ------------------------------------------------------ |
+| 100.0% | 52.6 MiB |      21,168 | `invoke` | `/venv/lib/python3.11/site-packages/click/core.py:853` |
 
 ##### `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`)
 
-|      % |     Size | Samples | Callee     | Location                                                    |
-| -----: | -------: | ------: | ---------- | ----------------------------------------------------------- |
-| 100.0% | 52.6 MiB |  21,167 | `new_func` | `/venv/lib/python3.11/site-packages/click/decorators.py:33` |
+|      % |     Size | Allocations | Callee     | Location                                                    |
+| -----: | -------: | ----------: | ---------- | ----------------------------------------------------------- |
+| 100.0% | 52.6 MiB |      21,167 | `new_func` | `/venv/lib/python3.11/site-packages/click/decorators.py:33` |
 
 ##### `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`)
 
-|      % |     Size | Samples | Callee | Location                |
-| -----: | -------: | ------: | ------ | ----------------------- |
-| 100.0% | 52.6 MiB |  21,165 | `main` | `black/__init__.py:244` |
+|      % |     Size | Allocations | Callee | Location                |
+| -----: | -------: | ----------: | ------ | ----------------------- |
+| 100.0% | 52.6 MiB |      21,165 | `main` | `black/__init__.py:244` |
 
 ##### `main` (`black/__init__.py:244`)
 
-|      % |     Size | Samples | Callee         | Location                |
-| -----: | -------: | ------: | -------------- | ----------------------- |
-| 100.0% | 52.6 MiB |  21,160 | `reformat_one` | `black/__init__.py:860` |
-|  <0.1% | 2.06 KiB |       2 | `get_sources`  | `black/__init__.py:724` |
+|      % |     Size | Allocations | Callee         | Location                |
+| -----: | -------: | ----------: | -------------- | ----------------------- |
+| 100.0% | 52.6 MiB |      21,160 | `reformat_one` | `black/__init__.py:860` |
+|  <0.1% | 2.06 KiB |           2 | `get_sources`  | `black/__init__.py:724` |
 
 ##### `reformat_one` (`black/__init__.py:860`)
 
-|      % |     Size | Samples | Callee                 | Location                |
-| -----: | -------: | ------: | ---------------------- | ----------------------- |
-| 100.0% | 52.6 MiB |  21,153 | `format_file_in_place` | `black/__init__.py:917` |
-|  <0.1% | 1.92 KiB |       2 | `done`                 | `black/report.py:36`    |
-|  <0.1% | 1.13 KiB |       1 | `read`                 | `black/cache.py:60`     |
-|  <0.1% |     72 B |       2 | `write`                | `black/cache.py:132`    |
+|      % |     Size | Allocations | Callee                 | Location                |
+| -----: | -------: | ----------: | ---------------------- | ----------------------- |
+| 100.0% | 52.6 MiB |      21,153 | `format_file_in_place` | `black/__init__.py:917` |
+|  <0.1% | 1.92 KiB |           2 | `done`                 | `black/report.py:36`    |
+|  <0.1% | 1.13 KiB |           1 | `read`                 | `black/cache.py:60`     |
+|  <0.1% |     72 B |           2 | `write`                | `black/cache.py:132`    |
 
 ##### `format_file_in_place` (`black/__init__.py:917`)
 
-|      % |     Size | Samples | Callee                 | Location                 |
-| -----: | -------: | ------: | ---------------------- | ------------------------ |
-| 100.0% | 52.6 MiB |  21,152 | `format_file_contents` | `black/__init__.py:1054` |
-|  <0.1% |    552 B |       1 | `decode_bytes`         | `black/__init__.py:1290` |
+|      % |     Size | Allocations | Callee                 | Location                 |
+| -----: | -------: | ----------: | ---------------------- | ------------------------ |
+| 100.0% | 52.6 MiB |      21,152 | `format_file_contents` | `black/__init__.py:1054` |
+|  <0.1% |    552 B |           1 | `decode_bytes`         | `black/__init__.py:1290` |
 
 ##### `format_file_contents` (`black/__init__.py:1054`)
 
-|     % |     Size | Samples | Callee                            | Location                 |
-| ----: | -------: | ------: | --------------------------------- | ------------------------ |
-| 66.7% | 35.1 MiB |      93 | `format_str`                      | `black/__init__.py:1189` |
-| 33.3% | 17.5 MiB |  21,059 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
+|     % |     Size | Allocations | Callee                            | Location                 |
+| ----: | -------: | ----------: | --------------------------------- | ------------------------ |
+| 66.7% | 35.1 MiB |          93 | `format_str`                      | `black/__init__.py:1189` |
+| 33.3% | 17.5 MiB |      21,059 | `check_stability_and_equivalence` | `black/__init__.py:1037` |
 
 ##### `_format_str_once` (`black/__init__.py:1236`)
 
-|     % |     Size | Samples | Callee              | Location                |
-| ----: | -------: | ------: | ------------------- | ----------------------- |
-| 70.0% | 35.4 MiB |  21,086 | `visit`             | `black/nodes.py:163`    |
-| 21.8% |   11 MiB |      30 | `lib2to3_parse`     | `black/parsing.py:55`   |
-|  6.1% | 3.08 MiB |      18 | `transform_line`    | `black/linegen.py:601`  |
-|  2.0% |    1 MiB |       3 | `maybe_empty_lines` | `black/lines.py:560`    |
-| <0.1% | 19.9 KiB |       3 | `normalize_fmt_off` | `black/comments.py:168` |
+|     % |     Size | Allocations | Callee              | Location                |
+| ----: | -------: | ----------: | ------------------- | ----------------------- |
+| 70.0% | 35.4 MiB |      21,086 | `visit`             | `black/nodes.py:163`    |
+| 21.8% |   11 MiB |          30 | `lib2to3_parse`     | `black/parsing.py:55`   |
+|  6.1% | 3.08 MiB |          18 | `transform_line`    | `black/linegen.py:601`  |
+|  2.0% |    1 MiB |           3 | `maybe_empty_lines` | `black/lines.py:560`    |
+| <0.1% | 19.9 KiB |           3 | `normalize_fmt_off` | `black/comments.py:168` |
 
 ##### `visit` (`black/nodes.py:163`)
 
-|      % |     Size | Samples | Callee              | Location               |
-| -----: | -------: | ------: | ------------------- | ---------------------- |
-| 100.0% | 35.4 MiB |  21,084 | `visit_default`     | `black/linegen.py:134` |
-|  99.2% | 35.2 MiB |  20,713 | `visit_stmt`        | `black/linegen.py:199` |
-|  98.2% | 34.8 MiB |  20,272 | `visit_funcdef`     | `black/linegen.py:254` |
-|  98.0% | 34.7 MiB |  20,146 | `visit_suite`       | `black/linegen.py:288` |
-|  67.2% | 23.8 MiB |  13,402 | `visit_simple_stmt` | `black/linegen.py:295` |
+|      % |     Size | Allocations | Callee              | Location               |
+| -----: | -------: | ----------: | ------------------- | ---------------------- |
+| 100.0% | 35.4 MiB |      21,084 | `visit_default`     | `black/linegen.py:134` |
+|  99.2% | 35.2 MiB |      20,713 | `visit_stmt`        | `black/linegen.py:199` |
+|  98.2% | 34.8 MiB |      20,272 | `visit_funcdef`     | `black/linegen.py:254` |
+|  98.0% | 34.7 MiB |      20,146 | `visit_suite`       | `black/linegen.py:288` |
+|  67.2% | 23.8 MiB |      13,402 | `visit_simple_stmt` | `black/linegen.py:295` |
 
 ##### `visit_default` (`black/nodes.py:187`)
 
-|      % |     Size | Samples | Callee  | Location             |
-| -----: | -------: | ------: | ------- | -------------------- |
-| 100.0% | 35.4 MiB |  21,084 | `visit` | `black/nodes.py:163` |
+|      % |     Size | Allocations | Callee  | Location             |
+| -----: | -------: | ----------: | ------- | -------------------- |
+| 100.0% | 35.4 MiB |      21,084 | `visit` | `black/nodes.py:163` |
 
 ##### `visit_default` (`black/linegen.py:134`)
 
-|      % |     Size | Samples | Callee              | Location               |
-| -----: | -------: | ------: | ------------------- | ---------------------- |
-| 100.0% | 35.4 MiB |  21,084 | `visit_default`     | `black/nodes.py:187`   |
-|  60.1% | 21.3 MiB |  20,886 | `append`            | `black/lines.py:63`    |
-|  16.9% |    6 MiB |       6 | `generate_comments` | `black/comments.py:52` |
+|      % |     Size | Allocations | Callee              | Location               |
+| -----: | -------: | ----------: | ------------------- | ---------------------- |
+| 100.0% | 35.4 MiB |      21,084 | `visit_default`     | `black/nodes.py:187`   |
+|  60.1% | 21.3 MiB |      20,886 | `append`            | `black/lines.py:63`    |
+|  16.9% |    6 MiB |           6 | `generate_comments` | `black/comments.py:52` |
 
 ##### `visit_stmt` (`black/linegen.py:199`)
 
-|      % |     Size | Samples | Callee                       | Location                |
-| -----: | -------: | ------: | ---------------------------- | ----------------------- |
-| 100.0% | 35.2 MiB |  20,711 | `visit`                      | `black/nodes.py:163`    |
-|  11.4% |    4 MiB |       5 | `normalize_invisible_parens` | `black/linegen.py:1328` |
+|      % |     Size | Allocations | Callee                       | Location                |
+| -----: | -------: | ----------: | ---------------------------- | ----------------------- |
+| 100.0% | 35.2 MiB |      20,711 | `visit`                      | `black/nodes.py:163`    |
+|  11.4% |    4 MiB |           5 | `normalize_invisible_parens` | `black/linegen.py:1328` |
 
 ##### `format_str` (`black/__init__.py:1189`)
 
-|      % |     Size | Samples | Callee             | Location                 |
-| -----: | -------: | ------: | ------------------ | ------------------------ |
-| 100.0% | 35.1 MiB |      92 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |     Size | Allocations | Callee             | Location                 |
+| -----: | -------: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 35.1 MiB |          92 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `visit_funcdef` (`black/linegen.py:254`)
 
-|      % |     Size | Samples | Callee  | Location             |
-| -----: | -------: | ------: | ------- | -------------------- |
-| 100.0% | 34.8 MiB |  20,272 | `visit` | `black/nodes.py:163` |
+|      % |     Size | Allocations | Callee  | Location             |
+| -----: | -------: | ----------: | ------- | -------------------- |
+| 100.0% | 34.8 MiB |      20,272 | `visit` | `black/nodes.py:163` |
 
 ##### `visit_suite` (`black/linegen.py:288`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 34.7 MiB |  20,146 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 34.7 MiB |      20,146 | `visit_default` | `black/linegen.py:134` |
 
 ##### `visit_simple_stmt` (`black/linegen.py:295`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 23.8 MiB |  13,402 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 23.8 MiB |      13,402 | `visit_default` | `black/linegen.py:134` |
 
 ##### `append` (`black/lines.py:63`)
 
-|     % |     Size | Samples | Callee       | Location               |
-| ----: | -------: | ------: | ------------ | ---------------------- |
-| 85.6% | 18.2 MiB |  20,790 | `mark`       | `black/brackets.py:70` |
-| 14.3% | 3.05 MiB |      92 | `whitespace` | `black/nodes.py:194`   |
+|     % |     Size | Allocations | Callee       | Location               |
+| ----: | -------: | ----------: | ------------ | ---------------------- |
+| 85.6% | 18.2 MiB |      20,790 | `mark`       | `black/brackets.py:70` |
+| 14.3% | 3.05 MiB |          92 | `whitespace` | `black/nodes.py:194`   |
 
 ##### `check_stability_and_equivalence` (`black/__init__.py:1037`)
 
-|     % |     Size | Samples | Callee              | Location                 |
-| ----: | -------: | ------: | ------------------- | ------------------------ |
-| 88.6% | 15.5 MiB |  21,054 | `assert_stable`     | `black/__init__.py:1557` |
-| 11.4% | 2.01 MiB |       4 | `assert_equivalent` | `black/__init__.py:1524` |
+|     % |     Size | Allocations | Callee              | Location                 |
+| ----: | -------: | ----------: | ------------------- | ------------------------ |
+| 88.6% | 15.5 MiB |      21,054 | `assert_stable`     | `black/__init__.py:1557` |
+| 11.4% | 2.01 MiB |           4 | `assert_equivalent` | `black/__init__.py:1524` |
 
 ##### `visit_power` (`black/linegen.py:341`)
 
-|      % |     Size | Samples | Callee          | Location               |
-| -----: | -------: | ------: | --------------- | ---------------------- |
-| 100.0% | 15.9 MiB |  10,806 | `visit_default` | `black/linegen.py:134` |
+|      % |     Size | Allocations | Callee          | Location               |
+| -----: | -------: | ----------: | --------------- | ---------------------- |
+| 100.0% | 15.9 MiB |      10,806 | `visit_default` | `black/linegen.py:134` |
 
 ##### `assert_stable` (`black/__init__.py:1557`)
 
-|      % |     Size | Samples | Callee             | Location                 |
-| -----: | -------: | ------: | ------------------ | ------------------------ |
-| 100.0% | 15.5 MiB |  21,054 | `_format_str_once` | `black/__init__.py:1236` |
+|      % |     Size | Allocations | Callee             | Location                 |
+| -----: | -------: | ----------: | ------------------ | ------------------------ |
+| 100.0% | 15.5 MiB |      21,054 | `_format_str_once` | `black/__init__.py:1236` |
 
 ##### `_get_module_details` (`<frozen runpy>:105`)
 
-|     % |     Size | Samples | Callee                | Location                             |
-| ----: | -------: | ------: | --------------------- | ------------------------------------ |
-| 99.9% | 5.42 MiB |   1,486 | `_find_and_load`      | `<frozen importlib._bootstrap>:1167` |
-| 99.9% | 5.42 MiB |   1,486 | `_get_module_details` | `<frozen runpy>:105`                 |
-|  0.1% | 5.66 KiB |       6 | `find_spec`           | `<frozen importlib.util>:73`         |
+|     % |     Size | Allocations | Callee                | Location                             |
+| ----: | -------: | ----------: | --------------------- | ------------------------------------ |
+| 99.9% | 5.42 MiB |       1,486 | `_find_and_load`      | `<frozen importlib._bootstrap>:1167` |
+| 99.9% | 5.42 MiB |       1,486 | `_get_module_details` | `<frozen runpy>:105`                 |
+|  0.1% | 5.66 KiB |           6 | `find_spec`           | `<frozen importlib.util>:73`         |
 
 ##### `_find_and_load` (`<frozen importlib._bootstrap>:1167`)
 
-|      % |     Size | Samples | Callee                    | Location                             |
-| -----: | -------: | ------: | ------------------------- | ------------------------------------ |
-| 100.0% | 5.42 MiB |   1,484 | `_find_and_load_unlocked` | `<frozen importlib._bootstrap>:1122` |
-|  <0.1% |    560 B |       1 | `__enter__`               | `<frozen importlib._bootstrap>:169`  |
+|      % |     Size | Allocations | Callee                    | Location                             |
+| -----: | -------: | ----------: | ------------------------- | ------------------------------------ |
+| 100.0% | 5.42 MiB |       1,484 | `_find_and_load_unlocked` | `<frozen importlib._bootstrap>:1122` |
+|  <0.1% |    560 B |           1 | `__enter__`               | `<frozen importlib._bootstrap>:169`  |
 
 ##### `_find_and_load_unlocked` (`<frozen importlib._bootstrap>:1122`)
 
-|      % |     Size | Samples | Callee                      | Location                             |
-| -----: | -------: | ------: | --------------------------- | ------------------------------------ |
-| 100.0% | 5.42 MiB |   1,483 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`  |
-|   0.7% | 37.2 KiB |      47 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`  |
-|   0.1% | 7.48 KiB |       4 | `_find_spec`                | `<frozen importlib._bootstrap>:1056` |
+|      % |     Size | Allocations | Callee                      | Location                             |
+| -----: | -------: | ----------: | --------------------------- | ------------------------------------ |
+| 100.0% | 5.42 MiB |       1,483 | `_load_unlocked`            | `<frozen importlib._bootstrap>:666`  |
+|   0.7% | 37.2 KiB |          47 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`  |
+|   0.1% | 7.48 KiB |           4 | `_find_spec`                | `<frozen importlib._bootstrap>:1056` |
 
 ##### `_load_unlocked` (`<frozen importlib._bootstrap>:666`)
 
-|      % |     Size | Samples | Callee             | Location                                     |
-| -----: | -------: | ------: | ------------------ | -------------------------------------------- |
-| 100.0% | 5.41 MiB |   1,481 | `exec_module`      | `<frozen importlib._bootstrap_external>:934` |
-|  <0.1% | 1.83 KiB |       2 | `module_from_spec` | `<frozen importlib._bootstrap>:566`          |
+|      % |     Size | Allocations | Callee             | Location                                     |
+| -----: | -------: | ----------: | ------------------ | -------------------------------------------- |
+| 100.0% | 5.41 MiB |       1,481 | `exec_module`      | `<frozen importlib._bootstrap_external>:934` |
+|  <0.1% | 1.83 KiB |           2 | `module_from_spec` | `<frozen importlib._bootstrap>:566`          |
 
 ##### `exec_module` (`<frozen importlib._bootstrap_external>:934`)
 
-|     % |     Size | Samples | Callee                      | Location                                      |
-| ----: | -------: | ------: | --------------------------- | --------------------------------------------- |
-| 99.1% | 5.37 MiB |   1,435 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
-| 49.6% | 2.69 MiB |     802 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
+|     % |     Size | Allocations | Callee                      | Location                                      |
+| ----: | -------: | ----------: | --------------------------- | --------------------------------------------- |
+| 99.1% | 5.37 MiB |       1,435 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233`           |
+| 49.6% | 2.69 MiB |         802 | `get_code`                  | `<frozen importlib._bootstrap_external>:1007` |
 
 ##### `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`)
 
-|     % |     Size | Samples | Callee     | Location                                                 |
-| ----: | -------: | ------: | ---------- | -------------------------------------------------------- |
-| 99.4% | 5.37 MiB |   1,435 | `<module>` | `black/__init__.py:1`                                    |
-| 43.3% | 2.34 MiB |     316 | `<module>` | `black/comments.py:1`                                    |
-| 24.4% | 1.32 MiB |     295 | `<module>` | `black/nodes.py:1`                                       |
-| 24.2% | 1.31 MiB |     304 | `<module>` | `/venv/lib/python3.11/site-packages/click/__init__.py:1` |
-| 22.8% | 1.23 MiB |     233 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`     |
+|     % |     Size | Allocations | Callee     | Location                                                 |
+| ----: | -------: | ----------: | ---------- | -------------------------------------------------------- |
+| 99.4% | 5.37 MiB |       1,435 | `<module>` | `black/__init__.py:1`                                    |
+| 43.3% | 2.34 MiB |         316 | `<module>` | `black/comments.py:1`                                    |
+| 24.4% | 1.32 MiB |         295 | `<module>` | `black/nodes.py:1`                                       |
+| 24.2% | 1.31 MiB |         304 | `<module>` | `/venv/lib/python3.11/site-packages/click/__init__.py:1` |
+| 22.8% | 1.23 MiB |         233 | `<module>` | `/venv/lib/python3.11/site-packages/click/core.py:1`     |
 
 ##### `get_code` (`<frozen importlib._bootstrap_external>:1007`)
 
-|     % |     Size | Samples | Callee                   | Location                                      |
-| ----: | -------: | ------: | ------------------------ | --------------------------------------------- |
-| 84.6% | 2.27 MiB |     352 | `source_to_code`         | `<frozen importlib._bootstrap_external>:999`  |
-| 11.3% |  311 KiB |     341 | `_compile_bytecode`      | `<frozen importlib._bootstrap_external>:727`  |
-|  4.1% |  112 KiB |     108 | `_code_to_timestamp_pyc` | `<frozen importlib._bootstrap_external>:740`  |
-| <0.1% |    624 B |       1 | `_cache_bytecode`        | `<frozen importlib._bootstrap_external>:1151` |
+|     % |     Size | Allocations | Callee                   | Location                                      |
+| ----: | -------: | ----------: | ------------------------ | --------------------------------------------- |
+| 84.6% | 2.27 MiB |         352 | `source_to_code`         | `<frozen importlib._bootstrap_external>:999`  |
+| 11.3% |  311 KiB |         341 | `_compile_bytecode`      | `<frozen importlib._bootstrap_external>:727`  |
+|  4.1% |  112 KiB |         108 | `_code_to_timestamp_pyc` | `<frozen importlib._bootstrap_external>:740`  |
+| <0.1% |    624 B |           1 | `_cache_bytecode`        | `<frozen importlib._bootstrap_external>:1151` |
 
 ##### `source_to_code` (`<frozen importlib._bootstrap_external>:999`)
 
-|      % |     Size | Samples | Callee                      | Location                            |
-| -----: | -------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 2.27 MiB |     352 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |     Size | Allocations | Callee                      | Location                            |
+| -----: | -------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 2.27 MiB |         352 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`)
 
-|     % |    Size | Samples | Callee           | Location                             |
-| ----: | ------: | ------: | ---------------- | ------------------------------------ |
-| 99.8% | 1.3 MiB |     303 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |    Size | Allocations | Callee           | Location                             |
+| ----: | ------: | ----------: | ---------------- | ------------------------------------ |
+| 99.8% | 1.3 MiB |         303 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`)
 
-|     % |     Size | Samples | Callee             | Location                                               |
-| ----: | -------: | ------: | ------------------ | ------------------------------------------------------ |
-| 85.5% | 1.05 MiB |      53 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167`                   |
-| 11.1% |  140 KiB |     145 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209`                   |
-|  1.1% | 13.9 KiB |       9 | `__new__`          | `<frozen abc>:105`                                     |
-|  0.2% | 2.49 KiB |       3 | `__new__`          | `/usr/lib/python3.11/enum.py:488`                      |
-|  0.1% |    768 B |       1 | `Context`          | `/venv/lib/python3.11/site-packages/click/core.py:204` |
+|     % |     Size | Allocations | Callee             | Location                                               |
+| ----: | -------: | ----------: | ------------------ | ------------------------------------------------------ |
+| 85.5% | 1.05 MiB |          53 | `_find_and_load`   | `<frozen importlib._bootstrap>:1167`                   |
+| 11.1% |  140 KiB |         145 | `_handle_fromlist` | `<frozen importlib._bootstrap>:1209`                   |
+|  1.1% | 13.9 KiB |           9 | `__new__`          | `<frozen abc>:105`                                     |
+|  0.2% | 2.49 KiB |           3 | `__new__`          | `/usr/lib/python3.11/enum.py:488`                      |
+|  0.1% |    768 B |           1 | `Context`          | `/venv/lib/python3.11/site-packages/click/core.py:204` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 99.8% | 1.02 MiB |      22 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 99.8% | 1.02 MiB |          22 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `_handle_fromlist` (`<frozen importlib._bootstrap>:1209`)
 
-|      % |    Size | Samples | Callee                      | Location                            |
-| -----: | ------: | ------: | --------------------------- | ----------------------------------- |
-| 100.0% | 333 KiB |     341 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
+|      % |    Size | Allocations | Callee                      | Location                            |
+| -----: | ------: | ----------: | --------------------------- | ----------------------------------- |
+| 100.0% | 333 KiB |         341 | `_call_with_frames_removed` | `<frozen importlib._bootstrap>:233` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/specifiers.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                                                         |
-| ----: | -------: | ------: | ---------------- | ---------------------------------------------------------------- |
-| 87.6% |  120 KiB |     129 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                             |
-|  6.2% |  8.5 KiB |       2 | `Specifier`      | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220` |
-|  4.4% | 6.07 KiB |       7 | `__new__`        | `<frozen abc>:105`                                               |
+|     % |     Size | Allocations | Callee           | Location                                                         |
+| ----: | -------: | ----------: | ---------------- | ---------------------------------------------------------------- |
+| 87.6% |  120 KiB |         129 | `_find_and_load` | `<frozen importlib._bootstrap>:1167`                             |
+|  6.2% |  8.5 KiB |           2 | `Specifier`      | `/venv/lib/python3.11/site-packages/packaging/specifiers.py:220` |
+|  4.4% | 6.07 KiB |           7 | `__new__`        | `<frozen abc>:105`                                               |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/click/types.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 53.0% | 66.2 KiB |      58 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
-| 30.6% | 38.2 KiB |      45 | `__new__`        | `<frozen abc>:105`                   |
-| 12.6% | 15.7 KiB |      19 | `__new__`        | `/usr/lib/python3.11/typing.py:2891` |
-|  1.1% | 1.42 KiB |       2 | `inner`          | `/usr/lib/python3.11/typing.py:338`  |
-|  0.4% |    542 B |       1 | `__init__`       | `/usr/lib/python3.11/typing.py:992`  |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 53.0% | 66.2 KiB |          58 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+| 30.6% | 38.2 KiB |          45 | `__new__`        | `<frozen abc>:105`                   |
+| 12.6% | 15.7 KiB |          19 | `__new__`        | `/usr/lib/python3.11/typing.py:2891` |
+|  1.1% | 1.42 KiB |           2 | `inner`          | `/usr/lib/python3.11/typing.py:338`  |
+|  0.4% |    542 B |           1 | `__init__`       | `/usr/lib/python3.11/typing.py:992`  |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/__init__.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 99.2% | 93.1 KiB |     118 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 99.2% | 93.1 KiB |         118 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/gitignore.py:1`)
 
-|     % |   Size | Samples | Callee           | Location                             |
-| ----: | -----: | ------: | ---------------- | ------------------------------------ |
-| 97.3% | 89 KiB |     112 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |   Size | Allocations | Callee           | Location                             |
+| ----: | -----: | ----------: | ---------------- | ------------------------------------ |
+| 97.3% | 89 KiB |         112 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/_backends/agg.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 98.9% | 64.8 KiB |      83 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 98.9% | 64.8 KiB |          83 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/utils.py:1`)
 
-|     % |   Size | Samples | Callee           | Location                             |
-| ----: | -----: | ------: | ---------------- | ------------------------------------ |
-| 94.4% | 60 KiB |      67 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |   Size | Allocations | Callee           | Location                             |
+| ----: | -----: | ----------: | ---------------- | ------------------------------------ |
+| 94.4% | 60 KiB |          67 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `compile` (`/usr/lib/python3.11/re/__init__.py:225`)
 
-|     % |     Size | Samples | Callee     | Location                                 |
-| ----: | -------: | ------: | ---------- | ---------------------------------------- |
-| 98.6% | 47.1 KiB |      24 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
+|     % |     Size | Allocations | Callee     | Location                                 |
+| ----: | -------: | ----------: | ---------- | ---------------------------------------- |
+| 98.6% | 47.1 KiB |          24 | `_compile` | `/usr/lib/python3.11/re/__init__.py:272` |
 
 ##### `decorator` (`/venv/lib/python3.11/site-packages/click/decorators.py:373`)
 
-|     % |     Size | Samples | Callee     | Location                                                |
-| ----: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 96.2% | 45.5 KiB |      32 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2883` |
+|     % |     Size | Allocations | Callee     | Location                                                |
+| ----: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 96.2% | 45.5 KiB |          32 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2883` |
 
 ##### `_compile` (`/usr/lib/python3.11/re/__init__.py:272`)
 
-|     % |     Size | Samples | Callee    | Location                                  |
-| ----: | -------: | ------: | --------- | ----------------------------------------- |
-| 98.6% | 46.5 KiB |      23 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
-|  1.4% |    698 B |       1 | `__and__` | `/usr/lib/python3.11/enum.py:1504`        |
+|     % |     Size | Allocations | Callee    | Location                                  |
+| ----: | -------: | ----------: | --------- | ----------------------------------------- |
+| 98.6% | 46.5 KiB |          23 | `compile` | `/usr/lib/python3.11/re/_compiler.py:738` |
+|  1.4% |    698 B |           1 | `__and__` | `/usr/lib/python3.11/enum.py:1504`        |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/pathspec/_backends/hyperscan/gitignore.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 94.8% | 44.5 KiB |      56 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 94.8% | 44.5 KiB |          56 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ##### `compile` (`/usr/lib/python3.11/re/_compiler.py:738`)
 
-|     % |     Size | Samples | Callee  | Location                                  |
-| ----: | -------: | ------: | ------- | ----------------------------------------- |
-| 31.0% | 14.4 KiB |       5 | `parse` | `/usr/lib/python3.11/re/_parser.py:970`   |
-| 20.4% |  9.5 KiB |       6 | `_code` | `/usr/lib/python3.11/re/_compiler.py:571` |
+|     % |     Size | Allocations | Callee  | Location                                  |
+| ----: | -------: | ----------: | ------- | ----------------------------------------- |
+| 31.0% | 14.4 KiB |           5 | `parse` | `/usr/lib/python3.11/re/_parser.py:970`   |
+| 20.4% |  9.5 KiB |           6 | `_code` | `/usr/lib/python3.11/re/_compiler.py:571` |
 
 ##### `__init__` (`/venv/lib/python3.11/site-packages/click/core.py:2883`)
 
-|    % |     Size | Samples | Callee     | Location                                                |
-| ---: | -------: | ------: | ---------- | ------------------------------------------------------- |
-| 2.6% | 1.17 KiB |       1 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2237` |
+|    % |     Size | Allocations | Callee     | Location                                                |
+| ---: | -------: | ----------: | ---------- | ------------------------------------------------------- |
+| 2.6% | 1.17 KiB |           1 | `__init__` | `/venv/lib/python3.11/site-packages/click/core.py:2237` |
 
 ##### `<module>` (`/venv/lib/python3.11/site-packages/packaging/_ranges.py:1`)
 
-|     % |     Size | Samples | Callee           | Location                             |
-| ----: | -------: | ------: | ---------------- | ------------------------------------ |
-| 80.6% | 32.9 KiB |      35 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
-|  4.1% | 1.69 KiB |       2 | `__new__`        | `/usr/lib/python3.11/enum.py:488`    |
+|     % |     Size | Allocations | Callee           | Location                             |
+| ----: | -------: | ----------: | ---------------- | ------------------------------------ |
+| 80.6% | 32.9 KiB |          35 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|  4.1% | 1.69 KiB |           2 | `__new__`        | `/usr/lib/python3.11/enum.py:488`    |
 
 ##### `<module>` (`/usr/lib/python3.11/tomllib/__init__.py:1`)
 
-|      % |   Size | Samples | Callee           | Location                             |
-| -----: | -----: | ------: | ---------------- | ------------------------------------ |
-| 100.0% | 35 KiB |      32 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
+|      % |   Size | Allocations | Callee           | Location                             |
+| -----: | -----: | ----------: | ---------------- | ------------------------------------ |
+| 100.0% | 35 KiB |          32 | `_find_and_load` | `<frozen importlib._bootstrap>:1167` |
 
 ## Hottest call stacks
 
@@ -2880,25 +2880,25 @@ Call stacks ranked by bytes never freed in their leaf frame.
 
 Common call stack: `run_module` (`<frozen runpy>:201`) ← `_run_tracker` (`/venv/lib/python3.11/site-packages/memray/commands/run.py:40`)
 
-|    % |     Size | Samples | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| ---: | -------: | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 8.6% |    5 MiB |       5 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `shift` (`blib2to3/pgen2/parse.py:373`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| 5.2% |    3 MiB |       6 | `transform_line` (`black/linegen.py:601`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| 3.5% | 2.01 MiB |       3 | `parse` (`/usr/lib/python3.11/ast.py:33`) ← `_parse_single_version` (`black/parsing.py:117`) ← `parse_ast` (129) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| 3.4% |    2 MiB |       2 | `_addtoken` (`blib2to3/pgen2/parse.py:290`) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| 3.4% |    2 MiB |       2 | `convert` (`blib2to3/pytree.py:486`) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| 1.8% | 1.07 MiB |      96 | `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `source_to_code` (`<frozen importlib._bootstrap_external>:999`) ← `get_code` (1007) ← `exec_module` (934) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| 1.7% | 1.01 MiB |       6 | `make_grammar` (`blib2to3/pgen2/pgen.py:49`) ← `generate_grammar` (426) ← `load_grammar` (`blib2to3/pgen2/driver.py:246`) ← `load_packaged_grammar` (280) ← `initialize` (`blib2to3/pygram.py:165`) ← `<module>` (`black/nodes.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| 1.7% | 1.01 MiB |      15 | `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `source_to_code` (`<frozen importlib._bootstrap_external>:999`) ← `get_code` (1007) ← `exec_module` (934) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| 1.7% | 1.01 MiB |      11 | `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| 1.7% |    1 MiB |       3 | `addtoken` (`blib2to3/pgen2/parse.py:242`) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| 1.7% |    1 MiB |       1 | `lines_with_leading_tabs_expanded` (`black/strings.py:46`) ← `fix_docstring` (65) ← `visit_STRING` (`black/linegen.py:413`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| 1.7% |    1 MiB |       1 | `is_import` (`black/lines.py:134`) ← `_maybe_empty_lines` (610) ← `maybe_empty_lines` (560) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| 1.7% |    1 MiB |       1 | `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| 1.7% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `preceding_leaf` (`black/nodes.py:441`) ← `whitespace` (194) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| 1.7% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| 1.7% |    1 MiB |       1 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| 1.7% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
-| 1.7% |    1 MiB |       1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_test` (160) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| 1.7% |    1 MiB |       1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                     |
-| 1.7% |    1 MiB |       1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `wrap_in_parentheses` (`black/nodes.py:935`) ← `normalize_invisible_parens` (`black/linegen.py:1328`) ← `visit_stmt` (199) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+|    % |     Size | Allocations | Call stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ---: | -------: | ----------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 8.6% |    5 MiB |           5 | `__new__` (`blib2to3/pytree.py:81`) ← `convert` (486) ← `shift` (`blib2to3/pgen2/parse.py:373`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| 5.2% |    3 MiB |           6 | `transform_line` (`black/linegen.py:601`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| 3.5% | 2.01 MiB |           3 | `parse` (`/usr/lib/python3.11/ast.py:33`) ← `_parse_single_version` (`black/parsing.py:117`) ← `parse_ast` (129) ← `assert_equivalent` (`black/__init__.py:1524`) ← `check_stability_and_equivalence` (1037) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| 3.4% |    2 MiB |           2 | `_addtoken` (`blib2to3/pgen2/parse.py:290`) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| 3.4% |    2 MiB |           2 | `convert` (`blib2to3/pytree.py:486`) ← `pop` (`blib2to3/pgen2/parse.py:398`) ← `_addtoken` (290) ← `addtoken` (242) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| 1.8% | 1.07 MiB |          96 | `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `source_to_code` (`<frozen importlib._bootstrap_external>:999`) ← `get_code` (1007) ← `exec_module` (934) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| 1.7% | 1.01 MiB |           6 | `make_grammar` (`blib2to3/pgen2/pgen.py:49`) ← `generate_grammar` (426) ← `load_grammar` (`blib2to3/pgen2/driver.py:246`) ← `load_packaged_grammar` (280) ← `initialize` (`blib2to3/pygram.py:165`) ← `<module>` (`black/nodes.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| 1.7% | 1.01 MiB |          15 | `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `source_to_code` (`<frozen importlib._bootstrap_external>:999`) ← `get_code` (1007) ← `exec_module` (934) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/comments.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| 1.7% | 1.01 MiB |          11 | `<module>` (`/venv/lib/python3.11/site-packages/click/parser.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/formatting.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/core.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`/venv/lib/python3.11/site-packages/click/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `<module>` (`black/__init__.py:1`) ← `_call_with_frames_removed` (`<frozen importlib._bootstrap>:233`) ← `exec_module` (`<frozen importlib._bootstrap_external>:934`) ← `_load_unlocked` (`<frozen importlib._bootstrap>:666`) ← `_find_and_load_unlocked` (1122) ← `_find_and_load` (1167) ← `_get_module_details` (`<frozen runpy>:105`) ← `_get_module_details` (105)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| 1.7% |    1 MiB |           3 | `addtoken` (`blib2to3/pgen2/parse.py:242`) ← `parse_tokens` (`blib2to3/pgen2/driver.py:114`) ← `parse_string` (198) ← `lib2to3_parse` (`black/parsing.py:55`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| 1.7% |    1 MiB |           1 | `lines_with_leading_tabs_expanded` (`black/strings.py:46`) ← `fix_docstring` (65) ← `visit_STRING` (`black/linegen.py:413`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| 1.7% |    1 MiB |           1 | `is_import` (`black/lines.py:134`) ← `_maybe_empty_lines` (610) ← `maybe_empty_lines` (560) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| 1.7% |    1 MiB |           1 | `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| 1.7% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `preceding_leaf` (`black/nodes.py:441`) ← `whitespace` (194) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| 1.7% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| 1.7% |    1 MiB |           1 | `mark` (`black/brackets.py:70`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| 1.7% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `prefix` (480) ← `normalize_trailing_prefix` (`black/comments.py:127`) ← `generate_comments` (52) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91) |
+| 1.7% |    1 MiB |           1 | `generate_comments` (`black/comments.py:52`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_test` (160) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| 1.7% |    1 MiB |           1 | `update_sibling_maps` (`blib2to3/pytree.py:369`) ← `prev_sibling` (207) ← `whitespace` (`black/nodes.py:194`) ← `append` (`black/lines.py:63`) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_power` (341) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                     |
+| 1.7% |    1 MiB |           1 | `changed` (`blib2to3/pytree.py:171`) ← `changed` (171) ← `prefix` (480) ← `wrap_in_parentheses` (`black/nodes.py:935`) ← `normalize_invisible_parens` (`black/linegen.py:1328`) ← `visit_stmt` (199) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_simple_stmt` (295) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_funcdef` (`black/linegen.py:254`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit_suite` (288) ← `visit` (`black/nodes.py:163`) ← `visit_stmt` (`black/linegen.py:199`) ← `visit` (`black/nodes.py:163`) ← `visit_default` (187) ← `visit_default` (`black/linegen.py:134`) ← `visit` (`black/nodes.py:163`) ← `_format_str_once` (`black/__init__.py:1236`) ← `format_str` (1189) ← `format_file_contents` (1054) ← `format_file_in_place` (917) ← `reformat_one` (860) ← `main` (244) ← `new_func` (`/venv/lib/python3.11/site-packages/click/decorators.py:33`) ← `invoke` (`/venv/lib/python3.11/site-packages/click/core.py:853`) ← `invoke` (1339) ← `main` (1422) ← `__call__` (1567) ← `patched_main` (`black/__init__.py:1594`) ← `<module>` (`black/__main__.py:1`) ← `_run_code` (`<frozen runpy>:65`) ← `_run_module_code` (91)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |

--- a/examples/output/python.memray.diff.memray.bin.md
+++ b/examples/output/python.memray.diff.memray.bin.md
@@ -1,12 +1,12 @@
 # Peak memory profile diff
 
-Held 72.4 MiB over 23,696 samples (3.13 KiB per sample).
+Held 72.4 MiB over 23,696 allocations (3.13 KiB per allocation).
 
-| Category         | Change | Delta |     % |     Size | Samples |
-| ---------------- | -----: | ----: | ----: | -------: | ------: |
-| Ours             |   0.0% |   0 B | 71.8% |   52 MiB |  21,382 |
-| Standard library |   0.0% |   0 B | 26.4% | 19.1 MiB |   2,080 |
-| Third-party      |   0.0% |   0 B |  1.8% | 1.27 MiB |     234 |
+| Category         | Change | Delta |     % |     Size | Allocations |
+| ---------------- | -----: | ----: | ----: | -------: | ----------: |
+| Ours             |   0.0% |   0 B | 71.8% |   52 MiB |      21,382 |
+| Standard library |   0.0% |   0 B | 26.4% | 19.1 MiB |       2,080 |
+| Third-party      |   0.0% |   0 B |  1.8% | 1.27 MiB |         234 |
 
 ## Hottest functions
 
@@ -18,7 +18,7 @@ Functions with the largest increase in bytes held at peak memory directly in the
 
 ##### Ours
 
-|    Change |  Delta |             % |                Size |         Samples | Function                           | Location                      |
+|    Change |  Delta |             % |                Size |     Allocations | Function                           | Location                      |
 | --------: | -----: | ------------: | ------------------: | --------------: | ---------------------------------- | ----------------------------- |
 |     +5.5% | +1 MiB | 25.2% → 26.5% | 18.2 MiB → 19.2 MiB | 20,790 → 20,791 | `mark`                             | `black/brackets.py:70`        |
 |    +46.7% | +1 MiB |   3.0% → 4.3% | 2.14 MiB → 3.14 MiB |       197 → 198 | `update_sibling_maps`              | `blib2to3/pytree.py:369`      |
@@ -35,14 +35,14 @@ Functions with the largest decrease in bytes held at peak memory directly in the
 
 ##### Ours
 
-|  Change |  Delta |            % |             Size | Samples | Function                               | Location                      |
-| ------: | -----: | -----------: | ---------------: | ------: | -------------------------------------- | ----------------------------- |
-|  -66.7% | -2 MiB |  4.1% → 1.4% |    3 MiB → 1 MiB |   4 → 2 | `visit_default`                        | `black/linegen.py:134`        |
-| removed | -2 MiB |  2.8% → 0.0% |      2 MiB → 0 B |   2 → 0 | `push`                                 | `blib2to3/pgen2/parse.py:386` |
-| removed | -1 MiB |  1.4% → 0.0% |      1 MiB → 0 B |   1 → 0 | `__init__`                             | `blib2to3/pytree.py:400`      |
-|  -99.9% | -1 MiB | 1.4% → <0.1% | 1 MiB → 1.11 KiB |   2 → 1 | `maybe_empty_lines`                    | `black/lines.py:560`          |
-|  -33.3% | -1 MiB |  4.1% → 2.8% |    3 MiB → 2 MiB |   3 → 2 | `generate_comments`                    | `black/comments.py:52`        |
-| removed | -1 MiB |  1.4% → 0.0% |      1 MiB → 0 B |   1 → 0 | `contains_uncollapsable_type_comments` | `black/lines.py:276`          |
+|  Change |  Delta |            % |             Size | Allocations | Function                               | Location                      |
+| ------: | -----: | -----------: | ---------------: | ----------: | -------------------------------------- | ----------------------------- |
+|  -66.7% | -2 MiB |  4.1% → 1.4% |    3 MiB → 1 MiB |       4 → 2 | `visit_default`                        | `black/linegen.py:134`        |
+| removed | -2 MiB |  2.8% → 0.0% |      2 MiB → 0 B |       2 → 0 | `push`                                 | `blib2to3/pgen2/parse.py:386` |
+| removed | -1 MiB |  1.4% → 0.0% |      1 MiB → 0 B |       1 → 0 | `__init__`                             | `blib2to3/pytree.py:400`      |
+|  -99.9% | -1 MiB | 1.4% → <0.1% | 1 MiB → 1.11 KiB |       2 → 1 | `maybe_empty_lines`                    | `black/lines.py:560`          |
+|  -33.3% | -1 MiB |  4.1% → 2.8% |    3 MiB → 2 MiB |       3 → 2 | `generate_comments`                    | `black/comments.py:52`        |
+| removed | -1 MiB |  1.4% → 0.0% |      1 MiB → 0 B |       1 → 0 | `contains_uncollapsable_type_comments` | `black/lines.py:276`          |
 
 ### Total size
 
@@ -52,7 +52,7 @@ Functions with the largest increase in total bytes held at peak memory in the fu
 
 ##### Ours
 
-|     Change |  Delta |             % |                Size |         Samples | Function                     | Location                      |
+|     Change |  Delta |             % |                Size |     Allocations | Function                     | Location                      |
 | ---------: | -----: | ------------: | ------------------: | --------------: | ---------------------------- | ----------------------------- |
 |     +10.4% | +2 MiB | 26.6% → 29.4% | 19.3 MiB → 21.3 MiB | 20,884 → 20,886 | `append`                     | `black/lines.py:63`           |
 |      +5.5% | +1 MiB | 25.2% → 26.5% | 18.2 MiB → 19.2 MiB | 20,790 → 20,791 | `mark`                       | `black/brackets.py:70`        |
@@ -81,7 +81,7 @@ Functions with the largest decrease in total bytes held at peak memory in the fu
 
 ##### Ours
 
-|  Change |  Delta |             % |                Size |         Samples | Function                               | Location                      |
+|  Change |  Delta |             % |                Size |     Allocations | Function                               | Location                      |
 | ------: | -----: | ------------: | ------------------: | --------------: | -------------------------------------- | ----------------------------- |
 | removed | -2 MiB |   2.8% → 0.0% |         2 MiB → 0 B |           2 → 0 | `push`                                 | `blib2to3/pgen2/parse.py:386` |
 |   -5.9% | -1 MiB | 23.3% → 22.0% | 16.9 MiB → 15.9 MiB | 10,808 → 10,807 | `visit_power`                          | `black/linegen.py:341`        |
@@ -96,9 +96,9 @@ Functions with the largest decrease in total bytes held at peak memory in the fu
 
 # Leaked memory profile diff
 
-Leaked 57.1 MiB → 58.1 MiB (+1 MiB, +1.8%) over 22,684 samples → 22,685 samples (2.58 KiB → 2.62 KiB per sample).
+Leaked 57.1 MiB → 58.1 MiB (+1 MiB, +1.8%) over 22,684 allocations → 22,685 allocations (2.58 KiB → 2.62 KiB per allocation).
 
-| Category         | Change |  Delta |             % |                Size |         Samples |
+| Category         | Change |  Delta |             % |                Size |     Allocations |
 | ---------------- | -----: | -----: | ------------: | ------------------: | --------------: |
 | Ours             |  +2.0% | +1 MiB | 89.1% → 89.3% | 50.9 MiB → 51.9 MiB | 21,386 → 21,387 |
 | Standard library |   0.0% |    0 B |   8.7% → 8.6% |            4.97 MiB |           1,068 |
@@ -114,7 +114,7 @@ Functions with the largest increase in bytes never freed directly in the functio
 
 ##### Ours
 
-|    Change |  Delta |             % |                Size |         Samples | Function                           | Location                      |
+|    Change |  Delta |             % |                Size |     Allocations | Function                           | Location                      |
 | --------: | -----: | ------------: | ------------------: | --------------: | ---------------------------------- | ----------------------------- |
 |    +11.6% | +2 MiB | 30.2% → 33.1% | 17.2 MiB → 19.2 MiB | 20,789 → 20,791 | `mark`                             | `black/brackets.py:70`        |
 | +87381.3% | +1 MiB |  <0.1% → 1.7% |    1.17 KiB → 1 MiB |           2 → 3 | `addtoken`                         | `blib2to3/pgen2/parse.py:242` |
@@ -131,14 +131,14 @@ Functions with the largest decrease in bytes never freed directly in the functio
 
 ##### Ours
 
-|  Change |  Delta |            % |             Size | Samples | Function                               | Location                      |
-| ------: | -----: | -----------: | ---------------: | ------: | -------------------------------------- | ----------------------------- |
-|  -66.7% | -2 MiB |  5.3% → 1.7% |    3 MiB → 1 MiB |   4 → 2 | `visit_default`                        | `black/linegen.py:134`        |
-| removed | -2 MiB |  3.5% → 0.0% |      2 MiB → 0 B |   2 → 0 | `push`                                 | `blib2to3/pgen2/parse.py:386` |
-|  -99.9% | -1 MiB | 1.8% → <0.1% | 1 MiB → 1.11 KiB |   2 → 1 | `maybe_empty_lines`                    | `black/lines.py:560`          |
-|  -33.3% | -1 MiB |  5.3% → 3.4% |    3 MiB → 2 MiB |   3 → 2 | `generate_comments`                    | `black/comments.py:52`        |
-| removed | -1 MiB |  1.8% → 0.0% |      1 MiB → 0 B |   1 → 0 | `contains_uncollapsable_type_comments` | `black/lines.py:276`          |
-| removed | -1 MiB |  1.8% → 0.0% |      1 MiB → 0 B |   1 → 0 | `__init__`                             | `blib2to3/pytree.py:400`      |
+|  Change |  Delta |            % |             Size | Allocations | Function                               | Location                      |
+| ------: | -----: | -----------: | ---------------: | ----------: | -------------------------------------- | ----------------------------- |
+|  -66.7% | -2 MiB |  5.3% → 1.7% |    3 MiB → 1 MiB |       4 → 2 | `visit_default`                        | `black/linegen.py:134`        |
+| removed | -2 MiB |  3.5% → 0.0% |      2 MiB → 0 B |       2 → 0 | `push`                                 | `blib2to3/pgen2/parse.py:386` |
+|  -99.9% | -1 MiB | 1.8% → <0.1% | 1 MiB → 1.11 KiB |       2 → 1 | `maybe_empty_lines`                    | `black/lines.py:560`          |
+|  -33.3% | -1 MiB |  5.3% → 3.4% |    3 MiB → 2 MiB |       3 → 2 | `generate_comments`                    | `black/comments.py:52`        |
+| removed | -1 MiB |  1.8% → 0.0% |      1 MiB → 0 B |       1 → 0 | `contains_uncollapsable_type_comments` | `black/lines.py:276`          |
+| removed | -1 MiB |  1.8% → 0.0% |      1 MiB → 0 B |       1 → 0 | `__init__`                             | `blib2to3/pytree.py:400`      |
 
 ### Total size
 
@@ -146,7 +146,7 @@ Functions with the largest decrease in bytes never freed directly in the functio
 
 Functions with the largest increase in total bytes never freed in the function and all its callees.
 
-| Change |  Delta |             % |                Size |         Samples | Function               | Location                                                       |
+| Change |  Delta |             % |                Size |     Allocations | Function               | Location                                                       |
 | -----: | -----: | ------------: | ------------------: | --------------: | ---------------------- | -------------------------------------------------------------- |
 | +16.4% | +3 MiB | 32.0% → 36.7% | 18.3 MiB → 21.3 MiB | 20,883 → 20,886 | `append`               | `black/lines.py:63`                                            |
 |  +6.0% | +2 MiB | 58.6% → 61.0% | 33.4 MiB → 35.4 MiB | 21,084 → 21,086 | `visit`                | `black/nodes.py:163`                                           |
@@ -171,7 +171,7 @@ Functions with the largest increase in total bytes never freed in the function a
 
 ##### Ours
 
-|     Change |  Delta |             % |                Size |         Samples | Function                     | Location                 |
+|     Change |  Delta |             % |                Size |     Allocations | Function                     | Location                 |
 | ---------: | -----: | ------------: | ------------------: | --------------: | ---------------------------- | ------------------------ |
 |     +16.4% | +3 MiB | 32.0% → 36.7% | 18.3 MiB → 21.3 MiB | 20,883 → 20,886 | `append`                     | `black/lines.py:63`      |
 |      +6.0% | +2 MiB | 58.6% → 61.0% | 33.4 MiB → 35.4 MiB | 21,084 → 21,086 | `visit`                      | `black/nodes.py:163`     |
@@ -196,7 +196,7 @@ Functions with the largest increase in total bytes never freed in the function a
 
 ##### Standard library
 
-| Change |  Delta |             % |                Size |         Samples | Function           | Location             |
+| Change |  Delta |             % |                Size |     Allocations | Function           | Location             |
 | -----: | -----: | ------------: | ------------------: | --------------: | ------------------ | -------------------- |
 |  +1.8% | +1 MiB |        100.0% | 57.1 MiB → 58.1 MiB | 22,683 → 22,684 | `run_module`       | `<frozen runpy>:201` |
 |  +1.9% | +1 MiB | 90.5% → 90.7% | 51.6 MiB → 52.6 MiB | 21,189 → 21,190 | `_run_code`        | `<frozen runpy>:65`  |
@@ -204,7 +204,7 @@ Functions with the largest increase in total bytes never freed in the function a
 
 ##### Third-party
 
-| Change |  Delta |             % |                Size |         Samples | Function       | Location                                                       |
+| Change |  Delta |             % |                Size |     Allocations | Function       | Location                                                       |
 | -----: | -----: | ------------: | ------------------: | --------------: | -------------- | -------------------------------------------------------------- |
 |  +1.8% | +1 MiB |        100.0% | 57.1 MiB → 58.1 MiB | 22,684 → 22,685 | `_run_tracker` | `/venv/lib/python3.11/site-packages/memray/commands/run.py:40` |
 |  +1.9% | +1 MiB | 90.5% → 90.6% | 51.6 MiB → 52.6 MiB | 21,166 → 21,167 | `new_func`     | `/venv/lib/python3.11/site-packages/click/decorators.py:33`    |
@@ -219,7 +219,7 @@ Functions with the largest decrease in total bytes never freed in the function a
 
 ##### Ours
 
-|  Change |  Delta |             % |                Size |         Samples | Function                               | Location                      |
+|  Change |  Delta |             % |                Size |     Allocations | Function                               | Location                      |
 | ------: | -----: | ------------: | ------------------: | --------------: | -------------------------------------- | ----------------------------- |
 | removed | -2 MiB |   3.5% → 0.0% |         2 MiB → 0 B |           2 → 0 | `push`                                 | `blib2to3/pgen2/parse.py:386` |
 |  -24.5% | -1 MiB |   7.2% → 5.3% | 4.08 MiB → 3.08 MiB |         19 → 18 | `transform_line`                       | `black/linegen.py:601`        |

--- a/src/formats/memray/index.test.ts
+++ b/src/formats/memray/index.test.ts
@@ -185,12 +185,12 @@ describe(`convert`, () => {
       `Leaked memory profile`,
     ])
     expect(summaryLines(md)).toEqual([
-      `Held 4\u00A0KiB over 2 samples (2\u00A0KiB per sample).`,
-      `Leaked 1.5\u00A0KiB over 2 samples (768\u00A0B per sample).`,
+      `Held 4\u00A0KiB over 2 allocations (2\u00A0KiB per allocation).`,
+      `Leaked 1.5\u00A0KiB over 2 allocations (768\u00A0B per allocation).`,
     ])
     expect(categoryTables(md)).toEqual([
-      [{ Category: `Ours`, '%': `100.0%`, Size: `4 KiB`, Samples: `2` }],
-      [{ Category: `Ours`, '%': `100.0%`, Size: `1.5 KiB`, Samples: `2` }],
+      [{ Category: `Ours`, '%': `100.0%`, Size: `4 KiB`, Allocations: `2` }],
+      [{ Category: `Ours`, '%': `100.0%`, Size: `1.5 KiB`, Allocations: `2` }],
     ])
 
     // At the peak both allocations are live and `cold` holds the larger one.
@@ -199,14 +199,14 @@ describe(`convert`, () => {
         {
           '%': `75.0%`,
           Size: `3 KiB`,
-          Samples: `1`,
+          Allocations: `1`,
           Function: `cold`,
           Location: `cold.py:20`,
         },
         {
           '%': `25.0%`,
           Size: `1 KiB`,
-          Samples: `1`,
+          Allocations: `1`,
           Function: `hot`,
           Location: `hot.py:10`,
         },
@@ -219,14 +219,14 @@ describe(`convert`, () => {
         {
           '%': `66.7%`,
           Size: `1 KiB`,
-          Samples: `1`,
+          Allocations: `1`,
           Function: `hot`,
           Location: `hot.py:10`,
         },
         {
           '%': `33.3%`,
           Size: `512 B`,
-          Samples: `1`,
+          Allocations: `1`,
           Function: `cold`,
           Location: `cold.py:20`,
         },
@@ -258,17 +258,17 @@ describe(`convert`, () => {
     )
 
     // `cold` holds no bytes, so the sizes the table ranks by leave it out, but
-    // its allocation is one of the samples the profile counts.
+    // the profile still counts its allocation.
     expect(summaryLines(md)).toEqual([
-      `Held 2\u00A0KiB over 2 samples (1\u00A0KiB per sample).`,
-      `Leaked 2\u00A0KiB over 2 samples (1\u00A0KiB per sample).`,
+      `Held 2\u00A0KiB over 2 allocations (1\u00A0KiB per allocation).`,
+      `Leaked 2\u00A0KiB over 2 allocations (1\u00A0KiB per allocation).`,
     ])
     expect(selfSizeTables(md, PEAK)).toEqual([
       [
         {
           '%': `100.0%`,
           Size: `2 KiB`,
-          Samples: `1`,
+          Allocations: `1`,
           Function: `hot`,
           Location: `hot.py:10`,
         },
@@ -303,7 +303,7 @@ describe(`convert`, () => {
         {
           '%': `100.0%`,
           Size: `2 KiB`,
-          Samples: `1`,
+          Allocations: `1`,
           Function: `hot`,
           Location: `hot.py:10`,
         },
@@ -314,14 +314,14 @@ describe(`convert`, () => {
         {
           '%': `100.0%`,
           Size: `2 KiB`,
-          Samples: `1`,
+          Allocations: `1`,
           Function: `hot`,
           Location: `hot.py:10`,
         },
         {
           '%': `100.0%`,
           Size: `2 KiB`,
-          Samples: `1`,
+          Allocations: `1`,
           Function: `cold`,
           Location: `cold.py:20`,
         },
@@ -361,8 +361,8 @@ describe(`convert`, () => {
     // The 4 KiB allocation is the peak, and the 1 KiB one that reused its
     // address is what leaked.
     expect(summaryLines(md)).toEqual([
-      `Held 4\u00A0KiB over 1 sample (4\u00A0KiB per sample).`,
-      `Leaked 1\u00A0KiB over 1 sample (1\u00A0KiB per sample).`,
+      `Held 4\u00A0KiB over 1 allocation (4\u00A0KiB per allocation).`,
+      `Leaked 1\u00A0KiB over 1 allocation (1\u00A0KiB per allocation).`,
     ])
   })
 
@@ -395,8 +395,8 @@ describe(`convert`, () => {
 
     // The peak is the 1 KiB allocation alone, since the 8 B one displaced it.
     expect(summaryLines(md)).toEqual([
-      `Held 1\u00A0KiB over 1 sample (1\u00A0KiB per sample).`,
-      `Leaked 8\u00A0B over 1 sample (8\u00A0B per sample).`,
+      `Held 1\u00A0KiB over 1 allocation (1\u00A0KiB per allocation).`,
+      `Leaked 8\u00A0B over 1 allocation (8\u00A0B per allocation).`,
     ])
   })
 
@@ -428,8 +428,8 @@ describe(`convert`, () => {
 
     // The two mappings cover 4 KiB together, not the 6 KiB they total.
     expect(summaryLines(md)).toEqual([
-      `Held 4\u00A0KiB over 2 samples (2\u00A0KiB per sample).`,
-      `Leaked 4\u00A0KiB over 2 samples (2\u00A0KiB per sample).`,
+      `Held 4\u00A0KiB over 2 allocations (2\u00A0KiB per allocation).`,
+      `Leaked 4\u00A0KiB over 2 allocations (2\u00A0KiB per allocation).`,
     ])
   })
 
@@ -460,10 +460,10 @@ describe(`convert`, () => {
     )
 
     // The two halves the unmapping left are two mappings by the end, so the
-    // leaked memory counts one sample each.
+    // leaked memory counts one allocation each.
     expect(summaryLines(md)).toEqual([
-      `Held 4\u00A0KiB over 1 sample (4\u00A0KiB per sample).`,
-      `Leaked 3\u00A0KiB over 2 samples (1.5\u00A0KiB per sample).`,
+      `Held 4\u00A0KiB over 1 allocation (4\u00A0KiB per allocation).`,
+      `Leaked 3\u00A0KiB over 2 allocations (1.5\u00A0KiB per allocation).`,
     ])
   })
 
@@ -492,7 +492,7 @@ describe(`convert`, () => {
         {
           '%': `100.0%`,
           Size: `1 KiB`,
-          Samples: `1`,
+          Allocations: `1`,
           Function: `hot`,
           Location: `hot.py:10`,
         },
@@ -541,8 +541,18 @@ describe(`convert`, () => {
     // table splits its size across the two lines it was executing.
     expect(linesTables(md, `hot`)).toEqual([
       [
-        { '%': `75.0%`, Size: `3 KiB`, Samples: `1`, Location: `hot.py:25` },
-        { '%': `25.0%`, Size: `1 KiB`, Samples: `1`, Location: `hot.py:15` },
+        {
+          '%': `75.0%`,
+          Size: `3 KiB`,
+          Allocations: `1`,
+          Location: `hot.py:25`,
+        },
+        {
+          '%': `25.0%`,
+          Size: `1 KiB`,
+          Allocations: `1`,
+          Location: `hot.py:15`,
+        },
       ],
     ])
   })
@@ -580,22 +590,22 @@ describe(`convert`, () => {
 
     // The same totals a capture of every allocation replays to.
     expect(summaryLines(md)).toEqual([
-      `Held 4\u00A0KiB over 2 samples (2\u00A0KiB per sample).`,
-      `Leaked 1.5\u00A0KiB over 2 samples (768\u00A0B per sample).`,
+      `Held 4\u00A0KiB over 2 allocations (2\u00A0KiB per allocation).`,
+      `Leaked 1.5\u00A0KiB over 2 allocations (768\u00A0B per allocation).`,
     ])
     expect(selfSizeTables(md, PEAK)).toEqual([
       [
         {
           '%': `75.0%`,
           Size: `3 KiB`,
-          Samples: `1`,
+          Allocations: `1`,
           Function: `cold`,
           Location: `cold.py:20`,
         },
         {
           '%': `25.0%`,
           Size: `1 KiB`,
-          Samples: `1`,
+          Allocations: `1`,
           Function: `hot`,
           Location: `hot.py:10`,
         },
@@ -637,15 +647,15 @@ describe(`convert`, () => {
     )
 
     expect(summaryLines(md)).toEqual([
-      `Held 1\u00A0KiB over 4 samples (256\u00A0B per sample).`,
-      `Leaked 768\u00A0B over 3 samples (256\u00A0B per sample).`,
+      `Held 1\u00A0KiB over 4 allocations (256\u00A0B per allocation).`,
+      `Leaked 768\u00A0B over 3 allocations (256\u00A0B per allocation).`,
     ])
     expect(selfSizeTables(md, PEAK)).toEqual([
       [
         {
           '%': `100.0%`,
           Size: `1 KiB`,
-          Samples: `4`,
+          Allocations: `4`,
           Function: `hot`,
           Location: `hot.py:10`,
         },
@@ -656,14 +666,14 @@ describe(`convert`, () => {
         {
           '%': `66.7%`,
           Size: `512 B`,
-          Samples: `1`,
+          Allocations: `1`,
           Function: `hot`,
           Location: `hot.py:10`,
         },
         {
           '%': `33.3%`,
           Size: `256 B`,
-          Samples: `2`,
+          Allocations: `2`,
           Function: `cold`,
           Location: `cold.py:20`,
         },
@@ -696,7 +706,7 @@ describe(`convert`, () => {
         {
           '%': `100.0%`,
           Size: `1 KiB`,
-          Samples: `1`,
+          Allocations: `1`,
           Function: `hot`,
           Location: `hot.py:10`,
         },
@@ -747,15 +757,15 @@ describe(`convert`, () => {
     // The malloc and the mapping are live together at the peak, and the two
     // halves of the mapping are what leaked.
     expect(summaryLines(md)).toEqual([
-      `Held 5\u00A0KiB over 2 samples (2.5\u00A0KiB per sample).`,
-      `Leaked 3\u00A0KiB over 2 samples (1.5\u00A0KiB per sample).`,
+      `Held 5\u00A0KiB over 2 allocations (2.5\u00A0KiB per allocation).`,
+      `Leaked 3\u00A0KiB over 2 allocations (1.5\u00A0KiB per allocation).`,
     ])
     expect(selfSizeTables(md, LEAKED)).toEqual([
       [
         {
           '%': `100.0%`,
           Size: `3 KiB`,
-          Samples: `2`,
+          Allocations: `2`,
           Function: `hot`,
           Location: `hot.py:10`,
         },
@@ -793,8 +803,8 @@ describe(`convert`, () => {
       `Leaked memory profile diff`,
     ])
     expect(summaryLines(md)).toEqual([
-      `Held 29\u00A0B over 1 sample → 7 samples (29\u00A0B → 4.14\u00A0B per sample).`,
-      `Leaked 29\u00A0B over 1 sample → 7 samples (29\u00A0B → 4.14\u00A0B per sample).`,
+      `Held 29\u00A0B over 1 allocation → 7 allocations (29\u00A0B → 4.14\u00A0B per allocation).`,
+      `Leaked 29\u00A0B over 1 allocation → 7 allocations (29\u00A0B → 4.14\u00A0B per allocation).`,
     ])
     expect(regressionsTables(md, `Self size`)).toEqual([])
     expect(improvementsTables(md, `Self size`)).toEqual([])
@@ -809,8 +819,8 @@ describe(`convert`, () => {
     )
 
     expect(summaryLines(md)).toEqual([
-      `Held 4\u00A0KiB over 2 samples (2\u00A0KiB per sample).`,
-      `Leaked 1.5\u00A0KiB over 2 samples (768\u00A0B per sample).`,
+      `Held 4\u00A0KiB over 2 allocations (2\u00A0KiB per allocation).`,
+      `Leaked 1.5\u00A0KiB over 2 allocations (768\u00A0B per allocation).`,
     ])
   })
 })

--- a/src/formats/memray/parse.ts
+++ b/src/formats/memray/parse.ts
@@ -4,7 +4,7 @@ import type {
   CallStackProfile,
   Observation,
 } from '../../modalities/call-stack-profile/index.ts'
-import { determineMetric, SAMPLES } from '../../modalities/metric.ts'
+import { countMetricOf, determineMetric } from '../../modalities/metric.ts'
 import type { StackFrame } from '../../modalities/stack-frame.ts'
 import { FormatParseError } from '../error.ts'
 
@@ -19,7 +19,7 @@ import { FormatParseError } from '../error.ts'
  * to whatever stack the pushes and pops have built up for its thread.
  *
  * The two measures count different allocations, so each is its own profile,
- * whose observations are the allocations that measure counts.
+ * counting each stack's allocations under that measure.
  *
  * A capture holds no aggregate totals, so both measures are computed by
  * replaying the stream: the peak from the live allocations at the moment total
@@ -418,14 +418,14 @@ class Capture {
         type: `call-stack-profile`,
         frames,
         metrics: [PEAK_METRIC],
-        countMetric: SAMPLES,
+        countMetric: ALLOCATIONS,
         observations: this.#observations(`peak`),
       },
       {
         type: `call-stack-profile`,
         frames,
         metrics: [LEAKED_METRIC],
-        countMetric: SAMPLES,
+        countMetric: ALLOCATIONS,
         observations: this.#observations(`leaked`),
       },
     ]
@@ -696,8 +696,7 @@ class Capture {
 
   /**
    * The observations of one measure's profile: each stack's bytes, over the
-   * allocations that measure counts for it, as a pprof heap profile counts its
-   * records by the objects allocated.
+   * allocations that measure counts for it.
    */
   *#observations(measure: `peak` | `leaked`): Iterable<Observation> {
     const bytesKey = measure === `peak` ? `peakBytes` : `leakedBytes`
@@ -708,8 +707,8 @@ class Capture {
       const count = usage[countKey]
 
       // A stack the other measure counts alone. A stack this one counts holds
-      // no bytes when every allocation it made was of no size, and those
-      // allocations still count toward the profile's observations.
+      // no bytes when every allocation it made was of no size, and the profile
+      // still counts those allocations.
       if (bytes === 0 && count === 0) {
         continue
       }
@@ -1149,6 +1148,12 @@ class LiveAllocations {
  */
 const hashAddress = (address: number): number =>
   Math.imul(address >>> 0, 0x9e_37_79_b1) >>> 0
+
+/**
+ * Memray hooks the allocator, so a stack's count is the number of allocations
+ * recorded for it rather than a number of samples.
+ */
+const ALLOCATIONS = countMetricOf(`allocation`)
 
 /** Bytes live at the moment the capture's total memory was highest. */
 const PEAK_METRIC = determineMetric({ name: `peak_space`, unit: `bytes` })


### PR DESCRIPTION
memray hooks the allocator and records every allocation, so a stack's count is the number of allocations recorded for it rather than a number of samples. The output stated 3.55 KiB per sample for a profiler that never sampled.