### PR TITLE
feat(metric): state which direction of change a metric improves in

### DIFF
--- a/.claude/skills/new-format/SKILL.md
+++ b/.claude/skills/new-format/SKILL.md
@@ -96,12 +96,11 @@ $ARGUMENTS
        `parseMetric` only where the input names its own unit. For a lone count
        metric, populate `Observation.count` with no metrics instead. State what
        one of those counts measures with `countMetric`, from the answer in step
-       4: `SAMPLES` when the profiler samples,
-       `countMetricOf('<singular noun>')` when it counts occurrences of
-       something else, a time or size metric when a count measures a quantity,
-       and `null` when they measure nothing. Where the emitters disagree, leave
-       the format's own answer and let the dissenting origin override it with
-       `OriginSpec.countMetric`
+       4: `SAMPLES` when the profiler samples, `countMetricOf(...)` when it
+       counts occurrences of something else, a time or size metric when a count
+       measures a quantity, and `null` when they measure nothing. Where the
+       emitters disagree, leave the format's own answer and let the dissenting
+       origin override it with `OriginSpec.countMetric`
      - A heap snapshot parses into a `HeapSnapshot` (node adjacency graph,
        lazily-classified nodes; see `src/modalities/heap-snapshot/type.ts`)
      - `parse` returns a list of them (`ParsedInput[]`), which may mix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,10 +296,11 @@ pnpm generate-inputs go ruby   # Limit to named workload scripts
   contention counts those events. One that records an event per allocation, but
   only for a subset of allocations, counts samples. State the answer with
   `CallStackProfile.countMetric`
-- Pass `countMetricOf('<singular noun>')` when the profiler counts occurrences
-  of something else. The noun titles a metric-less profile, heads its count
-  column, and follows the rate, so pick what one occurrence is. "object"
-  produces "over 78 objects" and "1.69 MiB per object"
+- Pass `countMetricOf(...)` when the profiler counts occurrences of something
+  else. The noun titles a metric-less profile, heads its count column, and
+  follows the rate, so pick what one occurrence is. "object" produces "over 78
+  objects" and "1.69 MiB per object". The direction states whether the program
+  incurs the occurrence (a cost, so `decrease`) or achieves it (`increase`)
 - Pass a time or size metric when one count measures a quantity rather than
   counting anything, so the counts format as that quantity and state no rate
 - Pass `null` when the counts measure nothing, so the profile reports its
@@ -309,6 +310,18 @@ pnpm generate-inputs go ruby   # Limit to named workload scripts
   overrides the same field with `OriginSpec.countMetric`
 - NEVER count what the profiler did not record. Dropping the count costs a
   column; keeping it states a rate nothing measured
+
+### Ranking change
+
+- State every metric's `improvement`, the direction of change a diff calls an
+  improvement. A duration, a size, and a count of what a profiler recorded are
+  costs, so a decrease improves them
+- Pass `improvement` to `parseMetric` wherever the emitter's own documentation
+  states what a unit this package does not recognize measures. A unit left
+  unclassified is `unknown`, and a diff of it ranks `Increases` and `Decreases`
+  instead of `Regressions` and `Improvements`
+- NEVER call a change the metric does not measure better or worse. A wrong call
+  reads as a finding; an unranked change reads as a number
 
 ### Categorizing
 
@@ -349,6 +362,6 @@ pnpm generate-inputs go ruby   # Limit to named workload scripts
 
 - Use heaps to avoid fully sorting data when possible
 - `src/cli/highlight.ts` heat-tints stdout by re-parsing the emitted Markdown
-  (column headers like `%`, `Delta`, and `Location`, and `name (location)`
-  heading keys), so a change to table or heading structure may require updating
-  it
+  (column headers like `%`, `Delta`, and `Location`, `name (location)` heading
+  keys, and the ranking headings a diff sorts its rows under), so a change to
+  table or heading structure may require updating it

--- a/glossary.md
+++ b/glossary.md
@@ -54,16 +54,17 @@ ambiguous.
 
 ## Costs and functions
 
-| Term         | Definition                                                                                                | Aliases to avoid      |
-| ------------ | --------------------------------------------------------------------------------------------------------- | --------------------- |
-| **Metric**   | A measured dimension with a unit: time, size, or a count (e.g. instructions)                              | dimension, value type |
-| **Value**    | A numeric measurement for one metric, summed across the observations or costs it aggregates               | measurement           |
-| **Self**     | Aggregated from a function's body, excluding its callees                                                  | exclusive             |
-| **Total**    | Aggregated from a function's body and its transitive callees                                              | inclusive, cumulative |
-| **Function** | A unique function, identified by name and location, aggregating every observation or cost recorded for it | node, call frame      |
-| **Caller**   | A function that calls another                                                                             | parent                |
-| **Callee**   | A function another calls                                                                                  | child                 |
-| **Hottest**  | Describes the entities with the highest measure in a call stack profile or call graph                     | top                   |
+| Term                      | Definition                                                                                                | Aliases to avoid      |
+| ------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------- |
+| **Metric**                | A measured dimension with a unit: time, size, or a count (e.g. instructions)                              | dimension, value type |
+| **Improvement direction** | Which direction of change in a metric's value is an improvement: a decrease, an increase, or unknown      | polarity, goodness    |
+| **Value**                 | A numeric measurement for one metric, summed across the observations or costs it aggregates               | measurement           |
+| **Self**                  | Aggregated from a function's body, excluding its callees                                                  | exclusive             |
+| **Total**                 | Aggregated from a function's body and its transitive callees                                              | inclusive, cumulative |
+| **Function**              | A unique function, identified by name and location, aggregating every observation or cost recorded for it | node, call frame      |
+| **Caller**                | A function that calls another                                                                             | parent                |
+| **Callee**                | A function another calls                                                                                  | child                 |
+| **Hottest**               | Describes the entities with the highest measure in a call stack profile or call graph                     | top                   |
 
 ## Call stack profile
 
@@ -118,8 +119,8 @@ ambiguous.
 | **Current**     | The side a diff compares to                                                      | after, new, right   |
 | **Entry match** | Normalized name and location overrides an entry's match key is built from        | match normalization |
 | **Match key**   | The normalized name + location key that pairs an entry across a diff's two sides | id, entry key       |
-| **Regression**  | A diffed entity whose measure worsened from base to current                      | increase            |
-| **Improvement** | A diffed entity whose measure improved from base to current                      | progression         |
+| **Regression**  | A diffed entity whose measure moved against its metric's improvement direction   | increase            |
+| **Improvement** | A diffed entity whose measure moved along its metric's improvement direction     | progression         |
 
 ## Examples and inputs
 
@@ -158,3 +159,6 @@ ambiguous.
   nodes are its **instances**
 - A **diff** pairs each **base** entity with a **current** entity by **match
   key**; an unpaired entity is new or removed
+- A **metric** states its **improvement direction**, by which a **diff** ranks
+  its **regressions** and **improvements**. A **diff** of a **metric** whose
+  direction is unknown ranks increases and decreases instead

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,8 @@ diffs.
   retained sizes, retainer paths, and the largest constructors, functions, and
   strings
 - **Diffing:** ranked regressions and improvements between two profiles or two
-  heap snapshots, ignoring run-varying identifiers like build hashes
+  heap snapshots, ignoring run-varying identifiers like build hashes, and
+  ranking increases and decreases where a metric's unit states neither as better
 - **Source maps:** resolves minified and transpiled locations back to original
   sources
 - **Zero config:** auto-detects the format and profiler, decompresses

--- a/src/cli/highlight.test.ts
+++ b/src/cli/highlight.test.ts
@@ -510,6 +510,117 @@ describe(`diff table intensity`, () => {
     expect(maxRed(highlighted, 2)).toBe(defaultRowRed)
   })
 
+  /** A diff table under {@link ranking}'s heading, as a diff's rankings are. */
+  const rankingSection = (ranking: string, rows: string[]): string =>
+    [`#### ${ranking}`, ``, diffTable(rows)].join(`\n`)
+
+  test(`a decrease under Regressions is red-tinted`, async () => {
+    // A metric a higher value is better for ranks its decreases as
+    // regressions, and a regression is red however its delta is signed.
+    const highlighted = await highlight(
+      rankingSection(`Regressions`, [`| -50.0%  |  -16ms  | 3.2% → 1.6% |`]),
+      highlightMarkdownOptions,
+    )
+
+    expect(maxRed(highlighted, 4)).toBe(215)
+  })
+
+  test(`an increase under Improvements is green-tinted`, async () => {
+    const highlighted = await highlight(
+      rankingSection(`Improvements`, [`| +100.0% |  +16ms  | 1.6% → 3.2% |`]),
+      highlightMarkdownOptions,
+    )
+
+    expect(maxGreen(highlighted, 4)).toBe(203)
+  })
+
+  test(`rows under Increases and Decreases are untinted`, async () => {
+    // The metric's improvement direction is unknown, so neither ranking's rows
+    // are colored as better or worse.
+    const highlighted = await highlight(
+      [
+        rankingSection(`Increases`, [`| +100.0% |  +16ms  | 1.6% → 3.2% |`]),
+        rankingSection(`Decreases`, [`| -50.0%  |  -16ms  | 3.2% → 1.6% |`]),
+      ].join(`\n\n`),
+      highlightMarkdownOptions,
+    )
+
+    expect(maxRed(highlighted, 4)).toBe(defaultRowRed)
+    expect(maxGreen(highlighted, 10)).toBe(defaultRowGreen)
+  })
+
+  test(`a summary table is untinted in a document whose metric's improvement direction is unknown`, async () => {
+    // No ranking heading covers the summary table, and the document's
+    // `Increases` heading states that its changes are neither better nor worse.
+    const highlighted = await highlight(
+      [
+        `# Weight profile diff`,
+        ``,
+        diffTable([`| +100.0% |  +16ms  | 1.6% → 3.2% |`]),
+        ``,
+        rankingSection(`Increases`, [`| +100.0% |  +16ms  | 1.6% → 3.2% |`]),
+      ].join(`\n`),
+      highlightMarkdownOptions,
+    )
+
+    expect(maxRed(highlighted, 4)).toBe(defaultRowRed)
+  })
+
+  test(`a summary table is tinted by what its profile's rankings call an increase`, async () => {
+    // The `Regressions` ranking covers a decrease, so a decrease is a
+    // regression throughout the profile, including in the summary table above
+    // it that no ranking heading covers.
+    const highlighted = await highlight(
+      [
+        `# Throughput profile diff`,
+        ``,
+        diffTable([`| -50.0%  |  -16ms  | 3.2% → 1.6% |`]),
+        ``,
+        rankingSection(`Regressions`, [`| -50.0%  |  -16ms  | 3.2% → 1.6% |`]),
+      ].join(`\n`),
+      highlightMarkdownOptions,
+    )
+
+    expect(maxRed(highlighted, 4)).toBe(215)
+  })
+
+  test(`each profile's summary table takes what its own rankings call an increase`, async () => {
+    const highlighted = await highlight(
+      [
+        `# Throughput profile diff`,
+        ``,
+        diffTable([`| -50.0%  |  -16ms  | 3.2% → 1.6% |`]),
+        ``,
+        rankingSection(`Regressions`, [`| -50.0%  |  -16ms  | 3.2% → 1.6% |`]),
+        ``,
+        `# CPU profile diff`,
+        ``,
+        diffTable([`| -50.0%  |  -16ms  | 3.2% → 1.6% |`]),
+        ``,
+        rankingSection(`Regressions`, [`| +100.0% |  +16ms  | 1.6% → 3.2% |`]),
+      ].join(`\n`),
+      highlightMarkdownOptions,
+    )
+
+    expect(maxRed(highlighted, 4)).toBe(215)
+    expect(maxGreen(highlighted, 16)).toBe(203)
+  })
+
+  test(`a summary table with no ranking after it is tinted by the sign of its deltas`, async () => {
+    const highlighted = await highlight(
+      [
+        `# CPU profile diff`,
+        ``,
+        diffTable([`| -50.0%  |  -16ms  | 3.2% → 1.6% |`]),
+        ``,
+        `No function differed in time spent.`,
+      ].join(`\n`),
+      highlightMarkdownOptions,
+    )
+
+    expect(maxGreen(highlighted, 4)).toBe(203)
+  })
+
   test(`diff table rows don't propagate intensity to matching headings`, async () => {
     const markdown = [
       `### Regressions`,

--- a/src/cli/highlight.ts
+++ b/src/cli/highlight.ts
@@ -88,17 +88,109 @@ const computeLineToIntensity = async (
 
   const lineToIntensity = new Map<number, number>()
   const sections: HeadingSection[] = []
+  const unranked: UnrankedDiffRows = { rows: [], increaseSign: null }
   for (const node of root.children) {
     if (node.type === `heading`) {
-      visitHeading(node, sections, lineToIntensity)
+      visitHeading(node, sections, unranked, lineToIntensity)
     } else if (node.type === `table`) {
       // Tables cannot cross heading boundaries, so the innermost section is
       // still current when the table is reached.
-      visitTable(node, sections.at(-1), lineToIntensity)
+      visitTable(node, sections.at(-1), unranked, lineToIntensity)
     }
   }
+  tintHeldRows(unranked, lineToIntensity)
 
   return lineToIntensity
+}
+
+/**
+ * What a diff row's change is: `1` where it is a regression, `-1` where it is
+ * an improvement, and `0` where its metric's improvement direction is unknown,
+ * so the ranking covering it calls it neither.
+ */
+type RegressionSign = 1 | -1 | 0
+
+/**
+ * The regression sign each ranking heading a diff emits states about the rows
+ * under it, whatever the sign of their deltas.
+ */
+const RANKING_REGRESSION_SIGNS: ReadonlyMap<string, RegressionSign> = new Map([
+  [`Regressions`, 1],
+  [`Improvements`, -1],
+  [`Increases`, 0],
+  [`Decreases`, 0],
+])
+
+/**
+ * What an increase is in a profile whose rankings state nothing about one,
+ * which happens when no ranking has rows to state it with. A profiler records
+ * what a program consumed, so an increase is a regression.
+ */
+const DEFAULT_INCREASE_SIGN: RegressionSign = 1
+
+/**
+ * The diff rows no ranking heading covers, which is every summary table, held
+ * until the profile's rankings state what an increase in it is. A summary table
+ * precedes the rankings measuring the same thing, so its rows are tinted once
+ * those rankings are reached.
+ */
+type UnrankedDiffRows = {
+  rows: RelativeDiffRow[]
+
+  /** The regression sign of an increase, null until a ranking states it. */
+  increaseSign: RegressionSign | null
+}
+
+/** One diff row's line and its delta as a share of the profile total. */
+type RelativeDiffRow = { lineIndex: number; relativeDelta: number }
+
+/**
+ * Holds {@link rows} until a ranking states what an increase is, or tints them
+ * where one already has.
+ */
+const holdRows = (
+  unranked: UnrankedDiffRows,
+  rows: RelativeDiffRow[],
+  lineToIntensity: Map<number, number>,
+): void => {
+  unranked.rows.push(...rows)
+  if (unranked.increaseSign !== null) {
+    tintHeldRows(unranked, lineToIntensity)
+  }
+}
+
+/**
+ * Records what a ranking states an increase is, tinting the rows held for it. A
+ * ranking with no row to state it passes null, leaving the held rows for a
+ * later one.
+ */
+const stateIncreaseSign = (
+  unranked: UnrankedDiffRows,
+  increaseSign: RegressionSign | null,
+  lineToIntensity: Map<number, number>,
+): void => {
+  if (increaseSign === null) {
+    return
+  }
+  unranked.increaseSign = increaseSign
+  tintHeldRows(unranked, lineToIntensity)
+}
+
+/**
+ * Tints the held rows by what the profile's rankings stated an increase is, or
+ * by the sign of their deltas where the rankings stated nothing.
+ */
+const tintHeldRows = (
+  unranked: UnrankedDiffRows,
+  lineToIntensity: Map<number, number>,
+): void => {
+  const increaseSign = unranked.increaseSign ?? DEFAULT_INCREASE_SIGN
+  if (increaseSign !== 0) {
+    for (const { lineIndex, relativeDelta } of unranked.rows) {
+      setIntensity(lineToIntensity, lineIndex, increaseSign * relativeDelta)
+    }
+  }
+  unranked.rows.length = 0
 }
 
 type HeadingSection = {
@@ -113,6 +205,12 @@ type HeadingSection = {
 
   /** Maps `name (location)` keys to intensities for child heading lookups. */
   nameLocationToIntensity: Map<string, NameIntensity>
+
+  /**
+   * The regression sign of this scope's diff rows, from the nearest ranking
+   * heading at or above it, or null where no ranking heading covers them.
+   */
+  regressionSign: RegressionSign | null
 }
 
 /**
@@ -127,9 +225,22 @@ type NameIntensity = {
 const visitHeading = (
   heading: Heading,
   sections: HeadingSection[],
+  unranked: UnrankedDiffRows,
   lineToIntensity: Map<number, number>,
 ): void => {
   closeDeeperSections(sections, heading.depth)
+
+  const rankingSign = RANKING_REGRESSION_SIGNS.get(nodeText(heading))
+  if (heading.depth === PROFILE_HEADING_DEPTH) {
+    // Each profile's rankings state what an increase is in its own metric, so
+    // the rows held for the profile above take what its rankings stated.
+    tintHeldRows(unranked, lineToIntensity)
+    unranked.increaseSign = null
+  } else if (rankingSign === 0) {
+    // A ranking naming the change itself states that the metric's improvement
+    // direction is unknown, whatever rows it covers.
+    stateIncreaseSign(unranked, 0, lineToIntensity)
+  }
 
   const key = headingNameLocationKey(heading)
   const intensity = key === null ? null : lookupAncestorIntensity(sections, key)
@@ -137,12 +248,16 @@ const visitHeading = (
     level: heading.depth,
     intensity,
     nameLocationToIntensity: new Map(),
+    regressionSign: rankingSign ?? sections.at(-1)?.regressionSign ?? null,
   })
   if (intensity !== null) {
     // ATX headings, the only kind the serializer emits, are single-line.
     lineToIntensity.set(heading.position!.start.line - 1, intensity)
   }
 }
+
+/** The heading level opening one profile's section of the output. */
+const PROFILE_HEADING_DEPTH = 1
 
 /**
  * Closes the heading sections at or deeper than {@link depth}. e.g. an H3
@@ -210,6 +325,7 @@ const lookupAncestorIntensity = (
 const visitTable = (
   table: Table,
   headingSection: HeadingSection | undefined,
+  unranked: UnrankedDiffRows,
   lineToIntensity: Map<number, number>,
 ): void => {
   const [headerRow, ...dataRows] = table.children
@@ -230,44 +346,73 @@ const visitTable = (
         delta: deltaColumnIndex,
         percent: percentColumnIndex,
       },
+      headingSection?.regressionSign ?? null,
+      unranked,
       lineToIntensity,
     )
   } else if (percentColumnIndex !== -1) {
-    // Column index of the backtick-quoted name cell, lazily detected from the
-    // first data row that has one.
-    let nameColumnIndex = -1
+    visitPercentTable(
+      dataRows,
+      { percent: percentColumnIndex, location: locationColumnIndex },
+      headingSection,
+      lineToIntensity,
+    )
+  }
+}
 
-    for (const row of dataRows) {
-      const cells = row.children
-      const percentageCell = cells[percentColumnIndex]
-      if (percentageCell === undefined) {
-        continue
-      }
-      const percentage = parsePercent(nodeText(percentageCell))
-      if (percentage === null) {
-        continue
-      }
+type PercentColumnIndexes = {
+  percent: number
+  location: number
+}
 
-      const intensity = (headingSection?.intensity ?? 1) * percentage
-      if (locationColumnIndex !== -1 && headingSection !== undefined) {
-        if (nameColumnIndex === -1) {
-          nameColumnIndex = cells.findIndex(
-            cell =>
-              cell.children.length === 1 &&
-              cell.children[0]!.type === `inlineCode`,
-          )
-        }
-        const nameCell = cells[nameColumnIndex]
-        const locationCell = cells[locationColumnIndex]
-        if (nameCell !== undefined && locationCell !== undefined) {
-          headingSection.nameLocationToIntensity.set(
-            nameLocationKey(nodeText(nameCell), nodeText(locationCell)),
-            { intensity, registeredLevel: headingSection.level },
-          )
-        }
-      }
-      lineToIntensity.set(row.position!.start.line - 1, intensity)
+/**
+ * Tints each row by its `%` cell, scaled by the intensity its heading section
+ * inherited, so a row's tint is proportional to its share of the profile.
+ *
+ * A row naming a function registers its intensity under the section's
+ * `name (location)` key, from which a later heading for that function takes its
+ * own tint.
+ */
+const visitPercentTable = (
+  dataRows: Table[`children`],
+  columnIndexes: PercentColumnIndexes,
+  headingSection: HeadingSection | undefined,
+  lineToIntensity: Map<number, number>,
+): void => {
+  // Column index of the backtick-quoted name cell, lazily detected from the
+  // first data row that has one.
+  let nameColumnIndex = -1
+
+  for (const row of dataRows) {
+    const cells = row.children
+    const percentageCell = cells[columnIndexes.percent]
+    if (percentageCell === undefined) {
+      continue
     }
+    const percentage = parsePercent(nodeText(percentageCell))
+    if (percentage === null) {
+      continue
+    }
+
+    const intensity = (headingSection?.intensity ?? 1) * percentage
+    if (columnIndexes.location !== -1 && headingSection !== undefined) {
+      if (nameColumnIndex === -1) {
+        nameColumnIndex = cells.findIndex(
+          cell =>
+            cell.children.length === 1 &&
+            cell.children[0]!.type === `inlineCode`,
+        )
+      }
+      const nameCell = cells[nameColumnIndex]
+      const locationCell = cells[columnIndexes.location]
+      if (nameCell !== undefined && locationCell !== undefined) {
+        headingSection.nameLocationToIntensity.set(
+          nameLocationKey(nodeText(nameCell), nodeText(locationCell)),
+          { intensity, registeredLevel: headingSection.level },
+        )
+      }
+    }
+    lineToIntensity.set(row.position!.start.line - 1, intensity)
   }
 }
 
@@ -282,6 +427,71 @@ type DiffColumnIndexes = {
  * absolute scale non-diff tables get from their `%` column, so a row's tint is
  * proportional to how much of the profile its change moved.
  *
+ * A row is tinted red where its change is a regression and green where it is an
+ * improvement, which {@link regressionSign} states for the rows a ranking
+ * heading covers. Where a ranking calls a change neither, the rows stay
+ * untinted. Rows no ranking covers are held until a ranking states what an
+ * increase is, which its own rows reveal: the delta sign a `Regressions`
+ * heading covers is the sign a regression has throughout the profile.
+ */
+const visitDiffTable = (
+  dataRows: Table[`children`],
+  columnIndexes: DiffColumnIndexes,
+  regressionSign: RegressionSign | null,
+  unranked: UnrankedDiffRows,
+  lineToIntensity: Map<number, number>,
+): void => {
+  if (regressionSign === 0) {
+    return
+  }
+
+  const rows = relativeDiffRows(dataRows, columnIndexes)
+  if (regressionSign === null) {
+    holdRows(unranked, rows, lineToIntensity)
+    return
+  }
+
+  stateIncreaseSign(
+    unranked,
+    statedIncreaseSign(rows, regressionSign),
+    lineToIntensity,
+  )
+  for (const { lineIndex, relativeDelta } of rows) {
+    setIntensity(
+      lineToIntensity,
+      lineIndex,
+      regressionSign * Math.abs(relativeDelta),
+    )
+  }
+}
+
+/**
+ * What a ranking's rows state an increase is: a regression where the ranking
+ * calls a positive delta one, or null where the ranking has no changed row to
+ * state it with.
+ */
+const statedIncreaseSign = (
+  rows: readonly RelativeDiffRow[],
+  regressionSign: 1 | -1,
+): RegressionSign | null => {
+  const row = rows.find(({ relativeDelta }) => relativeDelta !== 0)
+  return row === undefined
+    ? null
+    : ((regressionSign * Math.sign(row.relativeDelta)) as RegressionSign)
+}
+
+const setIntensity = (
+  lineToIntensity: Map<number, number>,
+  lineIndex: number,
+  intensity: number,
+): void => {
+  lineToIntensity.set(lineIndex, Math.max(-1, Math.min(1, intensity)))
+}
+
+/**
+ * Reads a diff table's changed rows into their line indexes and their deltas as
+ * shares of the profile total, or an empty array where no row implies a total.
+ *
  * The total isn't printed, but each row implies it: `Change` is
  * `delta ÷ base value` and `%` holds the base and current shares of their
  * totals, so `|delta ÷ Change| ÷ base%` recovers the base total (for `new` and
@@ -289,12 +499,11 @@ type DiffColumnIndexes = {
  * estimate divides by rounded percentages, so take it from the row with the
  * largest share, where rounding error is proportionally smallest.
  */
-const visitDiffTable = (
+const relativeDiffRows = (
   dataRows: Table[`children`],
   columnIndexes: DiffColumnIndexes,
-  lineToIntensity: Map<number, number>,
-): void => {
-  const pendingDiffRows: PendingDiffRow[] = []
+): RelativeDiffRow[] => {
+  const changedRows: { lineIndex: number; delta: number }[] = []
   let bestCandidate: TotalCandidate | null = null
   for (const row of dataRows) {
     const diffRow = parseDiffRow(row, columnIndexes)
@@ -302,10 +511,7 @@ const visitDiffTable = (
       continue
     }
     if (diffRow.delta !== 0) {
-      pendingDiffRows.push({
-        lineIndex: diffRow.lineIndex,
-        delta: diffRow.delta,
-      })
+      changedRows.push({ lineIndex: diffRow.lineIndex, delta: diffRow.delta })
     }
     if (
       diffRow.candidate !== null &&
@@ -315,16 +521,15 @@ const visitDiffTable = (
     }
   }
   if (bestCandidate === null) {
-    return
+    return []
   }
 
   const total = bestCandidate.value / bestCandidate.percent
-  for (const { lineIndex, delta } of pendingDiffRows) {
-    lineToIntensity.set(lineIndex, Math.max(-1, Math.min(1, delta / total)))
-  }
+  return changedRows.map(({ lineIndex, delta }) => ({
+    lineIndex,
+    relativeDelta: delta / total,
+  }))
 }
-
-type PendingDiffRow = { lineIndex: number; delta: number }
 
 /**
  * Reads one diff row's cells into its line index, parsed delta, and

--- a/src/formats/callgrind/index.test.ts
+++ b/src/formats/callgrind/index.test.ts
@@ -18,11 +18,10 @@ import {
   categorySectionTables,
   categoryTables,
   diffRankingTable,
-  improvementsTables,
   linesTables,
   profileTitles,
   rankingTable,
-  regressionsTables,
+  rankingTables,
   summaryLines,
 } from '../../testing.ts'
 import { convertBytesToMd, convertToMdAsync } from '../testing.ts'
@@ -1078,7 +1077,7 @@ describe(`convert`, () => {
     expect(summaryLines(md)).toEqual([
       `Recorded 300 instructions → 380 instructions (+80 instructions, +26.7%).`,
     ])
-    expect(regressionsTables(md, `Self instructions`)).toEqual([
+    expect(rankingTables(md, `Self instructions`, `Regressions`)).toEqual([
       [
         {
           Change: `+50.0%`,
@@ -1090,7 +1089,7 @@ describe(`convert`, () => {
         },
       ],
     ])
-    expect(improvementsTables(md, `Self instructions`)).toEqual([
+    expect(rankingTables(md, `Self instructions`, `Improvements`)).toEqual([
       [
         {
           Change: `-20.0%`,

--- a/src/formats/callgrind/parse.ts
+++ b/src/formats/callgrind/parse.ts
@@ -710,7 +710,9 @@ const callgrindEventMetric = (
 
   const singular = KNOWN_EVENTS.get(name)
   if (singular) {
-    return countMetricOf(singular)
+    // Each known event counts work the program made the machine do, so fewer
+    // is an improvement.
+    return countMetricOf(singular, { improvement: `decrease` })
   }
 
   const displayName = longName ?? name

--- a/src/formats/index.test.ts
+++ b/src/formats/index.test.ts
@@ -10,12 +10,7 @@ import {
 } from '../modalities/call-stack-profile/testing.ts'
 import { SAMPLES } from '../modalities/metrics.ts'
 import { normalizeProfileToMdOptions } from '../options.ts'
-import {
-  categoryTables,
-  improvementsTables,
-  profileTitles,
-  regressionsTables,
-} from '../testing.ts'
+import { categoryTables, profileTitles, rankingTables } from '../testing.ts'
 import type { JsonFormatConverter } from './converter.ts'
 import { FormatDetectError } from './error.ts'
 import {
@@ -909,10 +904,14 @@ describe(`diffProfiles`, () => {
         Function: `funcB`,
         Location: `src/b.ts:1:1`,
       }
-      expect(regressionsTables(md, `Self time`)).toEqual([[funcA, funcC]])
-      expect(improvementsTables(md, `Self time`)).toEqual([[funcB]])
-      expect(regressionsTables(md, `Total time`)).toEqual([[funcA, funcC]])
-      expect(improvementsTables(md, `Total time`)).toEqual([[funcB]])
+      expect(rankingTables(md, `Self time`, `Regressions`)).toEqual([
+        [funcA, funcC],
+      ])
+      expect(rankingTables(md, `Self time`, `Improvements`)).toEqual([[funcB]])
+      expect(rankingTables(md, `Total time`, `Regressions`)).toEqual([
+        [funcA, funcC],
+      ])
+      expect(rankingTables(md, `Total time`, `Improvements`)).toEqual([[funcB]])
     })
 
     test(`baseURL: 'auto' infers one common ancestor across both diff sides`, () => {
@@ -941,7 +940,7 @@ describe(`diffProfiles`, () => {
         { baseURL: `auto` },
       )
 
-      expect(regressionsTables(md, `Self time`)).toEqual([
+      expect(rankingTables(md, `Self time`, `Regressions`)).toEqual([
         [
           {
             Change: `new`,
@@ -954,7 +953,7 @@ describe(`diffProfiles`, () => {
           },
         ],
       ])
-      expect(improvementsTables(md, `Self time`)).toEqual([
+      expect(rankingTables(md, `Self time`, `Improvements`)).toEqual([
         [
           {
             Change: `removed`,
@@ -1022,10 +1021,18 @@ describe(`diffProfiles`, () => {
         Instances: `1 → 0`,
         Constructor: `Removed`,
       }
-      expect(regressionsTables(md, `Self size`)).toEqual([[grew, added]])
-      expect(improvementsTables(md, `Self size`)).toEqual([[removed]])
-      expect(regressionsTables(md, `Retained size`)).toEqual([[grew, added]])
-      expect(improvementsTables(md, `Retained size`)).toEqual([[removed]])
+      expect(rankingTables(md, `Self size`, `Regressions`)).toEqual([
+        [grew, added],
+      ])
+      expect(rankingTables(md, `Self size`, `Improvements`)).toEqual([
+        [removed],
+      ])
+      expect(rankingTables(md, `Retained size`, `Regressions`)).toEqual([
+        [grew, added],
+      ])
+      expect(rankingTables(md, `Retained size`, `Improvements`)).toEqual([
+        [removed],
+      ])
     })
 
     // The default `matchEntry`'s origin-aware normalization (stripping an
@@ -1080,7 +1087,7 @@ describe(`diffProfiles`, () => {
         },
       )
 
-      expect(regressionsTables(md, `Self time`)).toEqual([
+      expect(rankingTables(md, `Self time`, `Regressions`)).toEqual([
         [
           {
             Change: `+100.0%`,
@@ -1093,7 +1100,7 @@ describe(`diffProfiles`, () => {
           },
         ],
       ])
-      expect(improvementsTables(md, `Self time`)).toEqual([])
+      expect(rankingTables(md, `Self time`, `Improvements`)).toEqual([])
     })
 
     test(`reports when there is no profiling data`, () => {

--- a/src/formats/jfr/parse.ts
+++ b/src/formats/jfr/parse.ts
@@ -271,10 +271,10 @@ function* kindObservations(
 }
 
 /** One object sampled at allocation and still live when the recording ended. */
-const OBJECTS = countMetricOf(`object`)
+const OBJECTS = countMetricOf(`object`, { improvement: `decrease` })
 
 /** One acquisition of a contended monitor, or one park. */
-const CONTENTIONS = countMetricOf(`contention`)
+const CONTENTIONS = countMetricOf(`contention`, { improvement: `decrease` })
 
 /**
  * The metric and count metric for each sample kind, in the order profiles are

--- a/src/formats/memray/index.test.ts
+++ b/src/formats/memray/index.test.ts
@@ -8,10 +8,9 @@ import {
 import { normalizeProfileToMdOptions } from '../../options.ts'
 import {
   categoryTables,
-  improvementsTables,
   linesTables,
   profileTitles,
-  regressionsTables,
+  rankingTables,
   summaryLines,
 } from '../../testing.ts'
 import { convertBytesToMd, convertToMdAsync } from '../testing.ts'
@@ -806,8 +805,8 @@ describe(`convert`, () => {
       `Held 29\u00A0B over 1 allocation → 7 allocations (29\u00A0B → 4.14\u00A0B per allocation).`,
       `Leaked 29\u00A0B over 1 allocation → 7 allocations (29\u00A0B → 4.14\u00A0B per allocation).`,
     ])
-    expect(regressionsTables(md, `Self size`)).toEqual([])
-    expect(improvementsTables(md, `Self size`)).toEqual([])
+    expect(rankingTables(md, `Self size`, `Regressions`)).toEqual([])
+    expect(rankingTables(md, `Self size`, `Improvements`)).toEqual([])
   })
 
   test(`converts a compressed capture from a stream`, async () => {

--- a/src/formats/memray/parse.ts
+++ b/src/formats/memray/parse.ts
@@ -1157,7 +1157,7 @@ const hashAddress = (address: number): number =>
  * Memray hooks the allocator, so a stack's count is the number of allocations
  * recorded for it rather than a number of samples.
  */
-const ALLOCATIONS = countMetricOf(`allocation`)
+const ALLOCATIONS = countMetricOf(`allocation`, { improvement: `decrease` })
 
 /**
  * Returns the 1-based line {@link instructionOffset} is on, from the code

--- a/src/formats/pprof/parse.ts
+++ b/src/formats/pprof/parse.ts
@@ -176,7 +176,11 @@ const countedAs = (type: string): CountMetric | undefined => {
     return SAMPLES
   }
   const noun = COUNT_TYPE_NOUNS.get(name)
-  return noun === undefined ? undefined : countMetricOf(noun)
+  // Every name in the table counts something the profiled program spends,
+  // allocates, or blocks on, so fewer is an improvement.
+  return noun === undefined
+    ? undefined
+    : countMetricOf(noun, { improvement: `decrease` })
 }
 
 /** The type names for a count of call stack samples. */

--- a/src/formats/v8/heap-snapshot/index.test.ts
+++ b/src/formats/v8/heap-snapshot/index.test.ts
@@ -6,11 +6,7 @@ import {
   selfSizeTables,
 } from '../../../modalities/heap-snapshot/testing.ts'
 import { normalizeProfileToMdOptions } from '../../../options.ts'
-import {
-  categoryTables,
-  improvementsTables,
-  regressionsTables,
-} from '../../../testing.ts'
+import { categoryTables, rankingTables } from '../../../testing.ts'
 import { diffProfiles } from '../../index.ts'
 import { convertJsonToMd } from '../../testing.ts'
 import { v8HeapSnapshotConverter } from './index.ts'
@@ -418,15 +414,19 @@ describe(`convert`, () => {
       Location: `src/a-111.ts:6:11`,
       'Example path': `(GC root)`,
     }
-    expect(regressionsTables(unmatchedMd, `Largest functions`)).toEqual([
-      [newFunction],
-    ])
-    expect(improvementsTables(unmatchedMd, `Largest functions`)).toEqual([
-      [removedFunction],
-    ])
+    expect(
+      rankingTables(unmatchedMd, `Largest functions`, `Regressions`),
+    ).toEqual([[newFunction]])
+    expect(
+      rankingTables(unmatchedMd, `Largest functions`, `Improvements`),
+    ).toEqual([[removedFunction]])
     // With the hook the function matches across the snapshots and has no delta.
-    expect(regressionsTables(matchedMd, `Largest functions`)).toEqual([])
-    expect(improvementsTables(matchedMd, `Largest functions`)).toEqual([])
+    expect(
+      rankingTables(matchedMd, `Largest functions`, `Regressions`),
+    ).toEqual([])
+    expect(
+      rankingTables(matchedMd, `Largest functions`, `Improvements`),
+    ).toEqual([])
   })
 
   test(`weak edges are not followed for retainer paths`, () => {

--- a/src/modalities/call-graph/format.ts
+++ b/src/modalities/call-graph/format.ts
@@ -587,7 +587,7 @@ const formatDiffFunctions = ({
   )
 }
 
-/** The Self or Total regressions/improvements subsections of a diff. */
+/** The Self or Total diff subsections ranking each direction of change. */
 const formatDiffDirectionFunctions = ({
   diff,
   measure,
@@ -612,7 +612,7 @@ const formatDiffDirectionFunctions = ({
       ? 0
       : (direction === `self` ? func.selfValues : func.totalValues)[index]!
 
-  const { regressions, improvements, hasActive, categoryRankings } =
+  const { increases, decreases, hasActive, categoryRankings } =
     selectDiffEntities(
       diff.functions.map(func => ({
         entity: func,
@@ -653,10 +653,11 @@ const formatDiffDirectionFunctions = ({
     headingLevel,
     title,
     description,
+    improvement: metric.improvement,
     columns: functionColumns(metric, `Function`, options),
     hasActive,
-    regressions,
-    improvements,
+    increases,
+    decreases,
     categoryRankings,
     rowOf: ({ entity }) => rowOf(entity),
   })

--- a/src/modalities/call-stack-profile/diff.test.ts
+++ b/src/modalities/call-stack-profile/diff.test.ts
@@ -184,7 +184,7 @@ describe(`diffAggregatedCallStackProfiles`, () => {
       [],
       [func],
       undefined,
-      countMetricOf(`entry`),
+      countMetricOf(`entry`, { improvement: `decrease` }),
     )
 
     expect(() =>
@@ -209,7 +209,7 @@ describe(`diffAggregatedCallStackProfiles`, () => {
       [BYTES_METRIC],
       [func],
       undefined,
-      countMetricOf(`entry`),
+      countMetricOf(`entry`, { improvement: `decrease` }),
     )
 
     expect(

--- a/src/modalities/call-stack-profile/format.test.ts
+++ b/src/modalities/call-stack-profile/format.test.ts
@@ -6,18 +6,19 @@ import {
   categorySectionTables,
   categoryTables,
   diffRankingTable,
-  improvementsTables,
   profileTitles,
   rankingTable,
-  regressionsTables,
+  rankingTables,
   resolveProfileToMdOptions,
   summaryLines,
 } from '../../testing.ts'
 import { countMetricOf } from '../metric.ts'
+import type { Metric } from '../metric.ts'
 import {
   BYTES_METRIC,
   MEGABYTES_METRIC,
   MICROSECONDS_METRIC,
+  parseMetric,
   RETAINED_HEAP_METRIC,
 } from '../metrics.ts'
 import { diffAggregatedCallStackProfiles } from './diff.ts'
@@ -36,6 +37,44 @@ const defaultOptions = resolveProfileToMdOptions({ baseURL: `/project` })
  * contains a hidden frame.
  */
 const ELLIPSIS_NOTE = `\`…\` stands for frames the entry filter hides.`
+
+/**
+ * A diff in {@link metric} of one function whose value doubled and one whose
+ * value fell, so both of its rankings have a row.
+ */
+const formatDiffOfMetric = (metric: Metric): string => {
+  const profileOf = (funcAValue: number, funcBValue: number) =>
+    makeAggregatedCallStackProfile(
+      [metric],
+      [
+        {
+          name: `funcA`,
+          url: `file:///project/src/a.ts`,
+          line: 10,
+          selfCount: funcAValue / 20,
+          selfValues: [funcAValue],
+        },
+        {
+          name: `funcB`,
+          url: `file:///project/src/b.ts`,
+          line: 20,
+          selfCount: funcBValue / 20,
+          selfValues: [funcBValue],
+        },
+      ],
+    )
+
+  return mdastToMarkdown(
+    formatCallStackProfileDiff(
+      diffAggregatedCallStackProfiles(
+        profileOf(100, 60),
+        profileOf(200, 20),
+        defaultOptions,
+      ),
+      defaultOptions,
+    ),
+  )
+}
 
 describe(`formatCallStackProfile`, () => {
   test(`omits zero-valued call stacks from the hottest call stacks table`, () => {
@@ -727,7 +766,7 @@ describe(`formatCallStackProfile`, () => {
         },
       ],
       undefined,
-      countMetricOf(`entry`),
+      countMetricOf(`entry`, { improvement: `decrease` }),
     )
 
     const md = mdastToMarkdown(formatCallStackProfile(profile, defaultOptions))
@@ -752,7 +791,7 @@ describe(`formatCallStackProfile`, () => {
         },
       ],
       undefined,
-      countMetricOf(`goroutine`),
+      countMetricOf(`goroutine`, { improvement: `decrease` }),
     )
 
     const md = mdastToMarkdown(formatCallStackProfile(profile, defaultOptions))
@@ -867,7 +906,7 @@ describe(`formatCallStackProfileDiff`, () => {
       [BYTES_METRIC],
       [],
       undefined,
-      countMetricOf(`object`),
+      countMetricOf(`object`, { improvement: `decrease` }),
     )
     const current = makeAggregatedCallStackProfile(
       [BYTES_METRIC],
@@ -880,7 +919,7 @@ describe(`formatCallStackProfileDiff`, () => {
         },
       ],
       undefined,
-      countMetricOf(`object`),
+      countMetricOf(`object`, { improvement: `decrease` }),
     )
 
     const diff = diffAggregatedCallStackProfiles(base, current, defaultOptions)
@@ -1009,10 +1048,102 @@ describe(`formatCallStackProfileDiff`, () => {
       },
     ]
 
-    expect(regressionsTables(md, `Self time`)).toEqual([expectedRegressions])
-    expect(improvementsTables(md, `Self time`)).toEqual([expectedImprovements])
-    expect(regressionsTables(md, `Total time`)).toEqual([expectedRegressions])
-    expect(improvementsTables(md, `Total time`)).toEqual([expectedImprovements])
+    expect(rankingTables(md, `Self time`, `Regressions`)).toEqual([
+      expectedRegressions,
+    ])
+    expect(rankingTables(md, `Self time`, `Improvements`)).toEqual([
+      expectedImprovements,
+    ])
+    expect(rankingTables(md, `Total time`, `Regressions`)).toEqual([
+      expectedRegressions,
+    ])
+    expect(rankingTables(md, `Total time`, `Improvements`)).toEqual([
+      expectedImprovements,
+    ])
+  })
+
+  test(`names each ranking after its change when the metric's improvement direction is unknown`, () => {
+    const md = formatDiffOfMetric(
+      parseMetric({ name: `weight`, unit: `weight` }),
+    )
+
+    expect(rankingTables(md, `Self weight`, `Increases`)).toEqual([
+      [
+        {
+          Change: `+100.0%`,
+          Delta: `+100`,
+          '%': `62.5% → 90.9%`,
+          Weight: `100 → 200`,
+          Samples: `5 → 10`,
+          Function: `funcA`,
+          Location: `src/a.ts:10`,
+        },
+      ],
+    ])
+    expect(rankingTables(md, `Self weight`, `Decreases`)).toEqual([
+      [
+        {
+          Change: `-66.7%`,
+          Delta: `-40`,
+          '%': `37.5% → 9.1%`,
+          Weight: `60 → 20`,
+          Samples: `3 → 1`,
+          Function: `funcB`,
+          Location: `src/b.ts:20`,
+        },
+      ],
+    ])
+    expect(rankingTables(md, `Self weight`, `Regressions`)).toEqual([])
+    expect(rankingTables(md, `Self weight`, `Improvements`)).toEqual([])
+    expect(md).toContain(
+      `Functions with the largest increase in weight recorded directly in the function body, excluding callees.`,
+    )
+    expect(md.indexOf(`#### Increases`)).toBeLessThan(
+      md.indexOf(`#### Decreases`),
+    )
+  })
+
+  test(`ranks a decrease as a regression when a higher value is an improvement`, () => {
+    const md = formatDiffOfMetric(
+      parseMetric({
+        name: `request`,
+        unit: `request`,
+        improvement: `increase`,
+      }),
+    )
+
+    expect(rankingTables(md, `Self request`, `Regressions`)).toEqual([
+      [
+        {
+          Change: `-66.7%`,
+          Delta: `-40`,
+          '%': `37.5% → 9.1%`,
+          Request: `60 → 20`,
+          Samples: `3 → 1`,
+          Function: `funcB`,
+          Location: `src/b.ts:20`,
+        },
+      ],
+    ])
+    expect(rankingTables(md, `Self request`, `Improvements`)).toEqual([
+      [
+        {
+          Change: `+100.0%`,
+          Delta: `+100`,
+          '%': `62.5% → 90.9%`,
+          Request: `100 → 200`,
+          Samples: `5 → 10`,
+          Function: `funcA`,
+          Location: `src/a.ts:10`,
+        },
+      ],
+    ])
+    expect(md).toContain(
+      `Functions with the largest decrease in request recorded directly in the function body, excluding callees.`,
+    )
+    expect(md.indexOf(`#### Regressions`)).toBeLessThan(
+      md.indexOf(`#### Improvements`),
+    )
   })
 
   test(`omits functions hidden by showEntry without hiding functions from the other profile`, () => {
@@ -1066,7 +1197,7 @@ describe(`formatCallStackProfileDiff`, () => {
     const md = mdastToMarkdown(formatCallStackProfileDiff(diff, options))
 
     expect(md).not.toContain(`funcB`)
-    expect(regressionsTables(md, `Self time`)).toEqual([
+    expect(rankingTables(md, `Self time`, `Regressions`)).toEqual([
       [
         {
           Change: `+100.0%`,
@@ -1088,7 +1219,7 @@ describe(`formatCallStackProfileDiff`, () => {
         },
       ],
     ])
-    expect(improvementsTables(md, `Self time`)).toEqual([])
+    expect(rankingTables(md, `Self time`, `Improvements`)).toEqual([])
   })
 
   test(`notes that each function section is unchanged when nothing changed`, () => {
@@ -1121,8 +1252,8 @@ describe(`formatCallStackProfileDiff`, () => {
     // The sections are still formatted, with a note in place of empty tables so
     // the output doesn't look broken.
     expect(md).toMatch(/^## Hottest functions$/mu)
-    expect(regressionsTables(md, `Self time`)).toEqual([])
-    expect(improvementsTables(md, `Self time`)).toEqual([])
+    expect(rankingTables(md, `Self time`, `Regressions`)).toEqual([])
+    expect(rankingTables(md, `Self time`, `Improvements`)).toEqual([])
     expect(md).toContain(
       `No function differed in time spent directly in the function body, excluding callees.`,
     )
@@ -1216,7 +1347,7 @@ describe(`formatCallStackProfileDiff`, () => {
 
     expect(md).toMatch(/^## CPU$/mu)
     expect(md).toMatch(/^## Heap$/mu)
-    expect(regressionsTables(md, `Self time`)).not.toEqual([])
+    expect(rankingTables(md, `Self time`, `Regressions`)).not.toEqual([])
     expect(md).toContain(
       `No function differed in bytes allocated directly in the function body, excluding callees.`,
     )

--- a/src/modalities/call-stack-profile/format.ts
+++ b/src/modalities/call-stack-profile/format.ts
@@ -1022,7 +1022,7 @@ const formatDiffDirectionFunctions = ({
     side: Measure,
     func?: AggregatedCallStackProfileFunction,
   ) => (func === undefined ? 0 : valueOf(side, func))
-  const { regressions, improvements, hasActive, categoryRankings } =
+  const { increases, decreases, hasActive, categoryRankings } =
     selectDiffEntities(
       diff.functions.map(func => ({
         entity: func,
@@ -1055,10 +1055,11 @@ const formatDiffDirectionFunctions = ({
     headingLevel,
     title: titleOf(metric),
     description: descriptionOf(metric),
+    improvement: metric.improvement,
     columns: functionColumns(measure, `Function`, options),
     hasActive,
-    regressions,
-    improvements,
+    increases,
+    decreases,
     categoryRankings,
     rowOf: ({ entity }) => rowOf(entity),
   })

--- a/src/modalities/format.ts
+++ b/src/modalities/format.ts
@@ -18,7 +18,7 @@ import type {
 } from '../options.ts'
 import type { Diff } from './diff.ts'
 import type { HeapSnapshotNodeCategory } from './heap-snapshot/type.ts'
-import type { Metric } from './metric.ts'
+import type { Metric, MetricImprovement } from './metric.ts'
 import { formatDiffTable } from './table.ts'
 import type { Table } from './table.ts'
 
@@ -133,9 +133,55 @@ export const formatFunctionHeading = (
   )
 
 /**
- * Assembles the regressions and improvements subsections for one function
- * direction (self or total) under a {@link title} heading, with rows under the
- * given table {@link columns}.
+ * The two rankings a diff shows for a measure in {@link improvement}'s metric,
+ * in the order they are shown: what the metric's improvement direction calls
+ * worse first, or the increases first where that direction is unknown.
+ *
+ * A heading names the change itself wherever that direction is unknown, so
+ * the output never calls a change an improvement it cannot measure as one.
+ */
+export const diffRankings = (
+  improvement: MetricImprovement,
+): [DiffRanking, DiffRanking] => {
+  switch (improvement) {
+    case `decrease`:
+      return [
+        { change: `increase`, title: `Regressions` },
+        { change: `decrease`, title: `Improvements` },
+      ]
+    case `increase`:
+      return [
+        { change: `decrease`, title: `Regressions` },
+        { change: `increase`, title: `Improvements` },
+      ]
+    case `unknown`:
+      return [
+        { change: `increase`, title: `Increases` },
+        { change: `decrease`, title: `Decreases` },
+      ]
+  }
+}
+
+/** One of a diff's two rankings: the change it ranks, and its heading. */
+export type DiffRanking = {
+  change: DiffChange
+  title: string
+}
+
+/** A direction of change between a diff's two sides. */
+export type DiffChange = `increase` | `decrease`
+
+/** The sentence introducing a ranking of {@link change}s in {@link description}. */
+export const diffRankingSentence = (
+  plural: string,
+  change: DiffChange,
+  description: string,
+): string => `${plural} with the largest ${change} in ${description}.`
+
+/**
+ * Assembles the increase and decrease subsections for one function direction
+ * (self or total) under a {@link title} heading, with rows under the given
+ * table {@link columns}.
  *
  * When nothing differed but {@link hasActive} functions exist on either side,
  * the section stays, with a "did not differ" note. When no functions are
@@ -145,45 +191,41 @@ export const formatDiffFunctionSections = <Entity, Row>({
   headingLevel,
   title,
   description,
+  improvement,
   columns,
   hasActive,
-  regressions,
-  improvements,
+  increases,
+  decreases,
   categoryRankings = [],
   rowOf,
 }: {
   headingLevel: number
   title: string
   description: string
+  improvement: MetricImprovement
   columns: Table<Row>
   hasActive: boolean
-  regressions: Entity[]
-  improvements: Entity[]
+  increases: Entity[]
+  decreases: Entity[]
   categoryRankings?: DiffCategoryRanking<Entity>[]
   rowOf: (entity: Entity) => Diff<Row>
 }): RootContent[] => {
-  const sections = [
-    ...formatDiffRankingSections({
-      headingLevel: headingLevel + 1,
-      subtitle: `Regressions`,
-      sentence: `Functions with the largest increase in ${description}.`,
-      columns,
-      entities: regressions,
-      categoryRankings,
-      entitiesOf: ranking => ranking.regressions,
-      rowOf,
-    }),
-    ...formatDiffRankingSections({
-      headingLevel: headingLevel + 1,
-      subtitle: `Improvements`,
-      sentence: `Functions with the largest decrease in ${description}.`,
-      columns,
-      entities: improvements,
-      categoryRankings,
-      entitiesOf: ranking => ranking.improvements,
-      rowOf,
-    }),
-  ]
+  const sections = diffRankings(improvement).flatMap(
+    ({ change, title: subtitle }) =>
+      formatDiffRankingSections({
+        headingLevel: headingLevel + 1,
+        subtitle,
+        sentence: diffRankingSentence(`Functions`, change, description),
+        columns,
+        entities: change === `increase` ? increases : decreases,
+        categoryRankings,
+        entitiesOf: categoryRanking =>
+          change === `increase`
+            ? categoryRanking.increases
+            : categoryRanking.decreases,
+        rowOf,
+      }),
+  )
 
   if (sections.length === 0) {
     if (!hasActive) {
@@ -289,11 +331,11 @@ export const isRepeatedByCategory = <Entity>(
       entries.every((entry, index) => entry === ranking[index]),
   )
 
-/** One category's own regressions and improvements within a diff ranking. */
+/** One category's own increases and decreases within a diff ranking. */
 export type DiffCategoryRanking<Item> = {
   category: Category
-  regressions: Item[]
-  improvements: Item[]
+  increases: Item[]
+  decreases: Item[]
 }
 
 /**
@@ -339,8 +381,10 @@ export type ActiveDiffEntity<Entity> = {
 }
 
 /**
- * Selects the top regressed and improved entities from {@link candidates},
- * keeping only those active on at least one side and shown by {@link options}.
+ * Selects the entities whose measure increased and decreased the most from
+ * {@link candidates}, keeping only those active on at least one side and shown
+ * by {@link options}. {@link diffRankings} states which of the two a metric
+ * counts as a regression.
  *
  * {@link categories} additionally selects the top of each category, ranked the
  * same way among that category's own entities.
@@ -356,27 +400,27 @@ export const selectDiffEntities = <
   },
 ): {
   hasActive: boolean
-  regressions: ActiveDiffEntity<Entity>[]
-  improvements: ActiveDiffEntity<Entity>[]
+  increases: ActiveDiffEntity<Entity>[]
+  decreases: ActiveDiffEntity<Entity>[]
   categoryRankings: DiffCategoryRanking<ActiveDiffEntity<Entity>>[]
 } => {
   const active = candidates.filter(
     ({ entity, baseValue, currentValue }) =>
       (baseValue > 0 || currentValue > 0) && showDiffEntity(entity, options),
   )
-  const regressed = active.filter(
+  const increased = active.filter(
     ({ baseValue, currentValue }) => currentValue > baseValue,
   )
-  const improved = active.filter(
+  const decreased = active.filter(
     ({ baseValue, currentValue }) => currentValue < baseValue,
   )
-  const topRegressions = (entities: ActiveDiffEntity<Entity>[]) =>
+  const topIncreases = (entities: ActiveDiffEntity<Entity>[]) =>
     selectTopN(
       entities,
       options.topN,
       ({ baseValue, currentValue }) => currentValue - baseValue,
     )
-  const topImprovements = (entities: ActiveDiffEntity<Entity>[]) =>
+  const topDecreases = (entities: ActiveDiffEntity<Entity>[]) =>
     selectTopN(
       entities,
       options.topN,
@@ -385,15 +429,15 @@ export const selectDiffEntities = <
 
   return {
     hasActive: active.length > 0,
-    regressions: topRegressions(regressed),
-    improvements: topImprovements(improved),
+    increases: topIncreases(increased),
+    decreases: topDecreases(decreased),
     categoryRankings: (categories?.categories ?? []).map(category => {
       const inCategory = ({ entity }: ActiveDiffEntity<Entity>) =>
         categories!.categoryOf(entity) === category
       return {
         category,
-        regressions: topRegressions(regressed.filter(inCategory)),
-        improvements: topImprovements(improved.filter(inCategory)),
+        increases: topIncreases(increased.filter(inCategory)),
+        decreases: topDecreases(decreased.filter(inCategory)),
       }
     }),
   }

--- a/src/modalities/heap-snapshot/diff.test.ts
+++ b/src/modalities/heap-snapshot/diff.test.ts
@@ -3,8 +3,7 @@ import { mdastToMarkdown } from '../../helpers/markdown.ts'
 import type { ProfileToMdContext } from '../../options.ts'
 import {
   categoryTables,
-  improvementsTables,
-  regressionsTables,
+  rankingTables,
   resolveProfileToMdOptions,
 } from '../../testing.ts'
 import { diffAggregatedHeapSnapshots } from './diff.ts'
@@ -36,8 +35,8 @@ describe(`diffAggregatedHeapSnapshots`, () => {
     const diff = diffAggregatedHeapSnapshots(base, current, defaultOptions)
     const md = mdastToMarkdown(formatHeapSnapshotDiff(diff, defaultOptions))
 
-    expect(regressionsTables(md, `Self size`)).toEqual([])
-    expect(improvementsTables(md, `Self size`)).toEqual([
+    expect(rankingTables(md, `Self size`, `Regressions`)).toEqual([])
+    expect(rankingTables(md, `Self size`, `Improvements`)).toEqual([
       [
         {
           Change: `removed`,
@@ -67,7 +66,7 @@ describe(`diffAggregatedHeapSnapshots`, () => {
     const diff = diffAggregatedHeapSnapshots(base, current, defaultOptions)
     const md = mdastToMarkdown(formatHeapSnapshotDiff(diff, defaultOptions))
 
-    expect(regressionsTables(md, `Self size`)).toEqual([
+    expect(rankingTables(md, `Self size`, `Regressions`)).toEqual([
       [
         {
           Change: `new`,
@@ -79,7 +78,7 @@ describe(`diffAggregatedHeapSnapshots`, () => {
         },
       ],
     ])
-    expect(improvementsTables(md, `Self size`)).toEqual([])
+    expect(rankingTables(md, `Self size`, `Improvements`)).toEqual([])
   })
 
   test(`matches constructors by name despite differing locations`, () => {
@@ -109,7 +108,7 @@ describe(`diffAggregatedHeapSnapshots`, () => {
     const diff = diffAggregatedHeapSnapshots(base, current, defaultOptions)
     const md = mdastToMarkdown(formatHeapSnapshotDiff(diff, defaultOptions))
 
-    expect(regressionsTables(md, `Self size`)).toEqual([
+    expect(rankingTables(md, `Self size`, `Regressions`)).toEqual([
       [
         {
           Change: `+100.0%`,
@@ -122,7 +121,7 @@ describe(`diffAggregatedHeapSnapshots`, () => {
         },
       ],
     ])
-    expect(improvementsTables(md, `Self size`)).toEqual([])
+    expect(rankingTables(md, `Self size`, `Improvements`)).toEqual([])
   })
 
   test(`matches functions by name and file despite differing line and column`, () => {
@@ -150,7 +149,7 @@ describe(`diffAggregatedHeapSnapshots`, () => {
     const diff = diffAggregatedHeapSnapshots(base, current, defaultOptions)
     const md = mdastToMarkdown(formatHeapSnapshotDiff(diff, defaultOptions))
 
-    expect(regressionsTables(md, `Largest functions`)).toEqual([
+    expect(rankingTables(md, `Largest functions`, `Regressions`)).toEqual([
       [
         {
           Change: `+200.0%`,
@@ -165,7 +164,7 @@ describe(`diffAggregatedHeapSnapshots`, () => {
         },
       ],
     ])
-    expect(improvementsTables(md, `Largest functions`)).toEqual([])
+    expect(rankingTables(md, `Largest functions`, `Improvements`)).toEqual([])
   })
 
   test(`keys each side's functions under that snapshot's own context`, () => {
@@ -233,7 +232,7 @@ describe(`diffAggregatedHeapSnapshots`, () => {
     const diff = diffAggregatedHeapSnapshots(base, current, defaultOptions)
     const md = mdastToMarkdown(formatHeapSnapshotDiff(diff, defaultOptions))
 
-    expect(regressionsTables(md, `Largest functions`)).toEqual([
+    expect(rankingTables(md, `Largest functions`, `Regressions`)).toEqual([
       [
         {
           Change: `new`,
@@ -248,7 +247,7 @@ describe(`diffAggregatedHeapSnapshots`, () => {
         },
       ],
     ])
-    expect(improvementsTables(md, `Largest functions`)).toEqual([
+    expect(rankingTables(md, `Largest functions`, `Improvements`)).toEqual([
       [
         {
           Change: `removed`,
@@ -289,8 +288,8 @@ describe(`diffAggregatedHeapSnapshots`, () => {
     const diff = diffAggregatedHeapSnapshots(base, current, defaultOptions)
     const md = mdastToMarkdown(formatHeapSnapshotDiff(diff, defaultOptions))
 
-    expect(regressionsTables(md, `Largest functions`)).toEqual([])
-    expect(improvementsTables(md, `Largest functions`)).toEqual([
+    expect(rankingTables(md, `Largest functions`, `Regressions`)).toEqual([])
+    expect(rankingTables(md, `Largest functions`, `Improvements`)).toEqual([
       [
         {
           Change: `removed`,
@@ -330,7 +329,7 @@ describe(`diffAggregatedHeapSnapshots`, () => {
     const diff = diffAggregatedHeapSnapshots(base, current, defaultOptions)
     const md = mdastToMarkdown(formatHeapSnapshotDiff(diff, defaultOptions))
 
-    expect(regressionsTables(md, `Largest functions`)).toEqual([
+    expect(rankingTables(md, `Largest functions`, `Regressions`)).toEqual([
       [
         {
           Change: `+100.0%`,
@@ -344,7 +343,7 @@ describe(`diffAggregatedHeapSnapshots`, () => {
         },
       ],
     ])
-    expect(improvementsTables(md, `Largest functions`)).toEqual([])
+    expect(rankingTables(md, `Largest functions`, `Improvements`)).toEqual([])
   })
 
   test(`groups strings by value, merging duplicates and excluding unnamed strings`, () => {
@@ -364,8 +363,8 @@ describe(`diffAggregatedHeapSnapshots`, () => {
     const diff = diffAggregatedHeapSnapshots(base, current, defaultOptions)
     const md = mdastToMarkdown(formatHeapSnapshotDiff(diff, defaultOptions))
 
-    expect(regressionsTables(md, `Largest strings`)).toEqual([])
-    expect(improvementsTables(md, `Largest strings`)).toEqual([
+    expect(rankingTables(md, `Largest strings`, `Regressions`)).toEqual([])
+    expect(rankingTables(md, `Largest strings`, `Improvements`)).toEqual([
       [
         {
           Change: `-37.5%`,

--- a/src/modalities/heap-snapshot/format.test.ts
+++ b/src/modalities/heap-snapshot/format.test.ts
@@ -4,9 +4,8 @@ import {
   categoryRankingTables,
   categorySectionTables,
   categoryTables,
-  improvementsTables,
   profileTitles,
-  regressionsTables,
+  rankingTables,
   resolveProfileToMdOptions,
   summaryLines,
 } from '../../testing.ts'
@@ -340,12 +339,16 @@ describe(`formatHeapSnapshotDiff`, () => {
         Constructor: `Removed`,
       },
     ]
-    expect(regressionsTables(md, `Self size`)).toEqual([expectedRegressions])
-    expect(improvementsTables(md, `Self size`)).toEqual([expectedImprovements])
-    expect(regressionsTables(md, `Retained size`)).toEqual([
+    expect(rankingTables(md, `Self size`, `Regressions`)).toEqual([
       expectedRegressions,
     ])
-    expect(improvementsTables(md, `Retained size`)).toEqual([
+    expect(rankingTables(md, `Self size`, `Improvements`)).toEqual([
+      expectedImprovements,
+    ])
+    expect(rankingTables(md, `Retained size`, `Regressions`)).toEqual([
+      expectedRegressions,
+    ])
+    expect(rankingTables(md, `Retained size`, `Improvements`)).toEqual([
       expectedImprovements,
     ])
   })
@@ -388,7 +391,7 @@ describe(`formatHeapSnapshotDiff`, () => {
     const diff = diffAggregatedHeapSnapshots(base, current, defaultOptions)
     const md = mdastToMarkdown(formatHeapSnapshotDiff(diff, defaultOptions))
 
-    expect(regressionsTables(md, `Largest functions`)).toEqual([
+    expect(rankingTables(md, `Largest functions`, `Regressions`)).toEqual([
       [
         {
           Change: `+200.0%`,
@@ -403,7 +406,7 @@ describe(`formatHeapSnapshotDiff`, () => {
         },
       ],
     ])
-    expect(improvementsTables(md, `Largest functions`)).toEqual([
+    expect(rankingTables(md, `Largest functions`, `Improvements`)).toEqual([
       [
         {
           Change: `-75.0%`,
@@ -436,7 +439,7 @@ describe(`formatHeapSnapshotDiff`, () => {
     const diff = diffAggregatedHeapSnapshots(base, current, defaultOptions)
     const md = mdastToMarkdown(formatHeapSnapshotDiff(diff, defaultOptions))
 
-    expect(regressionsTables(md, `Largest strings`)).toEqual([
+    expect(rankingTables(md, `Largest strings`, `Regressions`)).toEqual([
       [
         {
           Change: `+220.0%`,
@@ -448,7 +451,7 @@ describe(`formatHeapSnapshotDiff`, () => {
         },
       ],
     ])
-    expect(improvementsTables(md, `Largest strings`)).toEqual([])
+    expect(rankingTables(md, `Largest strings`, `Improvements`)).toEqual([])
   })
 
   test(`omits the location column when nothing has a location`, () => {
@@ -490,7 +493,7 @@ describe(`formatHeapSnapshotDiff`, () => {
     const diff = diffAggregatedHeapSnapshots(base, current, defaultOptions)
     const md = mdastToMarkdown(formatHeapSnapshotDiff(diff, defaultOptions))
 
-    expect(regressionsTables(md, `Self size`)).toEqual([
+    expect(rankingTables(md, `Self size`, `Regressions`)).toEqual([
       [
         {
           Change: `+100.0%`,
@@ -502,7 +505,7 @@ describe(`formatHeapSnapshotDiff`, () => {
         },
       ],
     ])
-    expect(regressionsTables(md, `Largest functions`)).toEqual([
+    expect(rankingTables(md, `Largest functions`, `Regressions`)).toEqual([
       [
         {
           Change: `+100.0%`,
@@ -554,7 +557,7 @@ describe(`formatHeapSnapshotDiff`, () => {
     const md = mdastToMarkdown(formatHeapSnapshotDiff(diff, options))
 
     expect(md).not.toContain(`Hidden`)
-    expect(regressionsTables(md, `Self size`)).toEqual([
+    expect(rankingTables(md, `Self size`, `Regressions`)).toEqual([
       [
         {
           Change: `new`,
@@ -600,7 +603,7 @@ describe(`formatHeapSnapshotDiff`, () => {
     expect(md).toContain(
       `The entry filter hides every node, so all nodes are shown.`,
     )
-    expect(regressionsTables(md, `Self size`)).toEqual([
+    expect(rankingTables(md, `Self size`, `Regressions`)).toEqual([
       [
         {
           Change: `+100.0%`,

--- a/src/modalities/heap-snapshot/format.ts
+++ b/src/modalities/heap-snapshot/format.ts
@@ -26,12 +26,15 @@ import {
 } from '../category.ts'
 import type { Diff } from '../diff.ts'
 import {
+  diffRankings,
+  diffRankingSentence,
   formatDiffRankingSections,
   resolveEntryFilter,
   selectDiffEntities,
   showDiffEntity,
 } from '../format.ts'
 import type { DiffCategoryRanking } from '../format.ts'
+import { BYTES_METRIC } from '../metrics.ts'
 import { formatDiffTable, formatTable } from '../table.ts'
 import type { Table } from '../table.ts'
 import type {
@@ -656,7 +659,7 @@ const formatDiffSizeConstructors = ({
   options: FormattingProfileToMdOptions
   size: ConstructorSize
 }): RootContent[] => {
-  const { regressions, improvements, hasActive, categoryRankings } =
+  const { increases, decreases, hasActive, categoryRankings } =
     selectDiffEntities(
       diff.constructors.map(entity => ({
         entity,
@@ -686,8 +689,8 @@ const formatDiffSizeConstructors = ({
     description,
     columns: constructorColumns(hasLocation, options),
     hasActive,
-    regressions,
-    improvements,
+    increases,
+    decreases,
     categoryRankings,
     rowOf: ({ entity }) => rowOf(entity),
   })
@@ -702,7 +705,7 @@ const formatDiffFunctions = ({
   hasLocation: boolean
   options: FormattingProfileToMdOptions
 }): RootContent[] => {
-  const { regressions, improvements, hasActive } = selectDiffEntities(
+  const { increases, decreases, hasActive } = selectDiffEntities(
     diff.functions.map(entity => ({
       entity,
       baseValue: entity.base ? entity.base.retainedSize : 0,
@@ -723,8 +726,8 @@ const formatDiffFunctions = ({
     description: `retained size`,
     columns: functionColumns(hasLocation, options),
     hasActive,
-    regressions,
-    improvements,
+    increases,
+    decreases,
     rowOf: ({ entity }) => rowOf(entity),
   })
 }
@@ -764,7 +767,7 @@ const formatDiffStrings = ({
     minCategoryShare: options.minCategoryShare,
   })
 
-  const { regressions, improvements, hasActive, categoryRankings } =
+  const { increases, decreases, hasActive, categoryRankings } =
     selectDiffEntities(
       diff.strings.map(entity => ({
         entity,
@@ -788,8 +791,8 @@ const formatDiffStrings = ({
     // Diffed strings are matched by value, so they always have a value.
     columns: stringColumns(true),
     hasActive,
-    regressions,
-    improvements,
+    increases,
+    decreases,
     categoryRankings,
     rowOf: ({ entity }) => rowOf(entity),
   })
@@ -808,8 +811,11 @@ const nodeRowOf = (
 })
 
 /**
- * Assembles the regressions and improvements subsections for one diffed entity
- * table from its row records, with rows under the given table {@link columns}.
+ * Assembles the increase and decrease subsections for one diffed entity table
+ * from its row records, with rows under the given table {@link columns}.
+ *
+ * Every heap snapshot ranking measures bytes, so a decrease is an improvement
+ * in all of them.
  */
 const formatDiffEntitySections = <Entity, Row>({
   formatHeader,
@@ -818,8 +824,8 @@ const formatDiffEntitySections = <Entity, Row>({
   description,
   columns,
   hasActive,
-  regressions,
-  improvements,
+  increases,
+  decreases,
   categoryRankings = [],
   rowOf,
 }: {
@@ -829,33 +835,27 @@ const formatDiffEntitySections = <Entity, Row>({
   description: string
   columns: Table<Row>
   hasActive: boolean
-  regressions: Entity[]
-  improvements: Entity[]
+  increases: Entity[]
+  decreases: Entity[]
   categoryRankings?: DiffCategoryRanking<Entity>[]
   rowOf: (entity: Entity) => Diff<Row>
 }): RootContent[] => {
-  const sections = [
-    ...formatDiffRankingSections({
-      headingLevel,
-      subtitle: `Regressions`,
-      sentence: `${plural} with the largest increase in ${description}.`,
-      columns,
-      entities: regressions,
-      categoryRankings,
-      entitiesOf: ranking => ranking.regressions,
-      rowOf,
-    }),
-    ...formatDiffRankingSections({
-      headingLevel,
-      subtitle: `Improvements`,
-      sentence: `${plural} with the largest decrease in ${description}.`,
-      columns,
-      entities: improvements,
-      categoryRankings,
-      entitiesOf: ranking => ranking.improvements,
-      rowOf,
-    }),
-  ]
+  const sections = diffRankings(BYTES_METRIC.improvement).flatMap(
+    ({ change, title: subtitle }) =>
+      formatDiffRankingSections({
+        headingLevel,
+        subtitle,
+        sentence: diffRankingSentence(plural, change, description),
+        columns,
+        entities: change === `increase` ? increases : decreases,
+        categoryRankings,
+        entitiesOf: categoryRanking =>
+          change === `increase`
+            ? categoryRanking.increases
+            : categoryRanking.decreases,
+        rowOf,
+      }),
+  )
 
   // With active entities but no change, keep the section and let the header note
   // it didn't differ. With nothing active (the section a non-diff snapshot

--- a/src/modalities/metric.test.ts
+++ b/src/modalities/metric.test.ts
@@ -22,8 +22,8 @@ describe(`metricsEqual`, () => {
     },
     {
       scenario: `custom metrics with the same unit and phrases`,
-      left: countMetricOf(`widget`),
-      right: countMetricOf(`widget`),
+      left: countMetricOf(`widget`, { improvement: `decrease` }),
+      right: countMetricOf(`widget`, { improvement: `decrease` }),
     },
   ])(`returns true for $scenario`, ({ left, right }) => {
     expect(metricsEqual(left, right)).toBe(true)
@@ -47,8 +47,13 @@ describe(`metricsEqual`, () => {
     },
     {
       scenario: `custom metrics with different units`,
-      left: countMetricOf(`widget`),
-      right: countMetricOf(`gadget`),
+      left: countMetricOf(`widget`, { improvement: `decrease` }),
+      right: countMetricOf(`gadget`, { improvement: `decrease` }),
+    },
+    {
+      scenario: `the same unit and phrases but different improvement directions`,
+      left: countMetricOf(`widget`, { improvement: `decrease` }),
+      right: countMetricOf(`widget`, { improvement: `increase` }),
     },
   ])(`returns false for $scenario`, ({ left, right }) => {
     expect(metricsEqual(left, right)).toBe(false)

--- a/src/modalities/metric.ts
+++ b/src/modalities/metric.ts
@@ -15,6 +15,17 @@ export type MetricPhrases = {
   pastParticipleVerbPhrase: string
 }
 
+/**
+ * Which direction of change in a metric's value is an improvement.
+ *
+ * A profiler records what a program consumed, so a smaller value is a better
+ * one for every unit this package recognizes. `increase` is for a metric
+ * measuring something a program produces, and `unknown` for a metric whose
+ * emitter named a unit this package cannot classify, where a diff states the
+ * direction of each change and calls neither better or worse.
+ */
+export type MetricImprovement = `decrease` | `increase` | `unknown`
+
 /** A metric measured in a profile. */
 export type Metric = (
   | {
@@ -44,7 +55,12 @@ export type Metric = (
        */
       proseUnit: string
     }
-) & { phrases: MetricPhrases }
+) & {
+  phrases: MetricPhrases
+
+  /** Which direction of change in this metric's value is an improvement. */
+  improvement: MetricImprovement
+}
 
 /** A metric formatted as a bare count. */
 export type CountMetric = Extract<Metric, { type: `count` }>
@@ -55,6 +71,18 @@ export const metricWithPhrases = <M extends Metric>(
   phrases: MetricPhrases,
 ): M => ({ ...metric, phrases })
 
+/** Options for {@link countMetricOf}. */
+export type CountMetricOptions = {
+  /**
+   * Which direction of change in the count is an improvement.
+   *
+   * What one occurrence is decides it: an occurrence the profiled program
+   * incurs is a cost, so fewer of them is an improvement, while an occurrence
+   * it achieves (a cache hit, a completed request) improves as it grows.
+   */
+  improvement: MetricImprovement
+}
+
 /**
  * The metric for a count of things, named by the singular noun for one of them
  * (e.g. `entry`, `object`, `contention`), phrased as "recorded".
@@ -63,11 +91,15 @@ export const metricWithPhrases = <M extends Metric>(
  * call stack records them under that event's noun, so the output states no
  * rate per a sample the profiler never took.
  */
-export const countMetricOf = (noun: string): CountMetric => {
+export const countMetricOf = (
+  noun: string,
+  { improvement }: CountMetricOptions,
+): CountMetric => {
   const plural = plur(noun, 2)
   return {
     type: `count`,
     proseUnit: noun,
+    improvement,
     phrases: {
       titleNoun: noun,
       columnNoun: plural,
@@ -77,9 +109,20 @@ export const countMetricOf = (noun: string): CountMetric => {
   }
 }
 
-/** Returns whether two metrics measure the same thing in the same unit. */
+/**
+ * Returns whether two metrics measure the same thing in the same unit, and rank
+ * a change in it the same way.
+ *
+ * Two metrics disagreeing on which direction is an improvement measure
+ * different things, whatever their units, since a diff pairing them would rank
+ * every change by one side's direction alone.
+ */
 export const metricsEqual = (left: Metric, right: Metric): boolean => {
-  if (left.type !== right.type || !phrasesEqual(left.phrases, right.phrases)) {
+  if (
+    left.type !== right.type ||
+    left.improvement !== right.improvement ||
+    !phrasesEqual(left.phrases, right.phrases)
+  ) {
     return false
   }
 

--- a/src/modalities/metrics.test.ts
+++ b/src/modalities/metrics.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { parseMetric } from './metrics.ts'
+import { countMetricOf } from './metric.ts'
+import { NANOSECONDS_METRIC, parseMetric, SAMPLES } from './metrics.ts'
 
 describe(`parseMetric`, () => {
   it(`returns named size metric for alloc_space`, () => {
@@ -118,5 +119,41 @@ describe(`parseMetric`, () => {
       proseUnit: `time`,
       phrases: { titleNoun: `count`, columnNoun: `counts` },
     })
+  })
+
+  it.each([
+    { scenario: `a time unit`, unit: `nanoseconds`, improvement: `decrease` },
+    { scenario: `a size unit`, unit: `bytes`, improvement: `decrease` },
+    {
+      scenario: `an unrecognized unit`,
+      unit: `widgets`,
+      improvement: `unknown`,
+    },
+    { scenario: `the "none" unit`, unit: `none`, improvement: `unknown` },
+  ])(
+    `derives $improvement as the improvement for $scenario`,
+    ({ unit, improvement }) => {
+      expect(parseMetric({ name: `foo`, unit }).improvement).toBe(improvement)
+    },
+  )
+
+  it(`takes the improvement direction the caller states over the unit's`, () => {
+    const metric = parseMetric({
+      name: `cache hit`,
+      unit: `hit`,
+      improvement: `increase`,
+    })
+
+    expect(metric.improvement).toBe(`increase`)
+  })
+})
+
+describe(`improvement direction`, () => {
+  it(`is a decrease for a count of what a profiler recorded`, () => {
+    expect(
+      countMetricOf(`contention`, { improvement: `decrease` }).improvement,
+    ).toBe(`decrease`)
+    expect(SAMPLES.improvement).toBe(`decrease`)
+    expect(NANOSECONDS_METRIC.improvement).toBe(`decrease`)
   })
 })

--- a/src/modalities/metrics.ts
+++ b/src/modalities/metrics.ts
@@ -1,10 +1,16 @@
 import { metricWithPhrases } from './metric.ts'
-import type { CountMetric, Metric, MetricPhrases } from './metric.ts'
+import type {
+  CountMetric,
+  Metric,
+  MetricImprovement,
+  MetricPhrases,
+} from './metric.ts'
 
 /** What one count measures for a profiler that samples the call stack. */
 export const SAMPLES: CountMetric = {
   type: `count`,
   proseUnit: `sample`,
+  improvement: `decrease`,
   phrases: {
     titleNoun: `sampling`,
     columnNoun: `samples`,
@@ -17,6 +23,9 @@ export const SAMPLES: CountMetric = {
 const OCCURRENCES_METRIC: CountMetric = {
   type: `count`,
   proseUnit: `time`,
+  // An emitter stating its values have no unit states nothing about what they
+  // measure, so a diff ranks neither direction of change as better or worse.
+  improvement: `unknown`,
   phrases: {
     titleNoun: `count`,
     columnNoun: `counts`,
@@ -47,42 +56,50 @@ const HEAP_PHRASES: MetricPhrases = {
 export const NANOSECONDS_METRIC: Metric = {
   type: `time`,
   milliseconds: 1e-6,
+  improvement: `decrease`,
   phrases: CPU_TIME_PHRASES,
 }
 export const MICROSECONDS_METRIC: Metric = {
   type: `time`,
   milliseconds: 0.001,
+  improvement: `decrease`,
   phrases: CPU_TIME_PHRASES,
 }
 export const MILLISECONDS_METRIC: Metric = {
   type: `time`,
   milliseconds: 1,
+  improvement: `decrease`,
   phrases: CPU_TIME_PHRASES,
 }
 export const SECONDS_METRIC: Metric = {
   type: `time`,
   milliseconds: 1000,
+  improvement: `decrease`,
   phrases: CPU_TIME_PHRASES,
 }
 
 export const BYTES_METRIC: Metric = {
   type: `size`,
   bytes: 1,
+  improvement: `decrease`,
   phrases: HEAP_PHRASES,
 }
 const KILOBYTES_METRIC: Metric = {
   type: `size`,
   bytes: 1 << 10,
+  improvement: `decrease`,
   phrases: HEAP_PHRASES,
 }
 export const MEGABYTES_METRIC: Metric = {
   type: `size`,
   bytes: 1 << 20,
+  improvement: `decrease`,
   phrases: HEAP_PHRASES,
 }
 const GIGABYTES_METRIC: Metric = {
   type: `size`,
   bytes: 1 << 30,
+  improvement: `decrease`,
   phrases: HEAP_PHRASES,
 }
 
@@ -165,6 +182,7 @@ export const LEAKED_MEMORY_METRIC: Metric = metricWithPhrases(BYTES_METRIC, {
 export const CPU_CYCLES_METRIC: CountMetric = {
   type: `count`,
   proseUnit: `cycle`,
+  improvement: `decrease`,
   phrases: {
     titleNoun: `CPU cycles`,
     columnNoun: `CPU cycles`,
@@ -177,6 +195,7 @@ export const CPU_CYCLES_METRIC: CountMetric = {
 export const UNINTERRUPTIBLE_SLEEPS_METRIC: CountMetric = {
   type: `count`,
   proseUnit: `time`,
+  improvement: `decrease`,
   phrases: {
     titleNoun: `uninterruptible sleep`,
     columnNoun: `sleeps`,
@@ -189,6 +208,7 @@ export const UNINTERRUPTIBLE_SLEEPS_METRIC: CountMetric = {
 export const INTERRUPTIBLE_SLEEPS_METRIC: CountMetric = {
   type: `count`,
   proseUnit: `time`,
+  improvement: `decrease`,
   phrases: {
     titleNoun: `interruptible sleep`,
     columnNoun: `sleeps`,
@@ -205,17 +225,26 @@ export const INTERRUPTIBLE_SLEEPS_METRIC: CountMetric = {
  * missing from {@link UNIT_METRICS} becomes a count in that unit, named
  * verbatim, because a string the emitter chose states no grammatical number to
  * inflect from.
+ *
+ * Such a unit also states nothing about which direction of change is an
+ * improvement, so pass {@link MetricImprovement} wherever the emitter's own
+ * documentation states what its values measure.
  */
 export const parseMetric = ({
   name,
   unit,
+  improvement,
 }: {
   name: string
   unit: string
+
+  /** Overrides the direction derived from {@link unit}. */
+  improvement?: MetricImprovement
 }): Metric => {
-  const metric = UNIT_METRICS.get(unit.toLowerCase()) ?? {
+  const metric: Metric = UNIT_METRICS.get(unit.toLowerCase()) ?? {
     type: `count`,
     proseUnit: unit,
+    improvement: `unknown`,
     phrases: {
       titleNoun: name,
       columnNoun: name,
@@ -224,7 +253,10 @@ export const parseMetric = ({
     },
   }
   const phrases = NAME_PHRASES.get(metric.type)?.get(name.toLowerCase())
-  return phrases ? metricWithPhrases(metric, phrases) : metric
+  return {
+    ...(phrases ? metricWithPhrases(metric, phrases) : metric),
+    improvement: improvement ?? metric.improvement,
+  }
 }
 
 /**

--- a/src/testing.test.ts
+++ b/src/testing.test.ts
@@ -2,9 +2,8 @@ import dedent from 'dedent'
 import { describe, expect, test } from 'vitest'
 import {
   categoryTables,
-  improvementsTables,
   profileTitles,
-  regressionsTables,
+  rankingTables,
   summaryLines,
 } from './testing.ts'
 
@@ -146,9 +145,9 @@ describe(`categoryTables`, () => {
   })
 })
 
-describe(`regressionsTables`, () => {
+describe(`rankingTables`, () => {
   test(`returns [] when the section heading is absent`, () => {
-    const tables = regressionsTables(
+    const tables = rankingTables(
       dedent`
         ### Regressions
 
@@ -157,13 +156,14 @@ describe(`regressionsTables`, () => {
         | foo | +1ms |
       `,
       `Self time`,
+      `Regressions`,
     )
 
     expect(tables).toStrictEqual([])
   })
 
   test(`returns [] when the section has no Regressions sub-heading`, () => {
-    const tables = regressionsTables(
+    const tables = rankingTables(
       dedent`
         ### Self time
 
@@ -174,13 +174,14 @@ describe(`regressionsTables`, () => {
         | foo | -1ms |
       `,
       `Self time`,
+      `Regressions`,
     )
 
     expect(tables).toStrictEqual([])
   })
 
   test(`returns parsed rows from the Regressions table within the section`, () => {
-    const tables = regressionsTables(
+    const tables = rankingTables(
       dedent`
         ### Self time
 
@@ -193,13 +194,14 @@ describe(`regressionsTables`, () => {
         | foo | +1ms |
       `,
       `Self time`,
+      `Regressions`,
     )
 
     expect(tables).toStrictEqual([[{ Function: `foo`, Delta: `+1ms` }]])
   })
 
   test(`does not cross into the next section`, () => {
-    const tables = regressionsTables(
+    const tables = rankingTables(
       dedent`
         ### Self time
 
@@ -218,15 +220,14 @@ describe(`regressionsTables`, () => {
         | bar | +2ms |
       `,
       `Self time`,
+      `Regressions`,
     )
 
     expect(tables).toStrictEqual([[{ Function: `foo`, Delta: `+1ms` }]])
   })
-})
 
-describe(`improvementsTables`, () => {
   test(`returns [] when the section has no Improvements sub-heading`, () => {
-    const tables = improvementsTables(
+    const tables = rankingTables(
       dedent`
         ### Self time
 
@@ -237,13 +238,14 @@ describe(`improvementsTables`, () => {
         | foo | +1ms |
       `,
       `Self time`,
+      `Improvements`,
     )
 
     expect(tables).toStrictEqual([])
   })
 
   test(`returns parsed rows from the Improvements table within the section`, () => {
-    const tables = improvementsTables(
+    const tables = rankingTables(
       dedent`
         ### Total time
 
@@ -256,6 +258,7 @@ describe(`improvementsTables`, () => {
         | foo | -1ms |
       `,
       `Total time`,
+      `Improvements`,
     )
 
     expect(tables).toStrictEqual([[{ Function: `foo`, Delta: `-1ms` }]])

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -75,15 +75,19 @@ export const categoryTables = (md: string): Table[] => {
   return results
 }
 
-export const regressionsTables = (md: string, section: string): Table[] => {
-  const under = nodesUnderHeading(parseMd(md), section)
-  return allTablesAfterHeadingContaining(under, `Regressions`)
-}
-
-export const improvementsTables = (md: string, section: string): Table[] => {
-  const under = nodesUnderHeading(parseMd(md), section)
-  return allTablesAfterHeadingContaining(under, `Improvements`)
-}
+/**
+ * The tables under {@link ranking} (a diff's `Regressions`, `Improvements`,
+ * `Increases`, or `Decreases` heading) in {@link section}.
+ */
+export const rankingTables = (
+  md: string,
+  section: string,
+  ranking: string,
+): Table[] =>
+  allTablesAfterHeadingContaining(
+    nodesUnderHeading(parseMd(md), section),
+    ranking,
+  )
 
 /**
  * The table ranking {@link section}'s own entries, above its category


### PR DESCRIPTION
A diff called every increase a regression and every decrease an improvement, which a metric measuring something other than a cost makes wrong, and which no metric in an emitter's own unrecognized unit states at all.

Every metric now states its improvement direction. A time, a size, and a count of what a profiler recorded are costs, so a decrease improves them. A unit this package cannot classify leaves the direction unknown unless the format's parser states it, and a diff of such a metric ranks Increases and Decreases rather than judging either. The CLI tints a diff row red where its ranking calls it a regression and green where it calls it an improvement, and leaves the unjudged rows untinted.

Closes #369