### PR TITLE
feat: break each heap snapshot ranking down by category

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ profiler-md
 │   │       ├── graph.ts          # Node adjacency graph in CSR format
 │   │       ├── retained.ts       # Retained size computation
 │   │       ├── aggregate.ts      # Heap snapshot aggregation over classified nodes
+│   │       ├── categorize.ts     # Node and entity categorization under the resolved origin
 │   │       ├── diff.ts           # Aggregated heap snapshot diffing logic
 │   │       ├── table.ts          # The heap snapshot formatter's table columns
 │   │       ├── format.ts         # Heap snapshot and diff to Markdown formatting

--- a/examples/output/javascript.bun.base.heapsnapshot.md
+++ b/examples/output/javascript.bun.base.heapsnapshot.md
@@ -46,6 +46,39 @@ Constructors ranked by bytes allocated for their instances, excluding nodes kept
 | <0.1% |     65 B |         1 | `ModuleNamespaceObject`             |
 | <0.1% |     64 B |         2 | `Promise (fulfilled)`               |
 
+#### Categories
+
+##### Object
+
+|     % |     Size | Instances | Constructor                         |
+| ----: | -------: | --------: | ----------------------------------- |
+|  6.4% | 96.7 KiB |     1,367 | `Object`                            |
+|  0.7% | 10.3 KiB |         1 | `GlobalObject`                      |
+|  0.1% | 1.19 KiB |         1 | `InternalModuleRegistry`            |
+|  0.1% | 1.14 KiB |         2 | `NodeJSFS`                          |
+|  0.1% |    779 B |         3 | `FileSink`                          |
+| <0.1% |    659 B |         2 | `FileInternalReadableStreamSource`  |
+| <0.1% |    329 B |        10 | `Map`                               |
+| <0.1% |    256 B |         8 | `Promise (fulfilled: Object)`       |
+| <0.1% |    242 B |         2 | `WriteStream`                       |
+| <0.1% |    213 B |         1 | `url `                              |
+| <0.1% |    128 B |         4 | `Promise (fulfilled: JSSourceCode)` |
+| <0.1% |    108 B |         3 | `Set`                               |
+| <0.1% |     89 B |         2 | `ReadableStream`                    |
+| <0.1% |     89 B |         1 | `ReadStream`                        |
+| <0.1% |     70 B |         1 | `String`                            |
+| <0.1% |     65 B |         1 | `ModuleNamespaceObject`             |
+| <0.1% |     64 B |         2 | `Promise (fulfilled)`               |
+| <0.1% |     62 B |         1 | `Math`                              |
+| <0.1% |     54 B |         1 | `Prototype`                         |
+| <0.1% |     50 B |         2 | `Iterator`                          |
+
+##### Code
+
+|    % |     Size | Instances | Constructor    |
+| ---: | -------: | --------: | -------------- |
+| 1.8% | 27.5 KiB |         4 | `ModuleRecord` |
+
 #### Instances
 
 Instances ranked by contribution to each constructor's self size.
@@ -186,6 +219,25 @@ Instances ranked by contribution to each constructor's self size.
 | -----: | ---: | --------: | ----------- |
 | 100.0% | 64 B |         2 | `(GC root)` |
 
+##### `Math`
+
+|      % | Size | Instances | Path                 |
+| -----: | ---: | --------: | -------------------- |
+| 100.0% | 62 B |         1 | `.Math GlobalObject` |
+
+##### `Prototype`
+
+|      % | Size | Instances | Path             |
+| -----: | ---: | --------: | ---------------- |
+| 100.0% | 54 B |         1 | `. GlobalObject` |
+
+##### `Iterator`
+
+|     % | Size | Instances | Path                           |
+| ----: | ---: | --------: | ------------------------------ |
+| 62.0% | 31 B |         1 | `. GlobalObject`               |
+| 38.0% | 19 B |         1 | `. Structure ← . GlobalObject` |
+
 ### Retained size
 
 Constructors ranked by bytes allocated for their instances and all nodes that would be freed if their instances were garbage collected.
@@ -212,6 +264,39 @@ Constructors ranked by bytes allocated for their instances and all nodes that wo
 |  0.1% | 2.17 KiB |         1 | `EventEmitter`                     |
 |  0.1% | 1.96 KiB |         3 | `FileSink`                         |
 |  0.1% | 1.89 KiB |         2 | `FileInternalReadableStreamSource` |
+
+#### Categories
+
+##### Object
+
+|     % |     Size | Instances | Constructor                        |
+| ----: | -------: | --------: | ---------------------------------- |
+| 83.7% | 1.24 MiB |         1 | `GlobalObject`                     |
+| 40.2% |  609 KiB |     1,367 | `Object`                           |
+|  3.5% | 52.3 KiB |         1 | `InternalModuleRegistry`           |
+|  3.4% | 51.8 KiB |         1 | `url `                             |
+|  1.1% | 16.8 KiB |        10 | `Map`                              |
+|  1.0% | 14.9 KiB |         1 | `ReadStream`                       |
+|  0.6% | 8.66 KiB |         2 | `WriteStream`                      |
+|  0.3% |  4.9 KiB |         1 | `console`                          |
+|  0.3% | 4.88 KiB |         1 | `Prototype`                        |
+|  0.3% | 4.87 KiB |         1 | `Math`                             |
+|  0.3% | 4.46 KiB |         1 | `String`                           |
+|  0.3% | 4.22 KiB |         2 | `ReadableStream`                   |
+|  0.2% | 2.98 KiB |         2 | `Iterator`                         |
+|  0.2% | 2.96 KiB |         2 | `NodeJSFS`                         |
+|  0.2% | 2.35 KiB |         2 | `ArrayBuffer`                      |
+|  0.1% | 2.17 KiB |         1 | `EventEmitter`                     |
+|  0.1% | 1.96 KiB |         3 | `FileSink`                         |
+|  0.1% | 1.89 KiB |         2 | `FileInternalReadableStreamSource` |
+|  0.1% | 1.23 KiB |         1 | `Stats`                            |
+|  0.1% | 1.16 KiB |         1 | `AsyncDisposableStack`             |
+
+##### Code
+
+|    % | Size | Instances | Constructor    |
+| ---: | ---: | --------: | -------------- |
+| 0.0% |  0 B |         4 | `ModuleRecord` |
 
 #### Instances
 
@@ -351,6 +436,24 @@ Instances ranked by contribution to each constructor's retained size.
 | ----: | -------: | --------: | ------------- |
 | 67.4% | 1.27 KiB |         1 | `. Structure` |
 | 32.6% |    632 B |         1 | `(GC root)`   |
+
+##### `Stats`
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 1.23 KiB |         1 | `(GC root)` |
+
+##### `AsyncDisposableStack`
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 1.16 KiB |         1 | `(GC root)` |
+
+##### `ModuleRecord`
+
+|    % |     Size | Instances | Path        |
+| ---: | -------: | --------: | ----------- |
+| 0.0% | 27.5 KiB |         4 | `(GC root)` |
 
 ## Largest functions
 
@@ -583,6 +686,10 @@ Nodes ranked by contribution to each function's retained size.
 ## Largest strings
 
 Strings ranked by bytes allocated for them.
+
+### Categories
+
+#### String
 
 |     % |  Size | Value                                                    | Path                                                                                                                                                     |
 | ----: | ----: | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/examples/output/javascript.bun.base.jsc-heap-snapshot.json.md
+++ b/examples/output/javascript.bun.base.jsc-heap-snapshot.json.md
@@ -44,6 +44,91 @@ Constructors ranked by bytes allocated for their instances, excluding nodes kept
 |  0.3% | 4.45 KiB |         1 | `ModuleProgramCodeBlock`     |
 |  0.2% | 2.29 KiB |        70 | `AsyncFunction`              |
 
+#### Categories
+
+##### Code
+
+|     % |     Size | Instances | Constructor                      |
+| ----: | -------: | --------: | -------------------------------- |
+| 17.5% |  261 KiB |       122 | `FunctionCodeBlock`              |
+|  7.8% |  116 KiB |       931 | `FunctionExecutable`             |
+|  6.1% | 90.9 KiB |       121 | `UnlinkedFunctionCodeBlock`      |
+|  5.8% | 86.7 KiB |       925 | `UnlinkedFunctionExecutable`     |
+|  3.4% |   51 KiB |       653 | `NativeExecutable`               |
+|  1.9% | 27.7 KiB |         4 | `ModuleRecord`                   |
+|  0.3% | 4.45 KiB |         1 | `ModuleProgramCodeBlock`         |
+|  0.1% | 1.68 KiB |         2 | `UnlinkedModuleProgramCodeBlock` |
+| <0.1% |    224 B |         2 | `ModuleProgramExecutable`        |
+| <0.1% |    128 B |         4 | `JSSourceCode`                   |
+
+##### Object shape
+
+|     % |    Size | Instances | Constructor |
+| ----: | ------: | --------: | ----------- |
+| 13.3% | 199 KiB |     1,816 | `Structure` |
+
+##### Object
+
+|     % |     Size | Instances | Constructor                        |
+| ----: | -------: | --------: | ---------------------------------- |
+|  6.5% | 96.9 KiB |     1,373 | `Object`                           |
+|  0.7% | 10.3 KiB |         1 | `GlobalObject`                     |
+|  0.1% | 1.19 KiB |         1 | `InternalModuleRegistry`           |
+|  0.1% | 1.14 KiB |         2 | `NodeJSFS`                         |
+|  0.1% |    829 B |         4 | `FileSink`                         |
+| <0.1% |    659 B |         2 | `FileInternalReadableStreamSource` |
+| <0.1% |    512 B |        16 | `InternalPromise`                  |
+| <0.1% |    363 B |         2 | `Blob`                             |
+| <0.1% |    329 B |        10 | `Map`                              |
+| <0.1% |    242 B |         2 | `WriteStream`                      |
+| <0.1% |    213 B |         1 | `Process`                          |
+| <0.1% |    210 B |         4 | `Generator`                        |
+| <0.1% |    156 B |         3 | `ReadableStream`                   |
+| <0.1% |    130 B |         4 | `JSAsyncGeneratorFunction`         |
+| <0.1% |    108 B |         3 | `Set`                              |
+| <0.1% |     91 B |         1 | `ReadStream`                       |
+| <0.1% |     80 B |         2 | `Stats`                            |
+| <0.1% |     76 B |         2 | `Dirent`                           |
+| <0.1% |     76 B |         2 | `StringDecoder`                    |
+| <0.1% |     70 B |         1 | `String`                           |
+
+##### Internal
+
+|     % |     Size | Instances | Constructor                  |
+| ----: | -------: | --------: | ---------------------------- |
+|  1.2% | 18.3 KiB |       390 | `PropertyTable`              |
+|  1.2% | 17.2 KiB |        10 | `Cell Butterfly`             |
+|  1.1% | 16.4 KiB |       210 | `FunctionRareData`           |
+|  0.8% | 12.7 KiB |       170 | `JSLexicalEnvironment`       |
+|  0.8% | 11.6 KiB |       185 | `SymbolTable`                |
+|  0.7% | 9.84 KiB |       105 | `StructureRareData`          |
+|  0.3% | 4.59 KiB |       147 | `GetterSetter`               |
+|  0.1% | 2.17 KiB |         4 | `JSModuleEnvironment`        |
+|  0.1% | 1.44 KiB |        46 | `CustomGetterSetter`         |
+|  0.1% |    768 B |        16 | `DOMAttributeGetterSetter`   |
+| <0.1% |    208 B |        13 | `StructureChain`             |
+| <0.1% |    144 B |         3 | `JSPropertyNameEnumerator`   |
+| <0.1% |     64 B |         1 | `JSGlobalLexicalEnvironment` |
+| <0.1% |     48 B |         1 | `PromiseReaction`            |
+
+##### Function
+
+|     % |     Size | Instances | Constructor              |
+| ----: | -------: | --------: | ------------------------ |
+|  4.2% | 62.5 KiB |     1,734 | `Function`               |
+|  0.2% | 2.29 KiB |        70 | `AsyncFunction`          |
+| <0.1% |    128 B |         4 | `Callee`                 |
+| <0.1% |    102 B |         3 | `GeneratorFunction`      |
+| <0.1% |     70 B |         2 | `AsyncGeneratorFunction` |
+
+##### Array
+
+|     % |     Size | Instances | Constructor           |
+| ----: | -------: | --------: | --------------------- |
+|  1.1% | 16.9 KiB |     1,077 | `Array`               |
+|  0.1% | 1.06 KiB |        34 | `SparseArrayValueMap` |
+| <0.1% |     18 B |         1 | `Array Iterator`      |
+
 #### Instances
 
 Instances ranked by contribution to each constructor's self size.
@@ -235,6 +320,245 @@ Instances ranked by contribution to each constructor's self size.
 | 1.5% | 34 B |         1 | `.copyFile Object ← <root>`                          |
 | 1.5% | 34 B |         1 | `.chown Object ← <root>`                             |
 
+##### `JSModuleEnvironment`
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 2.17 KiB |         4 | `(GC root)` |
+
+##### `UnlinkedModuleProgramCodeBlock`
+
+|      % |     Size | Instances | Path     |
+| -----: | -------: | --------: | -------- |
+| 100.0% | 1.68 KiB |         2 | `<root>` |
+
+##### `CustomGetterSetter`
+
+|    % | Size | Instances | Path                                                   |
+| ---: | ---: | --------: | ------------------------------------------------------ |
+| 2.2% | 32 B |         1 | `.arguments Function`                                  |
+| 2.2% | 32 B |         1 | `.caller Function`                                     |
+| 2.2% | 32 B |         1 | `.constructor Iterator ← GlobalObject ← <root>`        |
+| 2.2% | 32 B |         1 | `.Symbol.toStringTag Iterator ← GlobalObject ← <root>` |
+| 2.2% | 32 B |         1 | `.Buffer GlobalObject ← <root>`                        |
+
+##### `InternalModuleRegistry`
+
+|      % |     Size | Instances | Path                    |
+| -----: | -------: | --------: | ----------------------- |
+| 100.0% | 1.19 KiB |         1 | `GlobalObject ← <root>` |
+
+##### `NodeJSFS`
+
+|     % |     Size | Instances | Path                                |
+| ----: | -------: | --------: | ----------------------------------- |
+| 90.9% | 1.04 KiB |         1 | `<root>`                            |
+|  9.1% |    106 B |         1 | `Structure ← GlobalObject ← <root>` |
+
+##### `SparseArrayValueMap`
+
+|    % | Size | Instances | Path                                                                                                                                                                                      |
+| ---: | ---: | --------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2.9% | 32 B |         1 | `Object ← .prototype Function ← <root>`                                                                                                                                                   |
+| 2.9% | 32 B |         1 | `Function ← <root>`                                                                                                                                                                       |
+| 2.9% | 32 B |         1 | `Object ← .prototype Function ← .SafeStringIterator Object ← InternalModuleRegistry ← GlobalObject ← <root>`                                                                              |
+| 2.9% | 32 B |         1 | `Function ← .SafeStringIterator Object ← InternalModuleRegistry ← GlobalObject ← <root>`                                                                                                  |
+| 2.9% | 32 B |         1 | `Object ← .prototype Function ← .SafeIterator JSLexicalEnvironment ← Function ← .entries Object ← .prototype Function ← .SafeMap Object ← InternalModuleRegistry ← GlobalObject ← <root>` |
+
+##### `FileSink`
+
+|     % |  Size | Instances | Path                                         |
+| ----: | ----: | --------: | -------------------------------------------- |
+| 90.7% | 752 B |         2 | `.kWriteStreamFastPath WriteStream ← <root>` |
+|  6.0% |  50 B |         1 | `GlobalObject ← <root>`                      |
+|  3.3% |  27 B |         1 | `Structure ← GlobalObject ← <root>`          |
+
+##### `DOMAttributeGetterSetter`
+
+|    % | Size | Instances | Path                                                   |
+| ---: | ---: | --------: | ------------------------------------------------------ |
+| 6.3% | 48 B |         1 | `.Dirent NodeJSFS ← Structure ← GlobalObject ← <root>` |
+| 6.3% | 48 B |         1 | `.Stats NodeJSFS ← Structure ← GlobalObject ← <root>`  |
+| 6.3% | 48 B |         1 | `.lastChar StringDecoder ← <root>`                     |
+| 6.3% | 48 B |         1 | `.lastNeed StringDecoder ← <root>`                     |
+| 6.3% | 48 B |         1 | `.lastTotal StringDecoder ← <root>`                    |
+
+##### `FileInternalReadableStreamSource`
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 659 B |         2 | `(GC root)` |
+
+##### `InternalPromise`
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 512 B |        16 | `(GC root)` |
+
+##### `Blob`
+
+|     % |  Size | Instances | Path                    |
+| ----: | ----: | --------: | ----------------------- |
+| 90.4% | 328 B |         1 | `GlobalObject ← <root>` |
+|  9.6% |  35 B |         1 | `<root>`                |
+
+##### `Map`
+
+|     % | Size | Instances | Path                                                                                                                   |
+| ----: | ---: | --------: | ---------------------------------------------------------------------------------------------------------------------- |
+| 19.5% | 64 B |         2 | `(GC root)`                                                                                                            |
+| 12.5% | 41 B |         1 | `<root>`                                                                                                               |
+|  9.7% | 32 B |         1 | `.registry ModuleLoader ← GlobalObject ← <root>`                                                                       |
+|  9.7% | 32 B |         1 | `GlobalObject ← <root>`                                                                                                |
+|  9.7% | 32 B |         1 | `.dummy JSLexicalEnvironment ← .prototype Function ← .SafeMap Object ← InternalModuleRegistry ← GlobalObject ← <root>` |
+
+##### `WriteStream`
+
+|      % |  Size | Instances | Path     |
+| -----: | ----: | --------: | -------- |
+| 100.0% | 242 B |         2 | `<root>` |
+
+##### `ModuleProgramExecutable`
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 224 B |         2 | `(GC root)` |
+
+##### `Process`
+
+|      % |  Size | Instances | Path                    |
+| -----: | ----: | --------: | ----------------------- |
+| 100.0% | 213 B |         1 | `GlobalObject ← <root>` |
+
+##### `Generator`
+
+|     % |  Size | Instances | Path                    |
+| ----: | ----: | --------: | ----------------------- |
+| 91.4% | 192 B |         3 | `(GC root)`             |
+|  8.6% |  18 B |         1 | `GlobalObject ← <root>` |
+
+##### `StructureChain`
+
+|     % | Size | Instances | Path                                                                  |
+| ----: | ---: | --------: | --------------------------------------------------------------------- |
+| 23.1% | 48 B |         3 | `Structure ← Structure ← <root>`                                      |
+| 15.4% | 32 B |         2 | `Structure ← Structure ← Function ← <root>`                           |
+|  7.7% | 16 B |         1 | `<root>`                                                              |
+|  7.7% | 16 B |         1 | `Structure ← Object ← InternalModuleRegistry ← GlobalObject ← <root>` |
+|  7.7% | 16 B |         1 | `Structure ← <root>`                                                  |
+
+##### `ReadableStream`
+
+|     % | Size | Instances | Path                    |
+| ----: | ---: | --------: | ----------------------- |
+| 42.9% | 67 B |         1 | `GlobalObject ← <root>` |
+| 35.9% | 56 B |         1 | `<root>`                |
+| 21.2% | 33 B |         1 | `(GC root)`             |
+
+##### `JSPropertyNameEnumerator`
+
+|     % | Size | Instances | Path                                                          |
+| ----: | ---: | --------: | ------------------------------------------------------------- |
+| 33.3% | 48 B |         1 | `<root>`                                                      |
+| 33.3% | 48 B |         1 | `StructureRareData ← Structure ← <root>`                      |
+| 33.3% | 48 B |         1 | `StructureRareData ← Structure ← FunctionExecutable ← <root>` |
+
+##### `JSAsyncGeneratorFunction`
+
+|     % | Size | Instances | Path                                                          |
+| ----: | ---: | --------: | ------------------------------------------------------------- |
+| 26.2% | 34 B |         1 | `.Symbol.asyncIterator Object ← .prototype Function ← <root>` |
+| 24.6% | 32 B |         1 | `<root>`                                                      |
+| 24.6% | 32 B |         1 | `.fromReadable JSLexicalEnvironment ← <root>`                 |
+| 24.6% | 32 B |         1 | `.createAsyncIterator JSLexicalEnvironment ← <root>`          |
+
+##### `JSSourceCode`
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 128 B |         4 | `(GC root)` |
+
+##### `Callee`
+
+|     % | Size | Instances | Path                    |
+| ----: | ---: | --------: | ----------------------- |
+| 75.0% | 96 B |         3 | `GlobalObject ← <root>` |
+| 25.0% | 32 B |         1 | `(GC root)`             |
+
+##### `Set`
+
+|     % | Size | Instances | Path                                                           |
+| ----: | ---: | --------: | -------------------------------------------------------------- |
+| 40.7% | 44 B |         1 | `<root>`                                                       |
+| 29.6% | 32 B |         1 | `.dummy JSLexicalEnvironment ← .prototype Function ← <root>`   |
+| 29.6% | 32 B |         1 | `.allowedNodeEnvironmentFlags Process ← GlobalObject ← <root>` |
+
+##### `GeneratorFunction`
+
+|     % | Size | Instances | Path                                                                |
+| ----: | ---: | --------: | ------------------------------------------------------------------- |
+| 50.0% | 51 B |         1 | `.constructor GeneratorFunction ← GlobalObject ← <root>`            |
+| 31.4% | 32 B |         1 | `.globSync Object ← InternalModuleRegistry ← GlobalObject ← <root>` |
+| 18.6% | 19 B |         1 | `GlobalObject ← <root>`                                             |
+
+##### `ReadStream`
+
+|      % | Size | Instances | Path     |
+| -----: | ---: | --------: | -------- |
+| 100.0% | 91 B |         1 | `<root>` |
+
+##### `Stats`
+
+|     % | Size | Instances | Path                    |
+| ----: | ---: | --------: | ----------------------- |
+| 63.7% | 51 B |         1 | `GlobalObject ← <root>` |
+| 36.3% | 29 B |         1 | `<root>`                |
+
+##### `Dirent`
+
+|     % | Size | Instances | Path                    |
+| ----: | ---: | --------: | ----------------------- |
+| 67.1% | 51 B |         1 | `GlobalObject ← <root>` |
+| 32.9% | 25 B |         1 | `<root>`                |
+
+##### `StringDecoder`
+
+|     % | Size | Instances | Path                    |
+| ----: | ---: | --------: | ----------------------- |
+| 67.1% | 51 B |         1 | `GlobalObject ← <root>` |
+| 32.9% | 25 B |         1 | `<root>`                |
+
+##### `String`
+
+|      % | Size | Instances | Path                    |
+| -----: | ---: | --------: | ----------------------- |
+| 100.0% | 70 B |         1 | `GlobalObject ← <root>` |
+
+##### `AsyncGeneratorFunction`
+
+|     % | Size | Instances | Path                                                          |
+| ----: | ---: | --------: | ------------------------------------------------------------- |
+| 72.9% | 51 B |         1 | `.constructor AsyncGeneratorFunction ← GlobalObject ← <root>` |
+| 27.1% | 19 B |         1 | `GlobalObject ← <root>`                                       |
+
+##### `JSGlobalLexicalEnvironment`
+
+|      % | Size | Instances | Path                    |
+| -----: | ---: | --------: | ----------------------- |
+| 100.0% | 64 B |         1 | `GlobalObject ← <root>` |
+
+##### `PromiseReaction`
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 48 B |         1 | `(GC root)` |
+
+##### `Array Iterator`
+
+|      % | Size | Instances | Path                    |
+| -----: | ---: | --------: | ----------------------- |
+| 100.0% | 18 B |         1 | `GlobalObject ← <root>` |
+
 ### Retained size
 
 Constructors ranked by bytes allocated for their instances and all nodes that would be freed if their instances were garbage collected.
@@ -261,6 +585,91 @@ Constructors ranked by bytes allocated for their instances and all nodes that wo
 |  1.1% | 16.8 KiB |        10 | `Map`                        |
 |  1.1% | 16.5 KiB |        10 | `Cell Butterfly`             |
 |  1.1% | 15.8 KiB |       147 | `GetterSetter`               |
+
+#### Categories
+
+##### Code
+
+|     % |     Size | Instances | Constructor                      |
+| ----: | -------: | --------: | -------------------------------- |
+| 31.8% |  474 KiB |       931 | `FunctionExecutable`             |
+| 17.9% |  267 KiB |       122 | `FunctionCodeBlock`              |
+|  6.1% | 90.9 KiB |       121 | `UnlinkedFunctionCodeBlock`      |
+|  5.8% | 86.7 KiB |       925 | `UnlinkedFunctionExecutable`     |
+|  3.4% | 50.9 KiB |       653 | `NativeExecutable`               |
+|  0.2% | 2.53 KiB |         2 | `UnlinkedModuleProgramCodeBlock` |
+|  0.0% |      0 B |         4 | `JSSourceCode`                   |
+|  0.0% |      0 B |         2 | `ModuleProgramExecutable`        |
+|  0.0% |      0 B |         4 | `ModuleRecord`                   |
+|  0.0% |      0 B |         1 | `ModuleProgramCodeBlock`         |
+
+##### Object shape
+
+|     % |    Size | Instances | Constructor |
+| ----: | ------: | --------: | ----------- |
+| 15.5% | 231 KiB |     1,816 | `Structure` |
+
+##### Object
+
+|     % |     Size | Instances | Constructor                        |
+| ----: | -------: | --------: | ---------------------------------- |
+| 89.1% |  1.3 MiB |         1 | `GlobalObject`                     |
+| 41.3% |  615 KiB |     1,373 | `Object`                           |
+|  3.3% | 49.5 KiB |         1 | `InternalModuleRegistry`           |
+|  1.3% | 18.8 KiB |         1 | `Process`                          |
+|  1.1% | 16.8 KiB |        10 | `Map`                              |
+|  1.0% | 15.6 KiB |         1 | `ReadStream`                       |
+|  0.6% | 9.16 KiB |         2 | `WriteStream`                      |
+|  0.3% | 4.89 KiB |         1 | `console`                          |
+|  0.3% | 4.88 KiB |         1 | `Prototype`                        |
+|  0.3% | 4.86 KiB |         1 | `Math`                             |
+|  0.3% | 4.83 KiB |         3 | `ReadableStream`                   |
+|  0.3% | 4.45 KiB |         1 | `String`                           |
+|  0.2% | 2.98 KiB |         2 | `Iterator`                         |
+|  0.2% | 2.95 KiB |         2 | `NodeJSFS`                         |
+|  0.2% | 2.41 KiB |         4 | `FileSink`                         |
+|  0.2% | 2.38 KiB |         2 | `Blob`                             |
+|  0.2% | 2.35 KiB |         2 | `ArrayBuffer`                      |
+|  0.1% | 2.17 KiB |         1 | `EventEmitter`                     |
+|  0.1% | 1.89 KiB |         2 | `FileInternalReadableStreamSource` |
+|  0.1% | 1.46 KiB |         2 | `Stats`                            |
+
+##### Internal
+
+|     % |     Size | Instances | Constructor                  |
+| ----: | -------: | --------: | ---------------------------- |
+|  1.8% | 26.6 KiB |       170 | `JSLexicalEnvironment`       |
+|  1.4% | 21.5 KiB |       105 | `StructureRareData`          |
+|  1.2% | 18.1 KiB |       390 | `PropertyTable`              |
+|  1.2% | 17.5 KiB |       210 | `FunctionRareData`           |
+|  1.1% | 16.5 KiB |        10 | `Cell Butterfly`             |
+|  1.1% | 15.8 KiB |       147 | `GetterSetter`               |
+|  0.8% | 11.3 KiB |       185 | `SymbolTable`                |
+|  0.1% | 1.44 KiB |        46 | `CustomGetterSetter`         |
+|  0.1% |    768 B |        16 | `DOMAttributeGetterSetter`   |
+| <0.1% |    240 B |         1 | `JSGlobalLexicalEnvironment` |
+| <0.1% |    212 B |         3 | `JSPropertyNameEnumerator`   |
+| <0.1% |    208 B |        13 | `StructureChain`             |
+|  0.0% |      0 B |         1 | `PromiseReaction`            |
+|  0.0% |      0 B |         4 | `JSModuleEnvironment`        |
+
+##### Function
+
+|     % |     Size | Instances | Constructor              |
+| ----: | -------: | --------: | ------------------------ |
+| 19.0% |  284 KiB |     1,734 | `Function`               |
+|  0.5% | 7.67 KiB |        70 | `AsyncFunction`          |
+| <0.1% |    488 B |         3 | `GeneratorFunction`      |
+| <0.1% |    466 B |         2 | `AsyncGeneratorFunction` |
+| <0.1% |     96 B |         4 | `Callee`                 |
+
+##### Array
+
+|     % |     Size | Instances | Constructor           |
+| ----: | -------: | --------: | --------------------- |
+| 29.9% |  446 KiB |     1,077 | `Array`               |
+|  0.1% | 1.03 KiB |        34 | `SparseArrayValueMap` |
+| <0.1% |    464 B |         1 | `Array Iterator`      |
 
 #### Instances
 
@@ -449,9 +858,255 @@ Instances ranked by contribution to each constructor's retained size.
 | 1.1% | 176 B |         1 | `.constructor Object ← .homeObject Function ← <root>`                                                                        |
 | 1.1% | 176 B |         1 | `.constructor Object ← .prototype Function ← .ExceptionWithHostPort Object ← InternalModuleRegistry ← GlobalObject ← <root>` |
 
+##### `ReadStream`
+
+|      % |     Size | Instances | Path     |
+| -----: | -------: | --------: | -------- |
+| 100.0% | 15.6 KiB |         1 | `<root>` |
+
+##### `SymbolTable`
+
+|     % |  Size | Instances | Path                                                 |
+| ----: | ----: | --------: | ---------------------------------------------------- |
+| 17.7% | 2 KiB |        16 | `<root>`                                             |
+|  7.7% | 896 B |         7 | `(GC root)`                                          |
+|  2.2% | 256 B |         2 | `UnlinkedModuleProgramCodeBlock ← <root>`            |
+|  0.6% |  64 B |         1 | `GlobalObject ← <root>`                              |
+|  0.6% |  64 B |         1 | `JSGlobalLexicalEnvironment ← GlobalObject ← <root>` |
+
+##### `WriteStream`
+
+|      % |     Size | Instances | Path     |
+| -----: | -------: | --------: | -------- |
+| 100.0% | 9.16 KiB |         2 | `<root>` |
+
+##### `AsyncFunction`
+
+|    % |  Size | Instances | Path                                                 |
+| ---: | ----: | --------: | ---------------------------------------------------- |
+| 7.7% | 607 B |         1 | `GlobalObject ← <root>`                              |
+| 4.0% | 311 B |         1 | `.Symbol.asyncDispose Object ← <root>`               |
+| 3.1% | 240 B |         1 | `.constructor AsyncFunction ← GlobalObject ← <root>` |
+| 2.1% | 162 B |         1 | `.access Object ← <root>`                            |
+| 2.1% | 162 B |         1 | `<root>`                                             |
+
+##### `console`
+
+|      % |     Size | Instances | Path                             |
+| -----: | -------: | --------: | -------------------------------- |
+| 100.0% | 4.89 KiB |         1 | `.console GlobalObject ← <root>` |
+
+##### `Prototype`
+
+|      % |     Size | Instances | Path                    |
+| -----: | -------: | --------: | ----------------------- |
+| 100.0% | 4.88 KiB |         1 | `GlobalObject ← <root>` |
+
+##### `Math`
+
+|      % |     Size | Instances | Path                          |
+| -----: | -------: | --------: | ----------------------------- |
+| 100.0% | 4.86 KiB |         1 | `.Math GlobalObject ← <root>` |
+
+##### `ReadableStream`
+
+|     % |     Size | Instances | Path                    |
+| ----: | -------: | --------: | ----------------------- |
+| 60.7% | 2.93 KiB |         1 | `(GC root)`             |
+| 26.7% | 1.29 KiB |         1 | `<root>`                |
+| 12.6% |    625 B |         1 | `GlobalObject ← <root>` |
+
+##### `String`
+
+|      % |     Size | Instances | Path                    |
+| -----: | -------: | --------: | ----------------------- |
+| 100.0% | 4.45 KiB |         1 | `GlobalObject ← <root>` |
+
+##### `Iterator`
+
+|     % |     Size | Instances | Path                                |
+| ----: | -------: | --------: | ----------------------------------- |
+| 79.2% | 2.36 KiB |         1 | `GlobalObject ← <root>`             |
+| 20.8% |    635 B |         1 | `Structure ← GlobalObject ← <root>` |
+
+##### `NodeJSFS`
+
+|     % |     Size | Instances | Path                                |
+| ----: | -------: | --------: | ----------------------------------- |
+| 64.8% | 1.92 KiB |         1 | `Structure ← GlobalObject ← <root>` |
+| 35.2% | 1.04 KiB |         1 | `<root>`                            |
+
+##### `UnlinkedModuleProgramCodeBlock`
+
+|      % |     Size | Instances | Path     |
+| -----: | -------: | --------: | -------- |
+| 100.0% | 2.53 KiB |         2 | `<root>` |
+
+##### `FileSink`
+
+|     % |     Size | Instances | Path                                         |
+| ----: | -------: | --------: | -------------------------------------------- |
+| 51.0% | 1.23 KiB |         1 | `Structure ← GlobalObject ← <root>`          |
+| 30.4% |    752 B |         2 | `.kWriteStreamFastPath WriteStream ← <root>` |
+| 18.5% |    458 B |         1 | `GlobalObject ← <root>`                      |
+
+##### `Blob`
+
+|     % |     Size | Instances | Path                    |
+| ----: | -------: | --------: | ----------------------- |
+| 86.6% | 2.06 KiB |         1 | `<root>`                |
+| 13.4% |    328 B |         1 | `GlobalObject ← <root>` |
+
+##### `ArrayBuffer`
+
+|      % |     Size | Instances | Path     |
+| -----: | -------: | --------: | -------- |
+| 100.0% | 2.35 KiB |         2 | `<root>` |
+
+##### `EventEmitter`
+
+|      % |     Size | Instances | Path     |
+| -----: | -------: | --------: | -------- |
+| 100.0% | 2.17 KiB |         1 | `<root>` |
+
+##### `FileInternalReadableStreamSource`
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 1.89 KiB |         2 | `(GC root)` |
+
+##### `Stats`
+
+|     % |     Size | Instances | Path                    |
+| ----: | -------: | --------: | ----------------------- |
+| 84.5% | 1.23 KiB |         1 | `<root>`                |
+| 15.5% |    232 B |         1 | `GlobalObject ← <root>` |
+
+##### `CustomGetterSetter`
+
+|    % | Size | Instances | Path                                                   |
+| ---: | ---: | --------: | ------------------------------------------------------ |
+| 2.2% | 32 B |         1 | `.arguments Function`                                  |
+| 2.2% | 32 B |         1 | `.caller Function`                                     |
+| 2.2% | 32 B |         1 | `.constructor Iterator ← GlobalObject ← <root>`        |
+| 2.2% | 32 B |         1 | `.Symbol.toStringTag Iterator ← GlobalObject ← <root>` |
+| 2.2% | 32 B |         1 | `.Buffer GlobalObject ← <root>`                        |
+
+##### `SparseArrayValueMap`
+
+|    % | Size | Instances | Path                                                                                                                                                                                      |
+| ---: | ---: | --------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 3.0% | 32 B |         1 | `Object ← .prototype Function ← <root>`                                                                                                                                                   |
+| 3.0% | 32 B |         1 | `Function ← <root>`                                                                                                                                                                       |
+| 3.0% | 32 B |         1 | `Object ← .prototype Function ← .SafeStringIterator Object ← InternalModuleRegistry ← GlobalObject ← <root>`                                                                              |
+| 3.0% | 32 B |         1 | `Function ← .SafeStringIterator Object ← InternalModuleRegistry ← GlobalObject ← <root>`                                                                                                  |
+| 3.0% | 32 B |         1 | `Object ← .prototype Function ← .SafeIterator JSLexicalEnvironment ← Function ← .entries Object ← .prototype Function ← .SafeMap Object ← InternalModuleRegistry ← GlobalObject ← <root>` |
+
+##### `DOMAttributeGetterSetter`
+
+|    % | Size | Instances | Path                                                   |
+| ---: | ---: | --------: | ------------------------------------------------------ |
+| 6.3% | 48 B |         1 | `.Dirent NodeJSFS ← Structure ← GlobalObject ← <root>` |
+| 6.3% | 48 B |         1 | `.Stats NodeJSFS ← Structure ← GlobalObject ← <root>`  |
+| 6.3% | 48 B |         1 | `.lastChar StringDecoder ← <root>`                     |
+| 6.3% | 48 B |         1 | `.lastNeed StringDecoder ← <root>`                     |
+| 6.3% | 48 B |         1 | `.lastTotal StringDecoder ← <root>`                    |
+
+##### `GeneratorFunction`
+
+|     % |  Size | Instances | Path                                                                |
+| ----: | ----: | --------: | ------------------------------------------------------------------- |
+| 93.4% | 456 B |         1 | `GlobalObject ← <root>`                                             |
+| 50.0% | 244 B |         1 | `.constructor GeneratorFunction ← GlobalObject ← <root>`            |
+|  6.6% |  32 B |         1 | `.globSync Object ← InternalModuleRegistry ← GlobalObject ← <root>` |
+
+##### `AsyncGeneratorFunction`
+
+|      % |  Size | Instances | Path                                                          |
+| -----: | ----: | --------: | ------------------------------------------------------------- |
+| 100.0% | 466 B |         1 | `GlobalObject ← <root>`                                       |
+|  53.4% | 249 B |         1 | `.constructor AsyncGeneratorFunction ← GlobalObject ← <root>` |
+
+##### `Array Iterator`
+
+|      % |  Size | Instances | Path                    |
+| -----: | ----: | --------: | ----------------------- |
+| 100.0% | 464 B |         1 | `GlobalObject ← <root>` |
+
+##### `JSGlobalLexicalEnvironment`
+
+|      % |  Size | Instances | Path                    |
+| -----: | ----: | --------: | ----------------------- |
+| 100.0% | 240 B |         1 | `GlobalObject ← <root>` |
+
+##### `JSPropertyNameEnumerator`
+
+|     % | Size | Instances | Path                                                          |
+| ----: | ---: | --------: | ------------------------------------------------------------- |
+| 38.7% | 82 B |         1 | `StructureRareData ← Structure ← <root>`                      |
+| 38.7% | 82 B |         1 | `StructureRareData ← Structure ← FunctionExecutable ← <root>` |
+| 22.6% | 48 B |         1 | `<root>`                                                      |
+
+##### `StructureChain`
+
+|     % | Size | Instances | Path                                                                  |
+| ----: | ---: | --------: | --------------------------------------------------------------------- |
+| 23.1% | 48 B |         3 | `Structure ← Structure ← <root>`                                      |
+| 15.4% | 32 B |         2 | `Structure ← Structure ← Function ← <root>`                           |
+|  7.7% | 16 B |         1 | `<root>`                                                              |
+|  7.7% | 16 B |         1 | `Structure ← Object ← InternalModuleRegistry ← GlobalObject ← <root>` |
+|  7.7% | 16 B |         1 | `Structure ← <root>`                                                  |
+
+##### `Callee`
+
+|      % | Size | Instances | Path                    |
+| -----: | ---: | --------: | ----------------------- |
+| 100.0% | 96 B |         3 | `GlobalObject ← <root>` |
+|  33.3% | 32 B |         1 | `(GC root)`             |
+
+##### `JSSourceCode`
+
+|    % |  Size | Instances | Path        |
+| ---: | ----: | --------: | ----------- |
+| 0.0% | 128 B |         4 | `(GC root)` |
+
+##### `ModuleProgramExecutable`
+
+|    % |  Size | Instances | Path        |
+| ---: | ----: | --------: | ----------- |
+| 0.0% | 224 B |         2 | `(GC root)` |
+
+##### `ModuleRecord`
+
+|    % |     Size | Instances | Path        |
+| ---: | -------: | --------: | ----------- |
+| 0.0% | 27.7 KiB |         4 | `(GC root)` |
+
+##### `ModuleProgramCodeBlock`
+
+|    % |     Size | Instances | Path        |
+| ---: | -------: | --------: | ----------- |
+| 0.0% | 4.45 KiB |         1 | `(GC root)` |
+
+##### `PromiseReaction`
+
+|    % | Size | Instances | Path        |
+| ---: | ---: | --------: | ----------- |
+| 0.0% | 48 B |         1 | `(GC root)` |
+
+##### `JSModuleEnvironment`
+
+|    % |     Size | Instances | Path        |
+| ---: | -------: | --------: | ----------- |
+| 0.0% | 2.17 KiB |         4 | `(GC root)` |
+
 ## Largest strings
 
 Strings ranked by bytes allocated for them.
+
+### Categories
+
+#### String
 
 |     % |  Size | Path                                                                                                                                                    |
 | ----: | ----: | ------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/examples/output/javascript.bun.current.heapsnapshot.md
+++ b/examples/output/javascript.bun.current.heapsnapshot.md
@@ -46,6 +46,39 @@ Constructors ranked by bytes allocated for their instances, excluding nodes kept
 | <0.1% |     65 B |         1 | `ModuleNamespaceObject`             |
 | <0.1% |     64 B |         2 | `Promise (fulfilled)`               |
 
+#### Categories
+
+##### Object
+
+|     % |     Size | Instances | Constructor                         |
+| ----: | -------: | --------: | ----------------------------------- |
+|  6.4% | 96.7 KiB |     1,367 | `Object`                            |
+|  0.7% | 10.3 KiB |         1 | `GlobalObject`                      |
+|  0.1% | 1.19 KiB |         1 | `InternalModuleRegistry`            |
+|  0.1% | 1.14 KiB |         2 | `NodeJSFS`                          |
+|  0.1% |    779 B |         3 | `FileSink`                          |
+| <0.1% |    659 B |         2 | `FileInternalReadableStreamSource`  |
+| <0.1% |    329 B |        10 | `Map`                               |
+| <0.1% |    256 B |         8 | `Promise (fulfilled: Object)`       |
+| <0.1% |    242 B |         2 | `WriteStream`                       |
+| <0.1% |    213 B |         1 | `url `                              |
+| <0.1% |    128 B |         4 | `Promise (fulfilled: JSSourceCode)` |
+| <0.1% |    108 B |         3 | `Set`                               |
+| <0.1% |     89 B |         2 | `ReadableStream`                    |
+| <0.1% |     89 B |         1 | `ReadStream`                        |
+| <0.1% |     70 B |         1 | `String`                            |
+| <0.1% |     65 B |         1 | `ModuleNamespaceObject`             |
+| <0.1% |     64 B |         2 | `Promise (fulfilled)`               |
+| <0.1% |     62 B |         1 | `Math`                              |
+| <0.1% |     54 B |         1 | `Prototype`                         |
+| <0.1% |     50 B |         2 | `Iterator`                          |
+
+##### Code
+
+|    % |     Size | Instances | Constructor    |
+| ---: | -------: | --------: | -------------- |
+| 1.8% | 27.5 KiB |         4 | `ModuleRecord` |
+
 #### Instances
 
 Instances ranked by contribution to each constructor's self size.
@@ -186,6 +219,25 @@ Instances ranked by contribution to each constructor's self size.
 | -----: | ---: | --------: | ----------- |
 | 100.0% | 64 B |         2 | `(GC root)` |
 
+##### `Math`
+
+|      % | Size | Instances | Path                 |
+| -----: | ---: | --------: | -------------------- |
+| 100.0% | 62 B |         1 | `.Math GlobalObject` |
+
+##### `Prototype`
+
+|      % | Size | Instances | Path             |
+| -----: | ---: | --------: | ---------------- |
+| 100.0% | 54 B |         1 | `. GlobalObject` |
+
+##### `Iterator`
+
+|     % | Size | Instances | Path                           |
+| ----: | ---: | --------: | ------------------------------ |
+| 62.0% | 31 B |         1 | `. GlobalObject`               |
+| 38.0% | 19 B |         1 | `. Structure ← . GlobalObject` |
+
 ### Retained size
 
 Constructors ranked by bytes allocated for their instances and all nodes that would be freed if their instances were garbage collected.
@@ -212,6 +264,39 @@ Constructors ranked by bytes allocated for their instances and all nodes that wo
 |  0.1% | 2.17 KiB |         1 | `EventEmitter`                     |
 |  0.1% | 1.96 KiB |         3 | `FileSink`                         |
 |  0.1% | 1.89 KiB |         2 | `FileInternalReadableStreamSource` |
+
+#### Categories
+
+##### Object
+
+|     % |     Size | Instances | Constructor                        |
+| ----: | -------: | --------: | ---------------------------------- |
+| 83.7% | 1.24 MiB |         1 | `GlobalObject`                     |
+| 40.3% |  609 KiB |     1,367 | `Object`                           |
+|  3.5% | 52.3 KiB |         1 | `InternalModuleRegistry`           |
+|  3.4% | 50.8 KiB |         1 | `url `                             |
+|  1.1% | 16.8 KiB |        10 | `Map`                              |
+|  0.9% | 13.7 KiB |         1 | `ReadStream`                       |
+|  0.6% | 8.66 KiB |         2 | `WriteStream`                      |
+|  0.3% |  4.9 KiB |         1 | `console`                          |
+|  0.3% | 4.88 KiB |         1 | `Prototype`                        |
+|  0.3% | 4.87 KiB |         1 | `Math`                             |
+|  0.3% | 4.46 KiB |         1 | `String`                           |
+|  0.3% | 4.22 KiB |         2 | `ReadableStream`                   |
+|  0.2% | 2.98 KiB |         2 | `Iterator`                         |
+|  0.2% | 2.96 KiB |         2 | `NodeJSFS`                         |
+|  0.2% | 2.35 KiB |         2 | `ArrayBuffer`                      |
+|  0.1% | 2.17 KiB |         1 | `EventEmitter`                     |
+|  0.1% | 1.96 KiB |         3 | `FileSink`                         |
+|  0.1% | 1.89 KiB |         2 | `FileInternalReadableStreamSource` |
+|  0.1% | 1.23 KiB |         1 | `Stats`                            |
+|  0.1% | 1.16 KiB |         1 | `AsyncDisposableStack`             |
+
+##### Code
+
+|    % | Size | Instances | Constructor    |
+| ---: | ---: | --------: | -------------- |
+| 0.0% |  0 B |         4 | `ModuleRecord` |
 
 #### Instances
 
@@ -351,6 +436,24 @@ Instances ranked by contribution to each constructor's retained size.
 | ----: | -------: | --------: | ------------- |
 | 67.4% | 1.27 KiB |         1 | `. Structure` |
 | 32.6% |    632 B |         1 | `(GC root)`   |
+
+##### `Stats`
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 1.23 KiB |         1 | `(GC root)` |
+
+##### `AsyncDisposableStack`
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 1.16 KiB |         1 | `(GC root)` |
+
+##### `ModuleRecord`
+
+|    % |     Size | Instances | Path        |
+| ---: | -------: | --------: | ----------- |
+| 0.0% | 27.5 KiB |         4 | `(GC root)` |
 
 ## Largest functions
 
@@ -583,6 +686,10 @@ Nodes ranked by contribution to each function's retained size.
 ## Largest strings
 
 Strings ranked by bytes allocated for them.
+
+### Categories
+
+#### String
 
 |     % |  Size | Value                                                    | Path                                                                                                                                                     |
 | ----: | ----: | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/examples/output/javascript.bun.current.jsc-heap-snapshot.json.md
+++ b/examples/output/javascript.bun.current.jsc-heap-snapshot.json.md
@@ -44,6 +44,91 @@ Constructors ranked by bytes allocated for their instances, excluding nodes kept
 |  0.3% | 4.45 KiB |         1 | `ModuleProgramCodeBlock`     |
 |  0.2% | 2.29 KiB |        70 | `AsyncFunction`              |
 
+#### Categories
+
+##### Code
+
+|     % |     Size | Instances | Constructor                      |
+| ----: | -------: | --------: | -------------------------------- |
+| 17.5% |  261 KiB |       122 | `FunctionCodeBlock`              |
+|  7.8% |  116 KiB |       931 | `FunctionExecutable`             |
+|  6.1% | 90.9 KiB |       121 | `UnlinkedFunctionCodeBlock`      |
+|  5.8% | 86.7 KiB |       925 | `UnlinkedFunctionExecutable`     |
+|  3.4% |   51 KiB |       653 | `NativeExecutable`               |
+|  1.9% | 27.7 KiB |         4 | `ModuleRecord`                   |
+|  0.3% | 4.45 KiB |         1 | `ModuleProgramCodeBlock`         |
+|  0.1% | 1.68 KiB |         2 | `UnlinkedModuleProgramCodeBlock` |
+| <0.1% |    224 B |         2 | `ModuleProgramExecutable`        |
+| <0.1% |    128 B |         4 | `JSSourceCode`                   |
+
+##### Object shape
+
+|     % |    Size | Instances | Constructor |
+| ----: | ------: | --------: | ----------- |
+| 13.4% | 200 KiB |     1,829 | `Structure` |
+
+##### Object
+
+|     % |     Size | Instances | Constructor                        |
+| ----: | -------: | --------: | ---------------------------------- |
+|  6.5% | 96.9 KiB |     1,373 | `Object`                           |
+|  0.7% | 10.3 KiB |         1 | `GlobalObject`                     |
+|  0.1% | 1.19 KiB |         1 | `InternalModuleRegistry`           |
+|  0.1% | 1.14 KiB |         2 | `NodeJSFS`                         |
+|  0.1% |    829 B |         4 | `FileSink`                         |
+| <0.1% |    659 B |         2 | `FileInternalReadableStreamSource` |
+| <0.1% |    512 B |        16 | `InternalPromise`                  |
+| <0.1% |    363 B |         2 | `Blob`                             |
+| <0.1% |    329 B |        10 | `Map`                              |
+| <0.1% |    242 B |         2 | `WriteStream`                      |
+| <0.1% |    213 B |         1 | `Process`                          |
+| <0.1% |    210 B |         4 | `Generator`                        |
+| <0.1% |    156 B |         3 | `ReadableStream`                   |
+| <0.1% |    130 B |         4 | `JSAsyncGeneratorFunction`         |
+| <0.1% |    108 B |         3 | `Set`                              |
+| <0.1% |     91 B |         1 | `ReadStream`                       |
+| <0.1% |     80 B |         2 | `Stats`                            |
+| <0.1% |     76 B |         2 | `Dirent`                           |
+| <0.1% |     76 B |         2 | `StringDecoder`                    |
+| <0.1% |     70 B |         1 | `String`                           |
+
+##### Internal
+
+|     % |     Size | Instances | Constructor                  |
+| ----: | -------: | --------: | ---------------------------- |
+|  1.2% | 18.3 KiB |       391 | `PropertyTable`              |
+|  1.2% | 17.2 KiB |        10 | `Cell Butterfly`             |
+|  1.1% | 16.4 KiB |       210 | `FunctionRareData`           |
+|  0.8% | 12.7 KiB |       170 | `JSLexicalEnvironment`       |
+|  0.8% | 11.6 KiB |       185 | `SymbolTable`                |
+|  0.7% | 9.84 KiB |       105 | `StructureRareData`          |
+|  0.3% | 4.59 KiB |       147 | `GetterSetter`               |
+|  0.1% | 2.17 KiB |         4 | `JSModuleEnvironment`        |
+|  0.1% | 1.44 KiB |        46 | `CustomGetterSetter`         |
+|  0.1% |    768 B |        16 | `DOMAttributeGetterSetter`   |
+| <0.1% |    208 B |        13 | `StructureChain`             |
+| <0.1% |    144 B |         3 | `JSPropertyNameEnumerator`   |
+| <0.1% |     64 B |         1 | `JSGlobalLexicalEnvironment` |
+| <0.1% |     48 B |         1 | `PromiseReaction`            |
+
+##### Function
+
+|     % |     Size | Instances | Constructor              |
+| ----: | -------: | --------: | ------------------------ |
+|  4.2% | 62.5 KiB |     1,734 | `Function`               |
+|  0.2% | 2.29 KiB |        70 | `AsyncFunction`          |
+| <0.1% |    128 B |         4 | `Callee`                 |
+| <0.1% |    102 B |         3 | `GeneratorFunction`      |
+| <0.1% |     70 B |         2 | `AsyncGeneratorFunction` |
+
+##### Array
+
+|     % |     Size | Instances | Constructor           |
+| ----: | -------: | --------: | --------------------- |
+|  1.1% | 16.9 KiB |     1,077 | `Array`               |
+|  0.1% | 1.06 KiB |        34 | `SparseArrayValueMap` |
+| <0.1% |     18 B |         1 | `Array Iterator`      |
+
 #### Instances
 
 Instances ranked by contribution to each constructor's self size.
@@ -235,6 +320,245 @@ Instances ranked by contribution to each constructor's self size.
 | 1.5% | 34 B |         1 | `.copyFile Object ← <root>`                          |
 | 1.5% | 34 B |         1 | `.chown Object ← <root>`                             |
 
+##### `JSModuleEnvironment`
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 2.17 KiB |         4 | `(GC root)` |
+
+##### `UnlinkedModuleProgramCodeBlock`
+
+|      % |     Size | Instances | Path     |
+| -----: | -------: | --------: | -------- |
+| 100.0% | 1.68 KiB |         2 | `<root>` |
+
+##### `CustomGetterSetter`
+
+|    % | Size | Instances | Path                                                   |
+| ---: | ---: | --------: | ------------------------------------------------------ |
+| 2.2% | 32 B |         1 | `.arguments Function`                                  |
+| 2.2% | 32 B |         1 | `.caller Function`                                     |
+| 2.2% | 32 B |         1 | `.constructor Iterator ← GlobalObject ← <root>`        |
+| 2.2% | 32 B |         1 | `.Symbol.toStringTag Iterator ← GlobalObject ← <root>` |
+| 2.2% | 32 B |         1 | `.Buffer GlobalObject ← <root>`                        |
+
+##### `InternalModuleRegistry`
+
+|      % |     Size | Instances | Path                    |
+| -----: | -------: | --------: | ----------------------- |
+| 100.0% | 1.19 KiB |         1 | `GlobalObject ← <root>` |
+
+##### `NodeJSFS`
+
+|     % |     Size | Instances | Path                                |
+| ----: | -------: | --------: | ----------------------------------- |
+| 90.9% | 1.04 KiB |         1 | `<root>`                            |
+|  9.1% |    106 B |         1 | `Structure ← GlobalObject ← <root>` |
+
+##### `SparseArrayValueMap`
+
+|    % | Size | Instances | Path                                                                                                                                                                                      |
+| ---: | ---: | --------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2.9% | 32 B |         1 | `Object ← .prototype Function ← <root>`                                                                                                                                                   |
+| 2.9% | 32 B |         1 | `Function ← <root>`                                                                                                                                                                       |
+| 2.9% | 32 B |         1 | `Object ← .prototype Function ← .SafeStringIterator Object ← InternalModuleRegistry ← GlobalObject ← <root>`                                                                              |
+| 2.9% | 32 B |         1 | `Function ← .SafeStringIterator Object ← InternalModuleRegistry ← GlobalObject ← <root>`                                                                                                  |
+| 2.9% | 32 B |         1 | `Object ← .prototype Function ← .SafeIterator JSLexicalEnvironment ← Function ← .entries Object ← .prototype Function ← .SafeMap Object ← InternalModuleRegistry ← GlobalObject ← <root>` |
+
+##### `FileSink`
+
+|     % |  Size | Instances | Path                                         |
+| ----: | ----: | --------: | -------------------------------------------- |
+| 90.7% | 752 B |         2 | `.kWriteStreamFastPath WriteStream ← <root>` |
+|  6.0% |  50 B |         1 | `GlobalObject ← <root>`                      |
+|  3.3% |  27 B |         1 | `Structure ← GlobalObject ← <root>`          |
+
+##### `DOMAttributeGetterSetter`
+
+|    % | Size | Instances | Path                                                   |
+| ---: | ---: | --------: | ------------------------------------------------------ |
+| 6.3% | 48 B |         1 | `.Dirent NodeJSFS ← Structure ← GlobalObject ← <root>` |
+| 6.3% | 48 B |         1 | `.Stats NodeJSFS ← Structure ← GlobalObject ← <root>`  |
+| 6.3% | 48 B |         1 | `.lastChar StringDecoder ← <root>`                     |
+| 6.3% | 48 B |         1 | `.lastNeed StringDecoder ← <root>`                     |
+| 6.3% | 48 B |         1 | `.lastTotal StringDecoder ← <root>`                    |
+
+##### `FileInternalReadableStreamSource`
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 659 B |         2 | `(GC root)` |
+
+##### `InternalPromise`
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 512 B |        16 | `(GC root)` |
+
+##### `Blob`
+
+|     % |  Size | Instances | Path                    |
+| ----: | ----: | --------: | ----------------------- |
+| 90.4% | 328 B |         1 | `GlobalObject ← <root>` |
+|  9.6% |  35 B |         1 | `<root>`                |
+
+##### `Map`
+
+|     % | Size | Instances | Path                                                                                                                   |
+| ----: | ---: | --------: | ---------------------------------------------------------------------------------------------------------------------- |
+| 19.5% | 64 B |         2 | `(GC root)`                                                                                                            |
+| 12.5% | 41 B |         1 | `<root>`                                                                                                               |
+|  9.7% | 32 B |         1 | `.registry ModuleLoader ← GlobalObject ← <root>`                                                                       |
+|  9.7% | 32 B |         1 | `GlobalObject ← <root>`                                                                                                |
+|  9.7% | 32 B |         1 | `.dummy JSLexicalEnvironment ← .prototype Function ← .SafeMap Object ← InternalModuleRegistry ← GlobalObject ← <root>` |
+
+##### `WriteStream`
+
+|      % |  Size | Instances | Path     |
+| -----: | ----: | --------: | -------- |
+| 100.0% | 242 B |         2 | `<root>` |
+
+##### `ModuleProgramExecutable`
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 224 B |         2 | `(GC root)` |
+
+##### `Process`
+
+|      % |  Size | Instances | Path                    |
+| -----: | ----: | --------: | ----------------------- |
+| 100.0% | 213 B |         1 | `GlobalObject ← <root>` |
+
+##### `Generator`
+
+|     % |  Size | Instances | Path                    |
+| ----: | ----: | --------: | ----------------------- |
+| 91.4% | 192 B |         3 | `(GC root)`             |
+|  8.6% |  18 B |         1 | `GlobalObject ← <root>` |
+
+##### `StructureChain`
+
+|     % | Size | Instances | Path                                                                  |
+| ----: | ---: | --------: | --------------------------------------------------------------------- |
+| 23.1% | 48 B |         3 | `Structure ← Structure ← <root>`                                      |
+| 15.4% | 32 B |         2 | `Structure ← Structure ← Function ← <root>`                           |
+|  7.7% | 16 B |         1 | `(GC root)`                                                           |
+|  7.7% | 16 B |         1 | `Structure ← Object ← InternalModuleRegistry ← GlobalObject ← <root>` |
+|  7.7% | 16 B |         1 | `Structure ← <root>`                                                  |
+
+##### `ReadableStream`
+
+|     % | Size | Instances | Path                    |
+| ----: | ---: | --------: | ----------------------- |
+| 42.9% | 67 B |         1 | `GlobalObject ← <root>` |
+| 35.9% | 56 B |         1 | `<root>`                |
+| 21.2% | 33 B |         1 | `(GC root)`             |
+
+##### `JSPropertyNameEnumerator`
+
+|     % | Size | Instances | Path                                                          |
+| ----: | ---: | --------: | ------------------------------------------------------------- |
+| 33.3% | 48 B |         1 | `<root>`                                                      |
+| 33.3% | 48 B |         1 | `StructureRareData ← Structure ← <root>`                      |
+| 33.3% | 48 B |         1 | `StructureRareData ← Structure ← FunctionExecutable ← <root>` |
+
+##### `JSAsyncGeneratorFunction`
+
+|     % | Size | Instances | Path                                                          |
+| ----: | ---: | --------: | ------------------------------------------------------------- |
+| 26.2% | 34 B |         1 | `.Symbol.asyncIterator Object ← .prototype Function ← <root>` |
+| 24.6% | 32 B |         1 | `<root>`                                                      |
+| 24.6% | 32 B |         1 | `.fromReadable JSLexicalEnvironment ← <root>`                 |
+| 24.6% | 32 B |         1 | `.createAsyncIterator JSLexicalEnvironment ← <root>`          |
+
+##### `JSSourceCode`
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 128 B |         4 | `(GC root)` |
+
+##### `Callee`
+
+|     % | Size | Instances | Path                    |
+| ----: | ---: | --------: | ----------------------- |
+| 75.0% | 96 B |         3 | `GlobalObject ← <root>` |
+| 25.0% | 32 B |         1 | `(GC root)`             |
+
+##### `Set`
+
+|     % | Size | Instances | Path                                                           |
+| ----: | ---: | --------: | -------------------------------------------------------------- |
+| 40.7% | 44 B |         1 | `<root>`                                                       |
+| 29.6% | 32 B |         1 | `.dummy JSLexicalEnvironment ← .homeObject Function ← <root>`  |
+| 29.6% | 32 B |         1 | `.allowedNodeEnvironmentFlags Process ← GlobalObject ← <root>` |
+
+##### `GeneratorFunction`
+
+|     % | Size | Instances | Path                                                                |
+| ----: | ---: | --------: | ------------------------------------------------------------------- |
+| 50.0% | 51 B |         1 | `.constructor GeneratorFunction ← GlobalObject ← <root>`            |
+| 31.4% | 32 B |         1 | `.globSync Object ← InternalModuleRegistry ← GlobalObject ← <root>` |
+| 18.6% | 19 B |         1 | `GlobalObject ← <root>`                                             |
+
+##### `ReadStream`
+
+|      % | Size | Instances | Path     |
+| -----: | ---: | --------: | -------- |
+| 100.0% | 91 B |         1 | `<root>` |
+
+##### `Stats`
+
+|     % | Size | Instances | Path                    |
+| ----: | ---: | --------: | ----------------------- |
+| 63.7% | 51 B |         1 | `GlobalObject ← <root>` |
+| 36.3% | 29 B |         1 | `<root>`                |
+
+##### `Dirent`
+
+|     % | Size | Instances | Path                    |
+| ----: | ---: | --------: | ----------------------- |
+| 67.1% | 51 B |         1 | `GlobalObject ← <root>` |
+| 32.9% | 25 B |         1 | `<root>`                |
+
+##### `StringDecoder`
+
+|     % | Size | Instances | Path                    |
+| ----: | ---: | --------: | ----------------------- |
+| 67.1% | 51 B |         1 | `GlobalObject ← <root>` |
+| 32.9% | 25 B |         1 | `<root>`                |
+
+##### `String`
+
+|      % | Size | Instances | Path                    |
+| -----: | ---: | --------: | ----------------------- |
+| 100.0% | 70 B |         1 | `GlobalObject ← <root>` |
+
+##### `AsyncGeneratorFunction`
+
+|     % | Size | Instances | Path                                                          |
+| ----: | ---: | --------: | ------------------------------------------------------------- |
+| 72.9% | 51 B |         1 | `.constructor AsyncGeneratorFunction ← GlobalObject ← <root>` |
+| 27.1% | 19 B |         1 | `GlobalObject ← <root>`                                       |
+
+##### `JSGlobalLexicalEnvironment`
+
+|      % | Size | Instances | Path                    |
+| -----: | ---: | --------: | ----------------------- |
+| 100.0% | 64 B |         1 | `GlobalObject ← <root>` |
+
+##### `PromiseReaction`
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 48 B |         1 | `(GC root)` |
+
+##### `Array Iterator`
+
+|      % | Size | Instances | Path                    |
+| -----: | ---: | --------: | ----------------------- |
+| 100.0% | 18 B |         1 | `GlobalObject ← <root>` |
+
 ### Retained size
 
 Constructors ranked by bytes allocated for their instances and all nodes that would be freed if their instances were garbage collected.
@@ -261,6 +585,91 @@ Constructors ranked by bytes allocated for their instances and all nodes that wo
 |  1.1% | 16.8 KiB |        10 | `Map`                        |
 |  1.1% | 16.5 KiB |        10 | `Cell Butterfly`             |
 |  1.1% | 15.8 KiB |       147 | `GetterSetter`               |
+
+#### Categories
+
+##### Code
+
+|     % |     Size | Instances | Constructor                      |
+| ----: | -------: | --------: | -------------------------------- |
+| 31.9% |  476 KiB |       931 | `FunctionExecutable`             |
+| 17.9% |  267 KiB |       122 | `FunctionCodeBlock`              |
+|  6.1% | 90.9 KiB |       121 | `UnlinkedFunctionCodeBlock`      |
+|  5.8% | 86.7 KiB |       925 | `UnlinkedFunctionExecutable`     |
+|  3.4% | 50.9 KiB |       653 | `NativeExecutable`               |
+|  0.2% | 2.53 KiB |         2 | `UnlinkedModuleProgramCodeBlock` |
+|  0.0% |      0 B |         4 | `JSSourceCode`                   |
+|  0.0% |      0 B |         2 | `ModuleProgramExecutable`        |
+|  0.0% |      0 B |         4 | `ModuleRecord`                   |
+|  0.0% |      0 B |         1 | `ModuleProgramCodeBlock`         |
+
+##### Object shape
+
+|     % |    Size | Instances | Constructor |
+| ----: | ------: | --------: | ----------- |
+| 15.6% | 232 KiB |     1,829 | `Structure` |
+
+##### Object
+
+|     % |     Size | Instances | Constructor                        |
+| ----: | -------: | --------: | ---------------------------------- |
+| 82.9% | 1.21 MiB |         1 | `GlobalObject`                     |
+| 40.5% |  603 KiB |     1,373 | `Object`                           |
+|  3.3% | 49.5 KiB |         1 | `InternalModuleRegistry`           |
+|  1.3% | 18.8 KiB |         1 | `Process`                          |
+|  1.1% | 16.8 KiB |        10 | `Map`                              |
+|  1.0% | 15.6 KiB |         1 | `ReadStream`                       |
+|  0.6% | 9.16 KiB |         2 | `WriteStream`                      |
+|  0.3% | 4.89 KiB |         1 | `console`                          |
+|  0.3% | 4.88 KiB |         1 | `Prototype`                        |
+|  0.3% | 4.86 KiB |         1 | `Math`                             |
+|  0.3% | 4.83 KiB |         3 | `ReadableStream`                   |
+|  0.3% | 4.45 KiB |         1 | `String`                           |
+|  0.2% | 2.98 KiB |         2 | `Iterator`                         |
+|  0.2% | 2.95 KiB |         2 | `NodeJSFS`                         |
+|  0.2% | 2.41 KiB |         4 | `FileSink`                         |
+|  0.2% | 2.38 KiB |         2 | `Blob`                             |
+|  0.2% | 2.35 KiB |         2 | `ArrayBuffer`                      |
+|  0.1% | 2.17 KiB |         1 | `EventEmitter`                     |
+|  0.1% | 1.89 KiB |         2 | `FileInternalReadableStreamSource` |
+|  0.1% | 1.46 KiB |         2 | `Stats`                            |
+
+##### Internal
+
+|     % |     Size | Instances | Constructor                  |
+| ----: | -------: | --------: | ---------------------------- |
+|  1.8% | 26.6 KiB |       170 | `JSLexicalEnvironment`       |
+|  1.4% | 20.7 KiB |       105 | `StructureRareData`          |
+|  1.2% | 18.2 KiB |       391 | `PropertyTable`              |
+|  1.2% | 17.5 KiB |       210 | `FunctionRareData`           |
+|  1.1% | 16.5 KiB |        10 | `Cell Butterfly`             |
+|  1.1% | 15.8 KiB |       147 | `GetterSetter`               |
+|  0.8% | 11.3 KiB |       185 | `SymbolTable`                |
+|  0.1% | 1.44 KiB |        46 | `CustomGetterSetter`         |
+|  0.1% |    768 B |        16 | `DOMAttributeGetterSetter`   |
+| <0.1% |    240 B |         1 | `JSGlobalLexicalEnvironment` |
+| <0.1% |    212 B |         3 | `JSPropertyNameEnumerator`   |
+| <0.1% |    208 B |        13 | `StructureChain`             |
+|  0.0% |      0 B |         1 | `PromiseReaction`            |
+|  0.0% |      0 B |         4 | `JSModuleEnvironment`        |
+
+##### Function
+
+|     % |     Size | Instances | Constructor              |
+| ----: | -------: | --------: | ------------------------ |
+| 19.0% |  284 KiB |     1,734 | `Function`               |
+|  0.5% | 7.67 KiB |        70 | `AsyncFunction`          |
+| <0.1% |    488 B |         3 | `GeneratorFunction`      |
+| <0.1% |    466 B |         2 | `AsyncGeneratorFunction` |
+| <0.1% |     96 B |         4 | `Callee`                 |
+
+##### Array
+
+|     % |     Size | Instances | Constructor           |
+| ----: | -------: | --------: | --------------------- |
+| 29.9% |  446 KiB |     1,077 | `Array`               |
+|  0.1% | 1.03 KiB |        34 | `SparseArrayValueMap` |
+| <0.1% |    464 B |         1 | `Array Iterator`      |
 
 #### Instances
 
@@ -449,9 +858,255 @@ Instances ranked by contribution to each constructor's retained size.
 | 1.1% | 176 B |         1 | `.constructor Object ← .homeObject Function ← <root>`                                                                         |
 | 1.1% | 176 B |         1 | `.constructor Object ← .homeObject Function ← .ExceptionWithHostPort Object ← InternalModuleRegistry ← GlobalObject ← <root>` |
 
+##### `ReadStream`
+
+|      % |     Size | Instances | Path     |
+| -----: | -------: | --------: | -------- |
+| 100.0% | 15.6 KiB |         1 | `<root>` |
+
+##### `SymbolTable`
+
+|     % |  Size | Instances | Path                                                 |
+| ----: | ----: | --------: | ---------------------------------------------------- |
+| 17.7% | 2 KiB |        16 | `<root>`                                             |
+|  7.7% | 896 B |         7 | `(GC root)`                                          |
+|  2.2% | 256 B |         2 | `UnlinkedModuleProgramCodeBlock ← <root>`            |
+|  0.6% |  64 B |         1 | `GlobalObject ← <root>`                              |
+|  0.6% |  64 B |         1 | `JSGlobalLexicalEnvironment ← GlobalObject ← <root>` |
+
+##### `WriteStream`
+
+|      % |     Size | Instances | Path     |
+| -----: | -------: | --------: | -------- |
+| 100.0% | 9.16 KiB |         2 | `<root>` |
+
+##### `AsyncFunction`
+
+|    % |  Size | Instances | Path                                                 |
+| ---: | ----: | --------: | ---------------------------------------------------- |
+| 7.7% | 607 B |         1 | `GlobalObject ← <root>`                              |
+| 4.0% | 311 B |         1 | `.Symbol.asyncDispose Object ← <root>`               |
+| 3.1% | 240 B |         1 | `.constructor AsyncFunction ← GlobalObject ← <root>` |
+| 2.1% | 162 B |         1 | `.access Object ← <root>`                            |
+| 2.1% | 162 B |         1 | `<root>`                                             |
+
+##### `console`
+
+|      % |     Size | Instances | Path                             |
+| -----: | -------: | --------: | -------------------------------- |
+| 100.0% | 4.89 KiB |         1 | `.console GlobalObject ← <root>` |
+
+##### `Prototype`
+
+|      % |     Size | Instances | Path                    |
+| -----: | -------: | --------: | ----------------------- |
+| 100.0% | 4.88 KiB |         1 | `GlobalObject ← <root>` |
+
+##### `Math`
+
+|      % |     Size | Instances | Path                          |
+| -----: | -------: | --------: | ----------------------------- |
+| 100.0% | 4.86 KiB |         1 | `.Math GlobalObject ← <root>` |
+
+##### `ReadableStream`
+
+|     % |     Size | Instances | Path                    |
+| ----: | -------: | --------: | ----------------------- |
+| 60.7% | 2.93 KiB |         1 | `(GC root)`             |
+| 26.7% | 1.29 KiB |         1 | `<root>`                |
+| 12.6% |    625 B |         1 | `GlobalObject ← <root>` |
+
+##### `String`
+
+|      % |     Size | Instances | Path                    |
+| -----: | -------: | --------: | ----------------------- |
+| 100.0% | 4.45 KiB |         1 | `GlobalObject ← <root>` |
+
+##### `Iterator`
+
+|     % |     Size | Instances | Path                                |
+| ----: | -------: | --------: | ----------------------------------- |
+| 79.2% | 2.36 KiB |         1 | `GlobalObject ← <root>`             |
+| 20.8% |    635 B |         1 | `Structure ← GlobalObject ← <root>` |
+
+##### `NodeJSFS`
+
+|     % |     Size | Instances | Path                                |
+| ----: | -------: | --------: | ----------------------------------- |
+| 64.8% | 1.92 KiB |         1 | `Structure ← GlobalObject ← <root>` |
+| 35.2% | 1.04 KiB |         1 | `<root>`                            |
+
+##### `UnlinkedModuleProgramCodeBlock`
+
+|      % |     Size | Instances | Path     |
+| -----: | -------: | --------: | -------- |
+| 100.0% | 2.53 KiB |         2 | `<root>` |
+
+##### `FileSink`
+
+|     % |     Size | Instances | Path                                         |
+| ----: | -------: | --------: | -------------------------------------------- |
+| 51.0% | 1.23 KiB |         1 | `Structure ← GlobalObject ← <root>`          |
+| 30.4% |    752 B |         2 | `.kWriteStreamFastPath WriteStream ← <root>` |
+| 18.5% |    458 B |         1 | `GlobalObject ← <root>`                      |
+
+##### `Blob`
+
+|     % |     Size | Instances | Path                    |
+| ----: | -------: | --------: | ----------------------- |
+| 86.6% | 2.06 KiB |         1 | `<root>`                |
+| 13.4% |    328 B |         1 | `GlobalObject ← <root>` |
+
+##### `ArrayBuffer`
+
+|      % |     Size | Instances | Path     |
+| -----: | -------: | --------: | -------- |
+| 100.0% | 2.35 KiB |         2 | `<root>` |
+
+##### `EventEmitter`
+
+|      % |     Size | Instances | Path     |
+| -----: | -------: | --------: | -------- |
+| 100.0% | 2.17 KiB |         1 | `<root>` |
+
+##### `FileInternalReadableStreamSource`
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 1.89 KiB |         2 | `(GC root)` |
+
+##### `Stats`
+
+|     % |     Size | Instances | Path                    |
+| ----: | -------: | --------: | ----------------------- |
+| 84.5% | 1.23 KiB |         1 | `<root>`                |
+| 15.5% |    232 B |         1 | `GlobalObject ← <root>` |
+
+##### `CustomGetterSetter`
+
+|    % | Size | Instances | Path                                                   |
+| ---: | ---: | --------: | ------------------------------------------------------ |
+| 2.2% | 32 B |         1 | `.arguments Function`                                  |
+| 2.2% | 32 B |         1 | `.caller Function`                                     |
+| 2.2% | 32 B |         1 | `.constructor Iterator ← GlobalObject ← <root>`        |
+| 2.2% | 32 B |         1 | `.Symbol.toStringTag Iterator ← GlobalObject ← <root>` |
+| 2.2% | 32 B |         1 | `.Buffer GlobalObject ← <root>`                        |
+
+##### `SparseArrayValueMap`
+
+|    % | Size | Instances | Path                                                                                                                                                                                      |
+| ---: | ---: | --------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 3.0% | 32 B |         1 | `Object ← .prototype Function ← <root>`                                                                                                                                                   |
+| 3.0% | 32 B |         1 | `Function ← <root>`                                                                                                                                                                       |
+| 3.0% | 32 B |         1 | `Object ← .prototype Function ← .SafeStringIterator Object ← InternalModuleRegistry ← GlobalObject ← <root>`                                                                              |
+| 3.0% | 32 B |         1 | `Function ← .SafeStringIterator Object ← InternalModuleRegistry ← GlobalObject ← <root>`                                                                                                  |
+| 3.0% | 32 B |         1 | `Object ← .prototype Function ← .SafeIterator JSLexicalEnvironment ← Function ← .entries Object ← .prototype Function ← .SafeMap Object ← InternalModuleRegistry ← GlobalObject ← <root>` |
+
+##### `DOMAttributeGetterSetter`
+
+|    % | Size | Instances | Path                                                   |
+| ---: | ---: | --------: | ------------------------------------------------------ |
+| 6.3% | 48 B |         1 | `.Dirent NodeJSFS ← Structure ← GlobalObject ← <root>` |
+| 6.3% | 48 B |         1 | `.Stats NodeJSFS ← Structure ← GlobalObject ← <root>`  |
+| 6.3% | 48 B |         1 | `.lastChar StringDecoder ← <root>`                     |
+| 6.3% | 48 B |         1 | `.lastNeed StringDecoder ← <root>`                     |
+| 6.3% | 48 B |         1 | `.lastTotal StringDecoder ← <root>`                    |
+
+##### `GeneratorFunction`
+
+|     % |  Size | Instances | Path                                                                |
+| ----: | ----: | --------: | ------------------------------------------------------------------- |
+| 93.4% | 456 B |         1 | `GlobalObject ← <root>`                                             |
+| 50.0% | 244 B |         1 | `.constructor GeneratorFunction ← GlobalObject ← <root>`            |
+|  6.6% |  32 B |         1 | `.globSync Object ← InternalModuleRegistry ← GlobalObject ← <root>` |
+
+##### `AsyncGeneratorFunction`
+
+|      % |  Size | Instances | Path                                                          |
+| -----: | ----: | --------: | ------------------------------------------------------------- |
+| 100.0% | 466 B |         1 | `GlobalObject ← <root>`                                       |
+|  53.4% | 249 B |         1 | `.constructor AsyncGeneratorFunction ← GlobalObject ← <root>` |
+
+##### `Array Iterator`
+
+|      % |  Size | Instances | Path                    |
+| -----: | ----: | --------: | ----------------------- |
+| 100.0% | 464 B |         1 | `GlobalObject ← <root>` |
+
+##### `JSGlobalLexicalEnvironment`
+
+|      % |  Size | Instances | Path                    |
+| -----: | ----: | --------: | ----------------------- |
+| 100.0% | 240 B |         1 | `GlobalObject ← <root>` |
+
+##### `JSPropertyNameEnumerator`
+
+|     % | Size | Instances | Path                                                          |
+| ----: | ---: | --------: | ------------------------------------------------------------- |
+| 38.7% | 82 B |         1 | `StructureRareData ← Structure ← <root>`                      |
+| 38.7% | 82 B |         1 | `StructureRareData ← Structure ← FunctionExecutable ← <root>` |
+| 22.6% | 48 B |         1 | `<root>`                                                      |
+
+##### `StructureChain`
+
+|     % | Size | Instances | Path                                                                  |
+| ----: | ---: | --------: | --------------------------------------------------------------------- |
+| 23.1% | 48 B |         3 | `Structure ← Structure ← <root>`                                      |
+| 15.4% | 32 B |         2 | `Structure ← Structure ← Function ← <root>`                           |
+|  7.7% | 16 B |         1 | `(GC root)`                                                           |
+|  7.7% | 16 B |         1 | `Structure ← Object ← InternalModuleRegistry ← GlobalObject ← <root>` |
+|  7.7% | 16 B |         1 | `Structure ← <root>`                                                  |
+
+##### `Callee`
+
+|      % | Size | Instances | Path                    |
+| -----: | ---: | --------: | ----------------------- |
+| 100.0% | 96 B |         3 | `GlobalObject ← <root>` |
+|  33.3% | 32 B |         1 | `(GC root)`             |
+
+##### `JSSourceCode`
+
+|    % |  Size | Instances | Path        |
+| ---: | ----: | --------: | ----------- |
+| 0.0% | 128 B |         4 | `(GC root)` |
+
+##### `ModuleProgramExecutable`
+
+|    % |  Size | Instances | Path        |
+| ---: | ----: | --------: | ----------- |
+| 0.0% | 224 B |         2 | `(GC root)` |
+
+##### `ModuleRecord`
+
+|    % |     Size | Instances | Path        |
+| ---: | -------: | --------: | ----------- |
+| 0.0% | 27.7 KiB |         4 | `(GC root)` |
+
+##### `ModuleProgramCodeBlock`
+
+|    % |     Size | Instances | Path        |
+| ---: | -------: | --------: | ----------- |
+| 0.0% | 4.45 KiB |         1 | `(GC root)` |
+
+##### `PromiseReaction`
+
+|    % | Size | Instances | Path        |
+| ---: | ---: | --------: | ----------- |
+| 0.0% | 48 B |         1 | `(GC root)` |
+
+##### `JSModuleEnvironment`
+
+|    % |     Size | Instances | Path        |
+| ---: | -------: | --------: | ----------- |
+| 0.0% | 2.17 KiB |         4 | `(GC root)` |
+
 ## Largest strings
 
 Strings ranked by bytes allocated for them.
+
+### Categories
+
+#### String
 
 |     % |  Size | Path                                                                                                                                                    |
 | ----: | ----: | ------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/examples/output/javascript.bun.diff.heapsnapshot.md
+++ b/examples/output/javascript.bun.diff.heapsnapshot.md
@@ -31,6 +31,8 @@ Constructors ranked by bytes allocated for their instances and all nodes that wo
 
 Constructors with the largest decrease in retained size.
 
+##### Object
+
 | Change |      Delta |            % |                Size | Instances | Constructor           |
 | -----: | ---------: | -----------: | ------------------: | --------: | --------------------- |
 |  -0.2% | -2.937 KiB |        83.7% |            1.24 MiB |         1 | `GlobalObject`        |

--- a/examples/output/javascript.bun.diff.jsc-heap-snapshot.json.md
+++ b/examples/output/javascript.bun.diff.jsc-heap-snapshot.json.md
@@ -30,6 +30,18 @@ Constructors with the largest increase in self size.
 |  +0.7% | +1.421 KiB | 13.3% → 13.4% | 199 KiB → 200 KiB | 1,816 → 1,829 | `Structure`     |
 |  +0.3% |      +48 B |          1.2% |          18.3 KiB |     390 → 391 | `PropertyTable` |
 
+##### Object shape
+
+| Change |      Delta |             % |              Size |     Instances | Constructor |
+| -----: | ---------: | ------------: | ----------------: | ------------: | ----------- |
+|  +0.7% | +1.421 KiB | 13.3% → 13.4% | 199 KiB → 200 KiB | 1,816 → 1,829 | `Structure` |
+
+##### Internal
+
+| Change | Delta |    % |     Size | Instances | Constructor     |
+| -----: | ----: | ---: | -------: | --------: | --------------- |
+|  +0.3% | +48 B | 1.2% | 18.3 KiB | 390 → 391 | `PropertyTable` |
+
 ### Retained size
 
 Constructors ranked by bytes allocated for their instances and all nodes that would be freed if their instances were garbage collected.
@@ -48,6 +60,38 @@ Constructors with the largest increase in retained size.
 |   +0.3% |      +48 B |          1.2% | 18.1 KiB → 18.2 KiB |     390 → 391 | `PropertyTable`       |
 |     ~0% |       +3 B |          1.3% |            18.8 KiB |             1 | `Process`             |
 
+##### Code
+
+| Change |      Delta |             % |              Size | Instances | Constructor          |
+| -----: | ---------: | ------------: | ----------------: | --------: | -------------------- |
+|  +0.3% | +1.467 KiB | 31.8% → 31.9% | 474 KiB → 476 KiB |       931 | `FunctionExecutable` |
+
+##### Object shape
+
+| Change |      Delta |             % |              Size |     Instances | Constructor |
+| -----: | ---------: | ------------: | ----------------: | ------------: | ----------- |
+|  +0.6% | +1.453 KiB | 15.5% → 15.6% | 231 KiB → 232 KiB | 1,816 → 1,829 | `Structure` |
+
+##### Object
+
+|  Change |  Delta |            % |             Size | Instances | Constructor           |
+| ------: | -----: | -----------: | ---------------: | --------: | --------------------- |
+|  +51.1% | +384 B | <0.1% → 0.1% | 752 B → 1.11 KiB |         1 | `FixedQueue`          |
+| +150.0% | +384 B |        <0.1% |    256 B → 640 B |         1 | `FixedCircularBuffer` |
+|     ~0% |   +3 B |         1.3% |         18.8 KiB |         1 | `Process`             |
+
+##### Internal
+
+| Change | Delta |    % |                Size | Instances | Constructor     |
+| -----: | ----: | ---: | ------------------: | --------: | --------------- |
+|  +0.3% | +48 B | 1.2% | 18.1 KiB → 18.2 KiB | 390 → 391 | `PropertyTable` |
+
+##### Array
+
+| Change |  Delta |     % |    Size | Instances | Constructor |
+| -----: | -----: | ----: | ------: | --------: | ----------- |
+|  +0.1% | +387 B | 29.9% | 446 KiB |     1,077 | `Array`     |
+
 #### Improvements
 
 Constructors with the largest decrease in retained size.
@@ -57,3 +101,16 @@ Constructors with the largest decrease in retained size.
 |  -6.8% | -90.746 KiB | 89.1% → 82.9% |  1.3 MiB → 1.21 MiB |         1 | `GlobalObject`      |
 |  -1.9% | -11.593 KiB | 41.3% → 40.5% |   615 KiB → 603 KiB |     1,373 | `Object`            |
 |  -4.0% |      -880 B |          1.4% | 21.5 KiB → 20.7 KiB |       105 | `StructureRareData` |
+
+##### Object
+
+| Change |       Delta |             % |               Size | Instances | Constructor    |
+| -----: | ----------: | ------------: | -----------------: | --------: | -------------- |
+|  -6.8% | -90.746 KiB | 89.1% → 82.9% | 1.3 MiB → 1.21 MiB |         1 | `GlobalObject` |
+|  -1.9% | -11.593 KiB | 41.3% → 40.5% |  615 KiB → 603 KiB |     1,373 | `Object`       |
+
+##### Internal
+
+| Change |  Delta |    % |                Size | Instances | Constructor         |
+| -----: | -----: | ---: | ------------------: | --------: | ------------------- |
+|  -4.0% | -880 B | 1.4% | 21.5 KiB → 20.7 KiB |       105 | `StructureRareData` |

--- a/examples/output/javascript.chrome.base.heapsnapshot.md
+++ b/examples/output/javascript.chrome.base.heapsnapshot.md
@@ -47,6 +47,65 @@ Constructors ranked by bytes allocated for their instances, excluding nodes kept
 | <0.1% |    304 B |         2 | `PerformanceResourceTiming`   | `<unknown>` |
 | <0.1% |    212 B |         3 | `MutationObserver`            | `<unknown>` |
 
+#### Categories
+
+##### Object
+
+|     % |     Size | Instances | Constructor        | Location           |
+| ----: | -------: | --------: | ------------------ | ------------------ |
+|  7.0% | 71.3 KiB |     1,464 | `Object`           | `<unknown>`        |
+|  0.3% | 2.65 KiB |       113 | `system / Context` | `<unknown>`        |
+|  0.1% |   1020 B |        37 | `Error`            | `<unknown>`        |
+|  0.1% |   1008 B |        36 | `TypedArray`       | `<unknown>`        |
+| <0.1% |    176 B |         5 | `Generator`        | `workload.mjs:1:1` |
+| <0.1% |    132 B |         6 | `Map`              | `<unknown>`        |
+| <0.1% |    116 B |         5 | `Set`              | `<unknown>`        |
+| <0.1% |    104 B |         4 | `Promise`          | `<unknown>`        |
+| <0.1% |    100 B |         4 | `WeakSet`          | `<unknown>`        |
+| <0.1% |    100 B |         4 | `WeakMap`          | `<unknown>`        |
+| <0.1% |     84 B |         3 | `AsyncGenerator`   | `<unknown>`        |
+| <0.1% |     84 B |         3 | `Map Iterator`     | `<unknown>`        |
+| <0.1% |     84 B |         3 | `Set Iterator`     | `<unknown>`        |
+| <0.1% |     84 B |         3 | `String Iterator`  | `<unknown>`        |
+| <0.1% |     84 B |         3 | `JSON`             | `<unknown>`        |
+| <0.1% |     84 B |         3 | `Tag`              | `<unknown>`        |
+| <0.1% |     84 B |         3 | `Math`             | `<unknown>`        |
+| <0.1% |     84 B |         3 | `Reflect`          | `<unknown>`        |
+| <0.1% |     84 B |         3 | `Intl`             | `<unknown>`        |
+| <0.1% |     84 B |         3 | `Atomics`          | `<unknown>`        |
+
+##### Native
+
+|     % |     Size | Instances | Constructor                                  | Location    |
+| ----: | -------: | --------: | -------------------------------------------- | ----------- |
+|  1.6% | 16.3 KiB |       208 | `Text`                                       | `<unknown>` |
+|  1.3% | 13.3 KiB |       154 | `system / ExternalStringData`                | `<unknown>` |
+|  1.2% | 11.7 KiB |       100 | `<p>`                                        | `<unknown>` |
+|  1.2% | 11.7 KiB |       100 | `<article class="status">`                   | `<unknown>` |
+|  1.2% | 11.7 KiB |       100 | `<h2>`                                       | `<unknown>` |
+|  0.3% |  3.2 KiB |         3 | `HTMLDocument`                               | `<unknown>` |
+|  0.1% |   1016 B |        10 | `Window`                                     | `<unknown>` |
+|  0.1% |    968 B |         1 | `Performance`                                | `<unknown>` |
+|  0.1% |    960 B |         8 | `<span class="hashtag">`                     | `<unknown>` |
+|  0.1% |    824 B |         1 | `StyleEngine`                                | `<unknown>` |
+| <0.1% |    416 B |         1 | `JSModuleScript`                             | `<unknown>` |
+| <0.1% |    400 B |         1 | `Navigator`                                  | `<unknown>` |
+| <0.1% |    328 B |         1 | `FontFaceSet`                                | `<unknown>` |
+| <0.1% |    304 B |         2 | `PerformanceResourceTiming`                  | `<unknown>` |
+| <0.1% |    212 B |         3 | `MutationObserver`                           | `<unknown>` |
+| <0.1% |    208 B |         1 | `ScriptedAnimationController`                | `<unknown>` |
+| <0.1% |    192 B |         1 | `NavigationHistoryEntry`                     | `<unknown>` |
+| <0.1% |    184 B |         1 | `DocumentTimeline`                           | `<unknown>` |
+| <0.1% |    184 B |         1 | `<script type="module" src="/workload.mjs">` | `<unknown>` |
+| <0.1% |    184 B |         1 | `PerformanceNavigationTiming`                | `<unknown>` |
+
+##### Array
+
+|     % |     Size | Instances | Constructor      | Location    |
+| ----: | -------: | --------: | ---------------- | ----------- |
+|  1.6% | 16.6 KiB |     1,060 | `Array`          | `<unknown>` |
+| <0.1% |     84 B |         3 | `Array Iterator` | `<unknown>` |
+
 #### Instances
 
 Instances ranked by contribution to each constructor's self size.
@@ -210,6 +269,156 @@ Instances ranked by contribution to each constructor's self size.
 | 13.2% |  28 B |         1 | `(GC root)`            |
 |  7.5% |  16 B |         1 | `.375 array`           |
 
+##### `ScriptedAnimationController` (`<unknown>`)
+
+|      % |  Size | Instances | Path                |
+| -----: | ----: | --------: | ------------------- |
+| 100.0% | 208 B |         1 | `[18] HTMLDocument` |
+
+##### `NavigationHistoryEntry` (`<unknown>`)
+
+|      % |  Size | Instances | Path         |
+| -----: | ----: | --------: | ------------ |
+| 100.0% | 192 B |         1 | `[6] Window` |
+
+##### `DocumentTimeline` (`<unknown>`)
+
+|      % |  Size | Instances | Path                |
+| -----: | ----: | --------: | ------------------- |
+| 100.0% | 184 B |         1 | `[22] HTMLDocument` |
+
+##### `<script type="module" src="/workload.mjs">` (`<unknown>`)
+
+|      % |  Size | Instances | Path         |
+| -----: | ----: | --------: | ------------ |
+| 100.0% | 184 B |         1 | `[1] <head>` |
+
+##### `PerformanceNavigationTiming` (`<unknown>`)
+
+|      % |  Size | Instances | Path                                                                  |
+| -----: | ----: | --------: | --------------------------------------------------------------------- |
+| 100.0% | 184 B |         1 | `[5] Performance ← [1] InternalNode ← [5] InternalNode ← [24] Window` |
+
+##### `Generator` (`workload.mjs:1:1`)
+
+|     % |  Size | Instances | Path                                      |
+| ----: | ----: | --------: | ----------------------------------------- |
+| 93.2% | 164 B |         4 | `(GC root)`                               |
+|  6.8% |  12 B |         1 | `.__proto__ Generator (workload.mjs:1:1)` |
+
+##### `Map` (`<unknown>`)
+
+|     % | Size | Instances | Path                                                         |
+| ----: | ---: | --------: | ------------------------------------------------------------ |
+| 63.6% | 84 B |         3 | `(GC root)`                                                  |
+| 12.1% | 16 B |         1 | `.L system / Context`                                        |
+| 12.1% | 16 B |         1 | `.#e v ← .customQuerySelectors Object`                       |
+| 12.1% | 16 B |         1 | `.byId Object ← .__retained Window / http://127.0.0.1:52789` |
+
+##### `Set` (`<unknown>`)
+
+|     % | Size | Instances | Path                   |
+| ----: | ---: | --------: | ---------------------- |
+| 72.4% | 84 B |         3 | `(GC root)`            |
+| 13.8% | 16 B |         1 | `.re system / Context` |
+| 13.8% | 16 B |         1 | `.ne system / Context` |
+
+##### `Promise` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 104 B |         4 | `(GC root)` |
+
+##### `WeakSet` (`<unknown>`)
+
+|     % | Size | Instances | Path                  |
+| ----: | ---: | --------: | --------------------- |
+| 56.0% | 56 B |         2 | `.prototype WeakSet`  |
+| 28.0% | 28 B |         1 | `(GC root)`           |
+| 16.0% | 16 B |         1 | `.W system / Context` |
+
+##### `WeakMap` (`<unknown>`)
+
+|     % | Size | Instances | Path                  |
+| ----: | ---: | --------: | --------------------- |
+| 56.0% | 56 B |         2 | `.prototype WeakMap`  |
+| 28.0% | 28 B |         1 | `(GC root)`           |
+| 16.0% | 16 B |         1 | `.I system / Context` |
+
+##### `AsyncGenerator` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 84 B |         3 | `(GC root)` |
+
+##### `Map Iterator` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 84 B |         3 | `(GC root)` |
+
+##### `Set Iterator` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 84 B |         3 | `(GC root)` |
+
+##### `String Iterator` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 84 B |         3 | `(GC root)` |
+
+##### `JSON` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 84 B |         3 | `(GC root)` |
+
+##### `Tag` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 84 B |         3 | `(GC root)` |
+
+##### `Math` (`<unknown>`)
+
+|     % | Size | Instances | Path                                    |
+| ----: | ---: | --------: | --------------------------------------- |
+| 33.3% | 28 B |         1 | `.Math Window / http://127.0.0.1:52789` |
+| 33.3% | 28 B |         1 | `.Math Window / ://`                    |
+| 33.3% | 28 B |         1 | `.Math Object / `                       |
+
+##### `Reflect` (`<unknown>`)
+
+|     % | Size | Instances | Path                                       |
+| ----: | ---: | --------: | ------------------------------------------ |
+| 33.3% | 28 B |         1 | `.Reflect Window / http://127.0.0.1:52789` |
+| 33.3% | 28 B |         1 | `.Reflect Window / ://`                    |
+| 33.3% | 28 B |         1 | `.Reflect Object / `                       |
+
+##### `Intl` (`<unknown>`)
+
+|     % | Size | Instances | Path                                    |
+| ----: | ---: | --------: | --------------------------------------- |
+| 33.3% | 28 B |         1 | `.Intl Window / http://127.0.0.1:52789` |
+| 33.3% | 28 B |         1 | `.Intl Window / ://`                    |
+| 33.3% | 28 B |         1 | `.Intl Object / `                       |
+
+##### `Atomics` (`<unknown>`)
+
+|     % | Size | Instances | Path                                       |
+| ----: | ---: | --------: | ------------------------------------------ |
+| 33.3% | 28 B |         1 | `.Atomics Window / http://127.0.0.1:52789` |
+| 33.3% | 28 B |         1 | `.Atomics Window / ://`                    |
+| 33.3% | 28 B |         1 | `.Atomics Object / `                       |
+
+##### `Array Iterator` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 84 B |         3 | `(GC root)` |
+
 ### Retained size
 
 Constructors ranked by bytes allocated for their instances and all nodes that would be freed if their instances were garbage collected.
@@ -236,6 +445,65 @@ Constructors ranked by bytes allocated for their instances and all nodes that wo
 |  0.5% |  5.2 KiB |        36 | `TypedArray`                      | `<unknown>` |
 |  0.5% | 4.79 KiB |         3 | `console`                         | `<unknown>` |
 |  0.4% | 4.48 KiB |         3 | `Intl.Locale`                     | `<unknown>` |
+
+#### Categories
+
+##### Object
+
+|     % |     Size | Instances | Constructor                       | Location    |
+| ----: | -------: | --------: | --------------------------------- | ----------- |
+| 19.0% |  192 KiB |     1,464 | `Object`                          | `<unknown>` |
+| 18.2% |  184 KiB |         1 | `Window / http://127.0.0.1:52789` | `<unknown>` |
+|  4.7% | 47.8 KiB |         1 | `Window / ://`                    | `<unknown>` |
+|  1.1% | 10.9 KiB |       113 | `system / Context`                | `<unknown>` |
+|  0.9% | 8.88 KiB |         6 | `Map`                             | `<unknown>` |
+|  0.6% | 6.45 KiB |         1 | `Object / `                       | `<unknown>` |
+|  0.6% | 5.91 KiB |        37 | `Error`                           | `<unknown>` |
+|  0.6% | 5.64 KiB |         1 | `Document`                        | `<unknown>` |
+|  0.5% | 5.45 KiB |         3 | `Math`                            | `<unknown>` |
+|  0.5% |  5.2 KiB |        36 | `TypedArray`                      | `<unknown>` |
+|  0.5% | 4.79 KiB |         3 | `console`                         | `<unknown>` |
+|  0.4% | 4.48 KiB |         3 | `Intl.Locale`                     | `<unknown>` |
+|  0.4% | 4.34 KiB |         3 | `String`                          | `<unknown>` |
+|  0.4% | 4.02 KiB |         3 | `DataView`                        | `<unknown>` |
+|  0.3% | 3.42 KiB |         3 | `HTMLElement`                     | `<unknown>` |
+|  0.3% | 3.42 KiB |         1 | `Element`                         | `<unknown>` |
+|  0.3% | 3.06 KiB |         3 | `Intl`                            | `<unknown>` |
+|  0.2% | 2.24 KiB |         3 | `Atomics`                         | `<unknown>` |
+|  0.2% | 2.21 KiB |         3 | `DisposableStack`                 | `<unknown>` |
+|  0.2% | 2.21 KiB |         3 | `AsyncDisposableStack`            | `<unknown>` |
+
+##### Native
+
+|     % |     Size | Instances | Constructor                                  | Location    |
+| ----: | -------: | --------: | -------------------------------------------- | ----------- |
+|  7.5% | 75.8 KiB |        10 | `Window`                                     | `<unknown>` |
+|  5.2% | 52.3 KiB |       100 | `<article class="status">`                   | `<unknown>` |
+|  1.9% | 19.5 KiB |       100 | `<p>`                                        | `<unknown>` |
+|  1.9% | 19.5 KiB |       100 | `<h2>`                                       | `<unknown>` |
+|  1.6% | 16.3 KiB |       208 | `Text`                                       | `<unknown>` |
+|  1.3% | 13.3 KiB |       154 | `system / ExternalStringData`                | `<unknown>` |
+|  0.5% | 5.23 KiB |         3 | `HTMLDocument`                               | `<unknown>` |
+|  0.3% | 3.03 KiB |       283 | `InternalNode`                               | `<unknown>` |
+|  0.2% | 1.56 KiB |         8 | `<span class="hashtag">`                     | `<unknown>` |
+|  0.2% | 1.56 KiB |         1 | `Performance`                                | `<unknown>` |
+|  0.1% |    944 B |         1 | `StyleEngine`                                | `<unknown>` |
+|  0.1% |    680 B |         1 | `Modulator`                                  | `<unknown>` |
+|  0.1% |    556 B |         3 | `MutationObserver`                           | `<unknown>` |
+| <0.1% |    416 B |         1 | `JSModuleScript`                             | `<unknown>` |
+| <0.1% |    400 B |         1 | `Navigator`                                  | `<unknown>` |
+| <0.1% |    400 B |         1 | `<head>`                                     | `<unknown>` |
+| <0.1% |    368 B |         1 | `Navigation`                                 | `<unknown>` |
+| <0.1% |    328 B |         1 | `FontFaceSet`                                | `<unknown>` |
+| <0.1% |    304 B |         2 | `PerformanceResourceTiming`                  | `<unknown>` |
+| <0.1% |    296 B |         1 | `<script type="module" src="/workload.mjs">` | `<unknown>` |
+
+##### Array
+
+|    % |     Size | Instances | Constructor      | Location    |
+| ---: | -------: | --------: | ---------------- | ----------- |
+| 3.4% | 34.4 KiB |     1,060 | `Array`          | `<unknown>` |
+| 0.1% |    528 B |         3 | `Array Iterator` | `<unknown>` |
 
 #### Instances
 
@@ -399,6 +667,153 @@ Instances ranked by contribution to each constructor's retained size.
 |      % |     Size | Instances | Path                |
 | -----: | -------: | --------: | ------------------- |
 | 100.0% | 4.48 KiB |         3 | `.prototype Locale` |
+
+##### `String` (`<unknown>`)
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 4.34 KiB |         3 | `(GC root)` |
+
+##### `DataView` (`<unknown>`)
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 4.02 KiB |         3 | `(GC root)` |
+
+##### `HTMLElement` (`<unknown>`)
+
+|     % |     Size | Instances | Path                                                     |
+| ----: | -------: | --------: | -------------------------------------------------------- |
+| 99.1% | 3.39 KiB |         1 | `(GC root)`                                              |
+|  0.5% |     16 B |         1 | `[6] InternalNode ← [1] InternalNode ← [1] InternalNode` |
+|  0.5% |     16 B |         1 | `.441 array`                                             |
+
+##### `Element` (`<unknown>`)
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 3.42 KiB |         1 | `(GC root)` |
+
+##### `Intl` (`<unknown>`)
+
+|     % |     Size | Instances | Path                                    |
+| ----: | -------: | --------: | --------------------------------------- |
+| 33.3% | 1.02 KiB |         1 | `.Intl Window / http://127.0.0.1:52789` |
+| 33.3% | 1.02 KiB |         1 | `.Intl Window / ://`                    |
+| 33.3% | 1.02 KiB |         1 | `.Intl Object / `                       |
+
+##### `InternalNode` (`<unknown>`)
+
+|     % |     Size | Instances | Path                                  |
+| ----: | -------: | --------: | ------------------------------------- |
+| 61.1% | 1.85 KiB |         1 | `[24] Window`                         |
+| 51.5% | 1.56 KiB |         1 | `[5] InternalNode ← [24] Window`      |
+| 25.0% |    776 B |         1 | `(GC root)`                           |
+| 25.0% |    776 B |         1 | `[1] InternalNode`                    |
+| 21.9% |    680 B |         1 | `[3] InternalNode ← [1] InternalNode` |
+
+##### `Atomics` (`<unknown>`)
+
+|     % |  Size | Instances | Path                                       |
+| ----: | ----: | --------: | ------------------------------------------ |
+| 33.3% | 764 B |         1 | `.Atomics Window / http://127.0.0.1:52789` |
+| 33.3% | 764 B |         1 | `.Atomics Window / ://`                    |
+| 33.3% | 764 B |         1 | `.Atomics Object / `                       |
+
+##### `DisposableStack` (`<unknown>`)
+
+|      % |     Size | Instances | Path                         |
+| -----: | -------: | --------: | ---------------------------- |
+| 100.0% | 2.21 KiB |         3 | `.prototype DisposableStack` |
+
+##### `AsyncDisposableStack` (`<unknown>`)
+
+|      % |     Size | Instances | Path                              |
+| -----: | -------: | --------: | --------------------------------- |
+| 100.0% | 2.21 KiB |         3 | `.prototype AsyncDisposableStack` |
+
+##### `<span class="hashtag">` (`<unknown>`)
+
+|     % |  Size | Instances | Path                                                                         |
+| ----: | ----: | --------: | ---------------------------------------------------------------------------- |
+| 50.0% | 800 B |         4 | `[4] <article class="status"> ← .__retained Window / http://127.0.0.1:52789` |
+| 37.5% | 600 B |         3 | `[4] <article class="status">`                                               |
+| 12.5% | 200 B |         1 | `.__retained Window / http://127.0.0.1:52789`                                |
+
+##### `Performance` (`<unknown>`)
+
+|      % |     Size | Instances | Path                                                |
+| -----: | -------: | --------: | --------------------------------------------------- |
+| 100.0% | 1.56 KiB |         1 | `[1] InternalNode ← [5] InternalNode ← [24] Window` |
+
+##### `StyleEngine` (`<unknown>`)
+
+|      % |  Size | Instances | Path                |
+| -----: | ----: | --------: | ------------------- |
+| 100.0% | 944 B |         1 | `[11] HTMLDocument` |
+
+##### `Modulator` (`<unknown>`)
+
+|      % |  Size | Instances | Path                                                     |
+| -----: | ----: | --------: | -------------------------------------------------------- |
+| 100.0% | 680 B |         1 | `[1] InternalNode ← [3] InternalNode ← [1] InternalNode` |
+
+##### `MutationObserver` (`<unknown>`)
+
+|     % |  Size | Instances | Path                   |
+| ----: | ----: | --------: | ---------------------- |
+| 61.9% | 344 B |         1 | `.se system / Context` |
+| 35.3% | 196 B |         1 | `(GC root)`            |
+|  2.9% |  16 B |         1 | `.375 array`           |
+
+##### `Array Iterator` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 528 B |         3 | `(GC root)` |
+
+##### `JSModuleScript` (`<unknown>`)
+
+|      % |  Size | Instances | Path                                                     |
+| -----: | ----: | --------: | -------------------------------------------------------- |
+| 100.0% | 416 B |         1 | `[1] InternalNode ← [3] InternalNode ← [1] InternalNode` |
+
+##### `Navigator` (`<unknown>`)
+
+|      % |  Size | Instances | Path         |
+| -----: | ----: | --------: | ------------ |
+| 100.0% | 400 B |         1 | `[5] Window` |
+
+##### `<head>` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 400 B |         1 | `(GC root)` |
+
+##### `Navigation` (`<unknown>`)
+
+|      % |  Size | Instances | Path         |
+| -----: | ----: | --------: | ------------ |
+| 100.0% | 368 B |         1 | `[6] Window` |
+
+##### `FontFaceSet` (`<unknown>`)
+
+|      % |  Size | Instances | Path                                   |
+| -----: | ----: | --------: | -------------------------------------- |
+| 100.0% | 328 B |         1 | `[2] InternalNode ← [31] HTMLDocument` |
+
+##### `PerformanceResourceTiming` (`<unknown>`)
+
+|     % |  Size | Instances | Path                                                                                     |
+| ----: | ----: | --------: | ---------------------------------------------------------------------------------------- |
+| 50.0% | 152 B |         1 | `[1] InternalNode ← [3] Performance ← [1] InternalNode ← [5] InternalNode ← [24] Window` |
+| 50.0% | 152 B |         1 | `[2] InternalNode ← [3] Performance ← [1] InternalNode ← [5] InternalNode ← [24] Window` |
+
+##### `<script type="module" src="/workload.mjs">` (`<unknown>`)
+
+|      % |  Size | Instances | Path         |
+| -----: | ----: | --------: | ------------ |
+| 100.0% | 296 B |         1 | `[1] <head>` |
 
 ## Largest functions
 
@@ -635,6 +1050,10 @@ Nodes ranked by contribution to each function's retained size.
 
 Strings ranked by bytes allocated for them.
 
+### Categories
+
+#### String
+
 |     % |     Size | Value                                                    | Path                                            |
 | ----: | -------: | -------------------------------------------------------- | ----------------------------------------------- |
 |  0.9% | 9.54 KiB | `(() => {\n      const module = {};\n      "use stri…`   | `.source code`                                  |
@@ -657,3 +1076,28 @@ Strings ranked by bytes allocated for them.
 | <0.1% |    280 B | `泉田新潟県知事は、東電の申請書提出を容認させられただけで、再稼働に必要な「同意」はまだ与えていませ…`     | `(GC root)`                                     |
 | <0.1% |    264 B | `ラウワン脱出→友達が家に連んで帰ってって言うから友達ん家に乗せて帰る(1度も行ったことない田舎道)…`     | `(GC root)`                                     |
 | <0.1% |    260 B | `GパングのA型K月克己中尉の非公式botです。 主に七巻と八巻が中心の台詞をつぶやきます。 4/1…`     | `(GC root)`                                     |
+
+#### Concatenated string
+
+|     % | Size | Value                   | Path                                                                                                                                                                                                                      |
+| ----: | ---: | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <0.1% | 20 B | `(concatenated string)` | `.<dummy> system / UncompiledDataWithPreparseData ← .trusted_function_data (shared function info)`                                                                                                                        |
+| <0.1% | 20 B | `(concatenated string)` | `.second (concatenated string) ← . system / ScopeInfo ← .name_or_scope_info get ← .(Compilation cache) (constant pool) ← .(GC roots) system / BytecodeArray ← .trusted_function_data J ← .shared J ← .J system / Context` |
+| <0.1% | 20 B | `(concatenated string)` | `. system / ScopeInfo ← .name_or_scope_info get ← .(Compilation cache) (constant pool) ← .(GC roots) system / BytecodeArray ← .trusted_function_data J ← .shared J ← .J system / Context`                                 |
+| <0.1% | 20 B | `(concatenated string)` | `.source code ← .script (shared function info) ← .shared (anonymous) ← .6 array ← .table Map ← .L system / Context`                                                                                                       |
+| <0.1% | 20 B | `(concatenated string)` | `.first (concatenated string) ← .124 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                     |
+| <0.1% | 20 B | `(concatenated string)` | `.124 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                                                    |
+| <0.1% | 20 B | `(concatenated string)` | `.<dummy> system / UncompiledDataWithoutPreparseData ← .trusted_function_data stringify`                                                                                                                                  |
+| <0.1% | 20 B | `(concatenated string)` | `.<dummy> system / UncompiledDataWithoutPreparseData ← .trusted_function_data (shared function info)`                                                                                                                     |
+| <0.1% | 20 B | `(concatenated string)` | `.first (concatenated string) ← .67 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                      |
+| <0.1% | 20 B | `(concatenated string)` | `.67 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                                                     |
+| <0.1% | 20 B | `(concatenated string)` | `.first (concatenated string) ← .70 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                      |
+| <0.1% | 20 B | `(concatenated string)` | `.70 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                                                     |
+| <0.1% | 20 B | `(concatenated string)` | `.first (concatenated string) ← .73 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                      |
+| <0.1% | 20 B | `(concatenated string)` | `.73 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                                                     |
+| <0.1% | 20 B | `(concatenated string)` | `.first (concatenated string) ← .76 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                      |
+| <0.1% | 20 B | `(concatenated string)` | `.76 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                                                     |
+| <0.1% | 20 B | `(concatenated string)` | `.first (concatenated string) ← .79 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                      |
+| <0.1% | 20 B | `(concatenated string)` | `.79 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                                                     |
+| <0.1% | 20 B | `(concatenated string)` | `.first (concatenated string) ← .82 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                      |
+| <0.1% | 20 B | `(concatenated string)` | `.82 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                                                     |

--- a/examples/output/javascript.chrome.current.heapsnapshot.md
+++ b/examples/output/javascript.chrome.current.heapsnapshot.md
@@ -47,6 +47,65 @@ Constructors ranked by bytes allocated for their instances, excluding nodes kept
 | <0.1% |    304 B |         2 | `PerformanceResourceTiming`   | `<unknown>` |
 | <0.1% |    212 B |         3 | `MutationObserver`            | `<unknown>` |
 
+#### Categories
+
+##### Object
+
+|     % |     Size | Instances | Constructor        | Location           |
+| ----: | -------: | --------: | ------------------ | ------------------ |
+|  7.0% | 71.3 KiB |     1,464 | `Object`           | `<unknown>`        |
+|  0.3% | 2.65 KiB |       113 | `system / Context` | `<unknown>`        |
+|  0.1% |   1020 B |        37 | `Error`            | `<unknown>`        |
+|  0.1% |   1008 B |        36 | `TypedArray`       | `<unknown>`        |
+| <0.1% |    176 B |         5 | `Generator`        | `workload.mjs:1:1` |
+| <0.1% |    132 B |         6 | `Map`              | `<unknown>`        |
+| <0.1% |    116 B |         5 | `Set`              | `<unknown>`        |
+| <0.1% |    104 B |         4 | `Promise`          | `<unknown>`        |
+| <0.1% |    100 B |         4 | `WeakSet`          | `<unknown>`        |
+| <0.1% |    100 B |         4 | `WeakMap`          | `<unknown>`        |
+| <0.1% |     84 B |         3 | `AsyncGenerator`   | `<unknown>`        |
+| <0.1% |     84 B |         3 | `Map Iterator`     | `<unknown>`        |
+| <0.1% |     84 B |         3 | `Set Iterator`     | `<unknown>`        |
+| <0.1% |     84 B |         3 | `String Iterator`  | `<unknown>`        |
+| <0.1% |     84 B |         3 | `JSON`             | `<unknown>`        |
+| <0.1% |     84 B |         3 | `Tag`              | `<unknown>`        |
+| <0.1% |     84 B |         3 | `Math`             | `<unknown>`        |
+| <0.1% |     84 B |         3 | `Reflect`          | `<unknown>`        |
+| <0.1% |     84 B |         3 | `Intl`             | `<unknown>`        |
+| <0.1% |     84 B |         3 | `Atomics`          | `<unknown>`        |
+
+##### Native
+
+|     % |     Size | Instances | Constructor                                  | Location    |
+| ----: | -------: | --------: | -------------------------------------------- | ----------- |
+|  1.6% | 16.3 KiB |       208 | `Text`                                       | `<unknown>` |
+|  1.3% | 13.3 KiB |       154 | `system / ExternalStringData`                | `<unknown>` |
+|  1.2% | 11.7 KiB |       100 | `<p>`                                        | `<unknown>` |
+|  1.2% | 11.7 KiB |       100 | `<article class="status">`                   | `<unknown>` |
+|  1.2% | 11.7 KiB |       100 | `<h2>`                                       | `<unknown>` |
+|  0.3% |  3.2 KiB |         3 | `HTMLDocument`                               | `<unknown>` |
+|  0.1% |   1016 B |        10 | `Window`                                     | `<unknown>` |
+|  0.1% |    968 B |         1 | `Performance`                                | `<unknown>` |
+|  0.1% |    960 B |         8 | `<span class="hashtag">`                     | `<unknown>` |
+|  0.1% |    824 B |         1 | `StyleEngine`                                | `<unknown>` |
+| <0.1% |    416 B |         1 | `JSModuleScript`                             | `<unknown>` |
+| <0.1% |    400 B |         1 | `Navigator`                                  | `<unknown>` |
+| <0.1% |    328 B |         1 | `FontFaceSet`                                | `<unknown>` |
+| <0.1% |    304 B |         2 | `PerformanceResourceTiming`                  | `<unknown>` |
+| <0.1% |    212 B |         3 | `MutationObserver`                           | `<unknown>` |
+| <0.1% |    208 B |         1 | `ScriptedAnimationController`                | `<unknown>` |
+| <0.1% |    200 B |         1 | `IntersectionObserver`                       | `<unknown>` |
+| <0.1% |    192 B |         1 | `NavigationHistoryEntry`                     | `<unknown>` |
+| <0.1% |    184 B |         1 | `<script type="module" src="/workload.mjs">` | `<unknown>` |
+| <0.1% |    184 B |         1 | `PerformanceNavigationTiming`                | `<unknown>` |
+
+##### Array
+
+|     % |     Size | Instances | Constructor      | Location    |
+| ----: | -------: | --------: | ---------------- | ----------- |
+|  1.6% | 16.6 KiB |     1,060 | `Array`          | `<unknown>` |
+| <0.1% |     84 B |         3 | `Array Iterator` | `<unknown>` |
+
 #### Instances
 
 Instances ranked by contribution to each constructor's self size.
@@ -209,6 +268,156 @@ Instances ranked by contribution to each constructor's self size.
 | 13.2% |  28 B |         1 | `(GC root)`            |
 |  7.5% |  16 B |         1 | `.375 array`           |
 
+##### `ScriptedAnimationController` (`<unknown>`)
+
+|      % |  Size | Instances | Path                |
+| -----: | ----: | --------: | ------------------- |
+| 100.0% | 208 B |         1 | `[18] HTMLDocument` |
+
+##### `IntersectionObserver` (`<unknown>`)
+
+|      % |  Size | Instances | Path                                                      |
+| -----: | ----: | --------: | --------------------------------------------------------- |
+| 100.0% | 200 B |         1 | `[2] InternalNode ← [1] InternalNode ← [31] HTMLDocument` |
+
+##### `NavigationHistoryEntry` (`<unknown>`)
+
+|      % |  Size | Instances | Path         |
+| -----: | ----: | --------: | ------------ |
+| 100.0% | 192 B |         1 | `[6] Window` |
+
+##### `<script type="module" src="/workload.mjs">` (`<unknown>`)
+
+|      % |  Size | Instances | Path         |
+| -----: | ----: | --------: | ------------ |
+| 100.0% | 184 B |         1 | `[1] <head>` |
+
+##### `PerformanceNavigationTiming` (`<unknown>`)
+
+|      % |  Size | Instances | Path                                                                  |
+| -----: | ----: | --------: | --------------------------------------------------------------------- |
+| 100.0% | 184 B |         1 | `[6] Performance ← [1] InternalNode ← [8] InternalNode ← [24] Window` |
+
+##### `Generator` (`workload.mjs:1:1`)
+
+|     % |  Size | Instances | Path                                      |
+| ----: | ----: | --------: | ----------------------------------------- |
+| 93.2% | 164 B |         4 | `(GC root)`                               |
+|  6.8% |  12 B |         1 | `.__proto__ Generator (workload.mjs:1:1)` |
+
+##### `Map` (`<unknown>`)
+
+|     % | Size | Instances | Path                                                         |
+| ----: | ---: | --------: | ------------------------------------------------------------ |
+| 63.6% | 84 B |         3 | `(GC root)`                                                  |
+| 12.1% | 16 B |         1 | `.L system / Context`                                        |
+| 12.1% | 16 B |         1 | `.#e v ← .customQuerySelectors Object`                       |
+| 12.1% | 16 B |         1 | `.byId Object ← .__retained Window / http://127.0.0.1:52789` |
+
+##### `Set` (`<unknown>`)
+
+|     % | Size | Instances | Path                   |
+| ----: | ---: | --------: | ---------------------- |
+| 72.4% | 84 B |         3 | `(GC root)`            |
+| 13.8% | 16 B |         1 | `.re system / Context` |
+| 13.8% | 16 B |         1 | `.ne system / Context` |
+
+##### `Promise` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 104 B |         4 | `(GC root)` |
+
+##### `WeakSet` (`<unknown>`)
+
+|     % | Size | Instances | Path                  |
+| ----: | ---: | --------: | --------------------- |
+| 56.0% | 56 B |         2 | `.prototype WeakSet`  |
+| 28.0% | 28 B |         1 | `(GC root)`           |
+| 16.0% | 16 B |         1 | `.W system / Context` |
+
+##### `WeakMap` (`<unknown>`)
+
+|     % | Size | Instances | Path                  |
+| ----: | ---: | --------: | --------------------- |
+| 56.0% | 56 B |         2 | `.prototype WeakMap`  |
+| 28.0% | 28 B |         1 | `(GC root)`           |
+| 16.0% | 16 B |         1 | `.I system / Context` |
+
+##### `AsyncGenerator` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 84 B |         3 | `(GC root)` |
+
+##### `Map Iterator` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 84 B |         3 | `(GC root)` |
+
+##### `Set Iterator` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 84 B |         3 | `(GC root)` |
+
+##### `String Iterator` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 84 B |         3 | `(GC root)` |
+
+##### `JSON` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 84 B |         3 | `(GC root)` |
+
+##### `Tag` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 84 B |         3 | `(GC root)` |
+
+##### `Math` (`<unknown>`)
+
+|     % | Size | Instances | Path                                    |
+| ----: | ---: | --------: | --------------------------------------- |
+| 33.3% | 28 B |         1 | `.Math Window / http://127.0.0.1:52789` |
+| 33.3% | 28 B |         1 | `.Math Window / ://`                    |
+| 33.3% | 28 B |         1 | `.Math Object / `                       |
+
+##### `Reflect` (`<unknown>`)
+
+|     % | Size | Instances | Path                                       |
+| ----: | ---: | --------: | ------------------------------------------ |
+| 33.3% | 28 B |         1 | `.Reflect Window / http://127.0.0.1:52789` |
+| 33.3% | 28 B |         1 | `.Reflect Window / ://`                    |
+| 33.3% | 28 B |         1 | `.Reflect Object / `                       |
+
+##### `Intl` (`<unknown>`)
+
+|     % | Size | Instances | Path                                    |
+| ----: | ---: | --------: | --------------------------------------- |
+| 33.3% | 28 B |         1 | `.Intl Window / http://127.0.0.1:52789` |
+| 33.3% | 28 B |         1 | `.Intl Window / ://`                    |
+| 33.3% | 28 B |         1 | `.Intl Object / `                       |
+
+##### `Atomics` (`<unknown>`)
+
+|     % | Size | Instances | Path                                       |
+| ----: | ---: | --------: | ------------------------------------------ |
+| 33.3% | 28 B |         1 | `.Atomics Window / http://127.0.0.1:52789` |
+| 33.3% | 28 B |         1 | `.Atomics Window / ://`                    |
+| 33.3% | 28 B |         1 | `.Atomics Object / `                       |
+
+##### `Array Iterator` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 84 B |         3 | `(GC root)` |
+
 ### Retained size
 
 Constructors ranked by bytes allocated for their instances and all nodes that would be freed if their instances were garbage collected.
@@ -235,6 +444,65 @@ Constructors ranked by bytes allocated for their instances and all nodes that wo
 |  0.5% |  5.2 KiB |        36 | `TypedArray`                      | `<unknown>` |
 |  0.5% | 4.79 KiB |         3 | `console`                         | `<unknown>` |
 |  0.4% | 4.48 KiB |         3 | `Intl.Locale`                     | `<unknown>` |
+
+#### Categories
+
+##### Object
+
+|     % |     Size | Instances | Constructor                       | Location    |
+| ----: | -------: | --------: | --------------------------------- | ----------- |
+| 19.0% |  192 KiB |     1,464 | `Object`                          | `<unknown>` |
+| 18.2% |  184 KiB |         1 | `Window / http://127.0.0.1:52789` | `<unknown>` |
+|  4.7% | 47.8 KiB |         1 | `Window / ://`                    | `<unknown>` |
+|  1.1% | 10.9 KiB |       113 | `system / Context`                | `<unknown>` |
+|  0.9% | 8.88 KiB |         6 | `Map`                             | `<unknown>` |
+|  0.6% | 6.45 KiB |         1 | `Object / `                       | `<unknown>` |
+|  0.6% | 5.91 KiB |        37 | `Error`                           | `<unknown>` |
+|  0.6% | 5.64 KiB |         1 | `Document`                        | `<unknown>` |
+|  0.5% | 5.45 KiB |         3 | `Math`                            | `<unknown>` |
+|  0.5% |  5.2 KiB |        36 | `TypedArray`                      | `<unknown>` |
+|  0.5% | 4.79 KiB |         3 | `console`                         | `<unknown>` |
+|  0.4% | 4.48 KiB |         3 | `Intl.Locale`                     | `<unknown>` |
+|  0.4% | 4.34 KiB |         3 | `String`                          | `<unknown>` |
+|  0.4% | 4.02 KiB |         3 | `DataView`                        | `<unknown>` |
+|  0.3% | 3.42 KiB |         3 | `HTMLElement`                     | `<unknown>` |
+|  0.3% | 3.42 KiB |         1 | `Element`                         | `<unknown>` |
+|  0.3% | 3.06 KiB |         3 | `Intl`                            | `<unknown>` |
+|  0.2% | 2.24 KiB |         3 | `Atomics`                         | `<unknown>` |
+|  0.2% | 2.21 KiB |         3 | `DisposableStack`                 | `<unknown>` |
+|  0.2% | 2.21 KiB |         3 | `AsyncDisposableStack`            | `<unknown>` |
+
+##### Native
+
+|     % |     Size | Instances | Constructor                                  | Location    |
+| ----: | -------: | --------: | -------------------------------------------- | ----------- |
+|  7.5% |   76 KiB |        10 | `Window`                                     | `<unknown>` |
+|  2.6% |   26 KiB |       100 | `<article class="status">`                   | `<unknown>` |
+|  1.6% | 16.3 KiB |       208 | `Text`                                       | `<unknown>` |
+|  1.4% | 14.4 KiB |       100 | `<p>`                                        | `<unknown>` |
+|  1.4% | 14.4 KiB |       100 | `<h2>`                                       | `<unknown>` |
+|  1.3% | 13.3 KiB |       154 | `system / ExternalStringData`                | `<unknown>` |
+|  0.5% | 5.46 KiB |         3 | `HTMLDocument`                               | `<unknown>` |
+|  0.3% | 3.52 KiB |     1,894 | `InternalNode`                               | `<unknown>` |
+|  0.2% | 1.81 KiB |         1 | `Performance`                                | `<unknown>` |
+|  0.1% | 1.33 KiB |         8 | `<span class="hashtag">`                     | `<unknown>` |
+|  0.1% |    944 B |         1 | `StyleEngine`                                | `<unknown>` |
+|  0.1% |    680 B |         1 | `Modulator`                                  | `<unknown>` |
+|  0.1% |    556 B |         3 | `MutationObserver`                           | `<unknown>` |
+| <0.1% |    416 B |         1 | `JSModuleScript`                             | `<unknown>` |
+| <0.1% |    400 B |         1 | `Navigator`                                  | `<unknown>` |
+| <0.1% |    400 B |         1 | `<head>`                                     | `<unknown>` |
+| <0.1% |    368 B |         1 | `Navigation`                                 | `<unknown>` |
+| <0.1% |    328 B |         1 | `FontFaceSet`                                | `<unknown>` |
+| <0.1% |    304 B |         2 | `PerformanceResourceTiming`                  | `<unknown>` |
+| <0.1% |    296 B |         1 | `<script type="module" src="/workload.mjs">` | `<unknown>` |
+
+##### Array
+
+|    % |     Size | Instances | Constructor      | Location    |
+| ---: | -------: | --------: | ---------------- | ----------- |
+| 3.4% | 34.4 KiB |     1,060 | `Array`          | `<unknown>` |
+| 0.1% |    528 B |         3 | `Array Iterator` | `<unknown>` |
 
 #### Instances
 
@@ -397,6 +665,153 @@ Instances ranked by contribution to each constructor's retained size.
 |      % |     Size | Instances | Path                |
 | -----: | -------: | --------: | ------------------- |
 | 100.0% | 4.48 KiB |         3 | `.prototype Locale` |
+
+##### `String` (`<unknown>`)
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 4.34 KiB |         3 | `(GC root)` |
+
+##### `DataView` (`<unknown>`)
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 4.02 KiB |         3 | `(GC root)` |
+
+##### `InternalNode` (`<unknown>`)
+
+|     % |     Size | Instances | Path                                  |
+| ----: | -------: | --------: | ------------------------------------- |
+| 59.8% |  2.1 KiB |         1 | `[24] Window`                         |
+| 51.6% | 1.81 KiB |         1 | `[8] InternalNode ← [24] Window`      |
+| 21.6% |    776 B |         1 | `(GC root)`                           |
+| 21.6% |    776 B |         1 | `[1] InternalNode`                    |
+| 18.9% |    680 B |         1 | `[3] InternalNode ← [1] InternalNode` |
+
+##### `HTMLElement` (`<unknown>`)
+
+|     % |     Size | Instances | Path                                                     |
+| ----: | -------: | --------: | -------------------------------------------------------- |
+| 99.1% | 3.39 KiB |         1 | `(GC root)`                                              |
+|  0.5% |     16 B |         1 | `[1] InternalNode ← [1] InternalNode ← [1] InternalNode` |
+|  0.5% |     16 B |         1 | `.441 array`                                             |
+
+##### `Element` (`<unknown>`)
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 3.42 KiB |         1 | `(GC root)` |
+
+##### `Intl` (`<unknown>`)
+
+|     % |     Size | Instances | Path                                    |
+| ----: | -------: | --------: | --------------------------------------- |
+| 33.3% | 1.02 KiB |         1 | `.Intl Window / http://127.0.0.1:52789` |
+| 33.3% | 1.02 KiB |         1 | `.Intl Window / ://`                    |
+| 33.3% | 1.02 KiB |         1 | `.Intl Object / `                       |
+
+##### `Atomics` (`<unknown>`)
+
+|     % |  Size | Instances | Path                                       |
+| ----: | ----: | --------: | ------------------------------------------ |
+| 33.3% | 764 B |         1 | `.Atomics Window / http://127.0.0.1:52789` |
+| 33.3% | 764 B |         1 | `.Atomics Window / ://`                    |
+| 33.3% | 764 B |         1 | `.Atomics Object / `                       |
+
+##### `DisposableStack` (`<unknown>`)
+
+|      % |     Size | Instances | Path                         |
+| -----: | -------: | --------: | ---------------------------- |
+| 100.0% | 2.21 KiB |         3 | `.prototype DisposableStack` |
+
+##### `AsyncDisposableStack` (`<unknown>`)
+
+|      % |     Size | Instances | Path                              |
+| -----: | -------: | --------: | --------------------------------- |
+| 100.0% | 2.21 KiB |         3 | `.prototype AsyncDisposableStack` |
+
+##### `Performance` (`<unknown>`)
+
+|      % |     Size | Instances | Path                                                |
+| -----: | -------: | --------: | --------------------------------------------------- |
+| 100.0% | 1.81 KiB |         1 | `[1] InternalNode ← [8] InternalNode ← [24] Window` |
+
+##### `<span class="hashtag">` (`<unknown>`)
+
+|     % |  Size | Instances | Path                                                                         |
+| ----: | ----: | --------: | ---------------------------------------------------------------------------- |
+| 58.8% | 800 B |         4 | `[4] <article class="status"> ← .__retained Window / http://127.0.0.1:52789` |
+| 26.5% | 360 B |         3 | `(GC root)`                                                                  |
+| 14.7% | 200 B |         1 | `.__retained Window / http://127.0.0.1:52789`                                |
+
+##### `StyleEngine` (`<unknown>`)
+
+|      % |  Size | Instances | Path                |
+| -----: | ----: | --------: | ------------------- |
+| 100.0% | 944 B |         1 | `[11] HTMLDocument` |
+
+##### `Modulator` (`<unknown>`)
+
+|      % |  Size | Instances | Path                                                     |
+| -----: | ----: | --------: | -------------------------------------------------------- |
+| 100.0% | 680 B |         1 | `[1] InternalNode ← [3] InternalNode ← [1] InternalNode` |
+
+##### `MutationObserver` (`<unknown>`)
+
+|     % |  Size | Instances | Path                   |
+| ----: | ----: | --------: | ---------------------- |
+| 61.9% | 344 B |         1 | `.se system / Context` |
+| 35.3% | 196 B |         1 | `(GC root)`            |
+|  2.9% |  16 B |         1 | `.375 array`           |
+
+##### `Array Iterator` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 528 B |         3 | `(GC root)` |
+
+##### `JSModuleScript` (`<unknown>`)
+
+|      % |  Size | Instances | Path                                                     |
+| -----: | ----: | --------: | -------------------------------------------------------- |
+| 100.0% | 416 B |         1 | `[1] InternalNode ← [3] InternalNode ← [1] InternalNode` |
+
+##### `Navigator` (`<unknown>`)
+
+|      % |  Size | Instances | Path         |
+| -----: | ----: | --------: | ------------ |
+| 100.0% | 400 B |         1 | `[5] Window` |
+
+##### `<head>` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 400 B |         1 | `(GC root)` |
+
+##### `Navigation` (`<unknown>`)
+
+|      % |  Size | Instances | Path         |
+| -----: | ----: | --------: | ------------ |
+| 100.0% | 368 B |         1 | `[6] Window` |
+
+##### `FontFaceSet` (`<unknown>`)
+
+|      % |  Size | Instances | Path                                   |
+| -----: | ----: | --------: | -------------------------------------- |
+| 100.0% | 328 B |         1 | `[6] InternalNode ← [31] HTMLDocument` |
+
+##### `PerformanceResourceTiming` (`<unknown>`)
+
+|     % |  Size | Instances | Path                                                                                     |
+| ----: | ----: | --------: | ---------------------------------------------------------------------------------------- |
+| 50.0% | 152 B |         1 | `[1] InternalNode ← [3] Performance ← [1] InternalNode ← [8] InternalNode ← [24] Window` |
+| 50.0% | 152 B |         1 | `[2] InternalNode ← [3] Performance ← [1] InternalNode ← [8] InternalNode ← [24] Window` |
+
+##### `<script type="module" src="/workload.mjs">` (`<unknown>`)
+
+|      % |  Size | Instances | Path         |
+| -----: | ----: | --------: | ------------ |
+| 100.0% | 296 B |         1 | `[1] <head>` |
 
 ## Largest functions
 
@@ -633,6 +1048,10 @@ Nodes ranked by contribution to each function's retained size.
 
 Strings ranked by bytes allocated for them.
 
+### Categories
+
+#### String
+
 |     % |     Size | Value                                                    | Path                                            |
 | ----: | -------: | -------------------------------------------------------- | ----------------------------------------------- |
 |  0.9% | 9.54 KiB | `(() => {\n      const module = {};\n      "use stri…`   | `.source code`                                  |
@@ -655,3 +1074,28 @@ Strings ranked by bytes allocated for them.
 | <0.1% |    280 B | `泉田新潟県知事は、東電の申請書提出を容認させられただけで、再稼働に必要な「同意」はまだ与えていませ…`     | `(GC root)`                                     |
 | <0.1% |    264 B | `ラウワン脱出→友達が家に連んで帰ってって言うから友達ん家に乗せて帰る(1度も行ったことない田舎道)…`     | `(GC root)`                                     |
 | <0.1% |    260 B | `GパングのA型K月克己中尉の非公式botです。 主に七巻と八巻が中心の台詞をつぶやきます。 4/1…`     | `(GC root)`                                     |
+
+#### Concatenated string
+
+|     % | Size | Value                   | Path                                                                                                                                                                                                                      |
+| ----: | ---: | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <0.1% | 20 B | `(concatenated string)` | `.<dummy> system / UncompiledDataWithPreparseData ← .trusted_function_data (shared function info)`                                                                                                                        |
+| <0.1% | 20 B | `(concatenated string)` | `.second (concatenated string) ← . system / ScopeInfo ← .name_or_scope_info get ← .(Compilation cache) (constant pool) ← .(GC roots) system / BytecodeArray ← .trusted_function_data J ← .shared J ← .J system / Context` |
+| <0.1% | 20 B | `(concatenated string)` | `. system / ScopeInfo ← .name_or_scope_info get ← .(Compilation cache) (constant pool) ← .(GC roots) system / BytecodeArray ← .trusted_function_data J ← .shared J ← .J system / Context`                                 |
+| <0.1% | 20 B | `(concatenated string)` | `.source code ← .script (shared function info) ← .shared (anonymous) ← .6 array ← .table Map ← .L system / Context`                                                                                                       |
+| <0.1% | 20 B | `(concatenated string)` | `.first (concatenated string) ← .124 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                     |
+| <0.1% | 20 B | `(concatenated string)` | `.124 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                                                    |
+| <0.1% | 20 B | `(concatenated string)` | `.<dummy> system / UncompiledDataWithoutPreparseData ← .trusted_function_data stringify`                                                                                                                                  |
+| <0.1% | 20 B | `(concatenated string)` | `.<dummy> system / UncompiledDataWithoutPreparseData ← .trusted_function_data (shared function info)`                                                                                                                     |
+| <0.1% | 20 B | `(concatenated string)` | `.first (concatenated string) ← .67 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                      |
+| <0.1% | 20 B | `(concatenated string)` | `.67 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                                                     |
+| <0.1% | 20 B | `(concatenated string)` | `.first (concatenated string) ← .70 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                      |
+| <0.1% | 20 B | `(concatenated string)` | `.70 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                                                     |
+| <0.1% | 20 B | `(concatenated string)` | `.first (concatenated string) ← .73 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                      |
+| <0.1% | 20 B | `(concatenated string)` | `.73 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                                                     |
+| <0.1% | 20 B | `(concatenated string)` | `.first (concatenated string) ← .76 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                      |
+| <0.1% | 20 B | `(concatenated string)` | `.76 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                                                     |
+| <0.1% | 20 B | `(concatenated string)` | `.first (concatenated string) ← .79 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                      |
+| <0.1% | 20 B | `(concatenated string)` | `.79 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                                                     |
+| <0.1% | 20 B | `(concatenated string)` | `.first (concatenated string) ← .82 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                      |
+| <0.1% | 20 B | `(concatenated string)` | `.82 array ← .table Map ← .byId Object ← .__retained Window / http://127.0.0.1:52789`                                                                                                                                     |

--- a/examples/output/javascript.chrome.diff.heapsnapshot.md
+++ b/examples/output/javascript.chrome.diff.heapsnapshot.md
@@ -28,6 +28,8 @@ Constructors ranked by bytes allocated for their instances, excluding nodes kept
 
 Constructors with the largest increase in self size.
 
+##### Native
+
 | Change |  Delta |            % |        Size | Instances | Constructor                    | Location    |
 | -----: | -----: | -----------: | ----------: | --------: | ------------------------------ | ----------- |
 |    new | +200 B | 0.0% → <0.1% | 0 B → 200 B |     0 → 1 | `IntersectionObserver`         | `<unknown>` |
@@ -43,6 +45,8 @@ Constructors ranked by bytes allocated for their instances and all nodes that wo
 
 Constructors with the largest increase in retained size.
 
+##### Native
+
 | Change |  Delta |            % |                Size |   Instances | Constructor                    | Location    |
 | -----: | -----: | -----------: | ------------------: | ----------: | ------------------------------ | ----------- |
 | +16.0% | +496 B |         0.3% | 3.03 KiB → 3.52 KiB | 283 → 1,894 | `InternalNode`                 | `<unknown>` |
@@ -57,6 +61,8 @@ Constructors with the largest increase in retained size.
 #### Improvements
 
 Constructors with the largest decrease in retained size.
+
+##### Native
 
 | Change |       Delta |           % |                Size | Instances | Constructor                | Location    |
 | -----: | ----------: | ----------: | ------------------: | --------: | -------------------------- | ----------- |
@@ -77,6 +83,8 @@ Strings ranked by bytes allocated for them.
 
 Strings with the largest increase in size.
 
+#### String
+
 | Change | Delta |            % |       Size | Value                                                | Path        |
 | -----: | ----: | -----------: | ---------: | ---------------------------------------------------- | ----------- |
 |    new | +68 B | 0.0% → <0.1% | 0 B → 68 B | `http://127.0.0.1:52789E855ACDCDA1A5B613DDD40E0D9D…` | `(GC root)` |
@@ -84,6 +92,8 @@ Strings with the largest increase in size.
 ### Improvements
 
 Strings with the largest decrease in size.
+
+#### String
 
 |  Change | Delta |            % |       Size | Value                                                | Path        |
 | ------: | ----: | -----------: | ---------: | ---------------------------------------------------- | ----------- |

--- a/examples/output/javascript.node.base.heapsnapshot.md
+++ b/examples/output/javascript.node.base.heapsnapshot.md
@@ -49,6 +49,73 @@ Constructors ranked by bytes allocated for their instances, excluding nodes kept
 | <0.1% |    752 B |         1 | `Node / PrincipalRealm`      | `<unknown>`                            |
 | <0.1% |    744 B |        31 | `RangeError`                 | `<unknown>`                            |
 
+#### Categories
+
+##### Object
+
+|     % |     Size | Instances | Constructor        | Location                                      |
+| ----: | -------: | --------: | ------------------ | --------------------------------------------- |
+|  3.4% |  178 KiB |     2,176 | `Object`           | `<unknown>`                                   |
+|  1.4% | 75.1 KiB |       794 | `system / Context` | `<unknown>`                                   |
+|  0.5% |   28 KiB |       359 | `BuiltinModule`    | `node:internal/bootstrap/realm:239:14`        |
+|  0.1% | 4.84 KiB |       193 | `Error`            | `<unknown>`                                   |
+|  0.1% | 3.06 KiB |        36 | `ArrayBuffer`      | `<unknown>`                                   |
+| <0.1% | 2.27 KiB |        97 | `TypeError`        | `<unknown>`                                   |
+| <0.1% |    904 B |        29 | `Map`              | `<unknown>`                                   |
+| <0.1% |    896 B |        19 | `Promise`          | `<unknown>`                                   |
+| <0.1% |    864 B |        18 | `Channel`          | `node:diagnostics_channel:182:14`             |
+| <0.1% |    864 B |        18 | `WeakReference`    | `node:internal/util:889:14`                   |
+| <0.1% |    776 B |        24 | `Set`              | `<unknown>`                                   |
+| <0.1% |    744 B |        31 | `RangeError`       | `<unknown>`                                   |
+| <0.1% |    728 B |        13 | `AsyncWrap`        | `<unknown>`                                   |
+| <0.1% |    704 B |         4 | `ModuleJob`        | `node:internal/modules/esm/module_job:133:14` |
+| <0.1% |    656 B |        20 | `WeakRef`          | `<unknown>`                                   |
+| <0.1% |    616 B |        11 | `TypedArray`       | `<unknown>`                                   |
+| <0.1% |    512 B |         1 | `ReadStream`       | `node:tty:51:20`                              |
+| <0.1% |    504 B |         6 | `Generator`        | `heap-snapshot.mjs:1:1`                       |
+| <0.1% |    456 B |         3 | `WritableState`    | `node:internal/streams/writable:304:23`       |
+| <0.1% |    400 B |         5 | `ModuleWrap`       | `<unknown>`                                   |
+
+##### Array
+
+|     % |     Size | Instances | Constructor      | Location    |
+| ----: | -------: | --------: | ---------------- | ----------- |
+|  0.7% | 38.5 KiB |     1,230 | `Array`          | `<unknown>` |
+| <0.1% | 1.22 KiB |        13 | `Float64Array`   | `<unknown>` |
+| <0.1% |    752 B |         9 | `Uint8Array`     | `<unknown>` |
+| <0.1% |    672 B |         7 | `Uint32Array`    | `<unknown>` |
+| <0.1% |    480 B |         5 | `Int8Array`      | `<unknown>` |
+| <0.1% |    288 B |         3 | `Int32Array`     | `<unknown>` |
+| <0.1% |    192 B |         2 | `BigInt64Array`  | `<unknown>` |
+| <0.1% |    104 B |         2 | `Array Iterator` | `<unknown>` |
+| <0.1% |     96 B |         1 | `BigUint64Array` | `<unknown>` |
+| <0.1% |     96 B |         1 | `Float32Array`   | `<unknown>` |
+
+##### Native
+
+|     % |     Size | Instances | Constructor                       | Location    |
+| ----: | -------: | --------: | --------------------------------- | ----------- |
+|  0.2% | 10.4 KiB |        31 | `system / JSArrayBufferData`      | `<unknown>` |
+|  0.1% |  4.2 KiB |         1 | `Node / IsolateData`              | `<unknown>` |
+| <0.1% | 1.19 KiB |         8 | `Node / BindingData`              | `<unknown>` |
+| <0.1% | 1.11 KiB |        50 | `Node / std::basic_string`        | `<unknown>` |
+| <0.1% |    752 B |         1 | `Node / PrincipalRealm`           | `<unknown>` |
+| <0.1% |    528 B |         1 | `Node / async_wrap_providers`     | `<unknown>` |
+| <0.1% |    448 B |         4 | `Node / ModuleWrap`               | `<unknown>` |
+| <0.1% |    392 B |         7 | `Node / AliasedFloat64Array`      | `<unknown>` |
+| <0.1% |    336 B |         6 | `Node / AliasedUint32Array`       | `<unknown>` |
+| <0.1% |    240 B |         1 | `Node / AsyncHooks`               | `<unknown>` |
+| <0.1% |    168 B |         3 | `Node / AliasedInt32Array`        | `<unknown>` |
+| <0.1% |    112 B |         2 | `Node / AliasedUint8Array`        | `<unknown>` |
+| <0.1% |    112 B |         2 | `Node / AliasedBigInt64Array`     | `<unknown>` |
+| <0.1% |     96 B |         1 | `Node / BlobBindingData`          | `<unknown>` |
+| <0.1% |     80 B |         1 | `Node / CleanupQueue`             | `<unknown>` |
+| <0.1% |     64 B |         1 | `Node / ImmediateInfo`            | `<unknown>` |
+| <0.1% |     64 B |         1 | `Node / TickInfo`                 | `<unknown>` |
+| <0.1% |     32 B |         1 | `Node / NodeArrayBufferAllocator` | `<unknown>` |
+| <0.1% |     32 B |         1 | `Node / js_promise_hooks`         | `<unknown>` |
+| <0.1% |     24 B |         1 | `Node / BaseObjectList`           | `<unknown>` |
+
 #### Instances
 
 Instances ranked by contribution to each constructor's self size.
@@ -241,6 +308,213 @@ Instances ranked by contribution to each constructor's self size.
 | 3.2% | 24 B |         1 | `.prototype HideStackFramesError (node:internal/errors:407:16) ← .HideStackFramesError NodeError (node:internal/errors:466:20) ← .RangeError NodeError (node:internal/errors:466:20)` |
 | 3.2% | 24 B |         1 | `.prototype NodeError (node:internal/errors:498:20)`                                                                                                                                  |
 
+##### `AsyncWrap` (`<unknown>`)
+
+|    % | Size | Instances | Path                      |
+| ---: | ---: | --------: | ------------------------- |
+| 7.7% | 56 B |         1 | `.prototype DirHandle`    |
+| 7.7% | 56 B |         1 | `.prototype QueryReqWrap` |
+| 7.7% | 56 B |         1 | `.prototype ChannelWrap`  |
+| 7.7% | 56 B |         1 | `.prototype ShutdownWrap` |
+| 7.7% | 56 B |         1 | `.prototype WriteWrap`    |
+
+##### `ModuleJob` (`node:internal/modules/esm/module_job:133:14`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 704 B |         4 | `(GC root)` |
+
+##### `Uint32Array` (`<unknown>`)
+
+|     % |  Size | Instances | Path                    |
+| ----: | ----: | --------: | ----------------------- |
+| 85.7% | 576 B |         6 | `(GC root)`             |
+| 14.3% |  96 B |         1 | `.urlComponents Object` |
+
+##### `WeakRef` (`<unknown>`)
+
+|    % | Size | Instances | Path                                                                                                                                            |
+| ---: | ---: | --------: | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 8.5% | 56 B |         1 | `(GC root)`                                                                                                                                     |
+| 4.9% | 32 B |         1 | `.#weak WeakReference (node:internal/util:889:14) ← .38 array ← .table WeakRefMap (node:diagnostics_channel:38:1) ← .channels system / Context` |
+| 4.9% | 32 B |         1 | `.#weak WeakReference (node:internal/util:889:14) ← .41 array ← .table WeakRefMap (node:diagnostics_channel:38:1) ← .channels system / Context` |
+| 4.9% | 32 B |         1 | `.#weak WeakReference (node:internal/util:889:14) ← .44 array ← .table WeakRefMap (node:diagnostics_channel:38:1) ← .channels system / Context` |
+| 4.9% | 32 B |         1 | `.#weak WeakReference (node:internal/util:889:14) ← .47 array ← .table WeakRefMap (node:diagnostics_channel:38:1) ← .channels system / Context` |
+
+##### `TypedArray` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 616 B |        11 | `(GC root)` |
+
+##### `Node / async_wrap_providers` (`<unknown>`)
+
+|      % |  Size | Instances | Path                                       |
+| -----: | ----: | --------: | ------------------------------------------ |
+| 100.0% | 528 B |         1 | `.async_wrap_providers Node / IsolateData` |
+
+##### `ReadStream` (`node:tty:51:20`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 512 B |         1 | `(GC root)` |
+
+##### `Generator` (`heap-snapshot.mjs:1:1`)
+
+|     % |  Size | Instances | Path                                                                                                                                                                                                                                                                                                                                                |
+| ----: | ----: | --------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 65.1% | 328 B |         4 | `(GC root)`                                                                                                                                                                                                                                                                                                                                         |
+| 17.5% |  88 B |         1 | `.extension system / Context ← .reactions_or_result Promise ← .(Bootstrapper) Generator (node:internal/modules/esm/module_job:332:12)`                                                                                                                                                                                                              |
+| 17.5% |  88 B |         1 | `.extension system / Context ← .reactions_or_result Promise ← .(Bootstrapper) system / PromiseReaction ← .reactions_or_result Promise ← .(Bootstrapper) Generator (node:internal/modules/esm/loader:679:34) ← .extension system / Context ← .reactions_or_result Promise ← .(Bootstrapper) Generator (node:internal/modules/esm/module_job:332:12)` |
+
+##### `Int8Array` (`<unknown>`)
+
+|     % |  Size | Instances | Path                                                                                                                                                                                    |
+| ----: | ----: | --------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 40.0% | 192 B |         2 | `.noEscape system / Context`                                                                                                                                                            |
+| 20.0% |  96 B |         1 | `(GC root)`                                                                                                                                                                             |
+| 20.0% |  96 B |         1 | `.noEscapeAuth system / Context ← .exports BuiltinModule (node:internal/bootstrap/realm:239:14) ← .1313 array ← .table Map ← .map BuiltinModule (node:internal/bootstrap/realm:239:14)` |
+| 20.0% |  96 B |         1 | `.unhexTable system / Context`                                                                                                                                                          |
+
+##### `WritableState` (`node:internal/streams/writable:304:23`)
+
+|     % |  Size | Instances | Path                                                                         |
+| ----: | ----: | --------: | ---------------------------------------------------------------------------- |
+| 66.7% | 304 B |         2 | `._writableState SyncWriteStream (node:internal/fs/sync_write_stream:12:25)` |
+| 33.3% | 152 B |         1 | `._writableState ReadStream (node:tty:51:20)`                                |
+
+##### `Node / ModuleWrap` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 448 B |         4 | `(GC root)` |
+
+##### `ModuleWrap` (`<unknown>`)
+
+|     % |  Size | Instances | Path         |
+| ----: | ----: | --------: | ------------ |
+| 80.0% | 320 B |         4 | `(GC root)`  |
+| 20.0% |  80 B |         1 | `.439 array` |
+
+##### `Node / AliasedFloat64Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                                         |
+| ----: | ---: | --------: | -------------------------------------------- |
+| 14.3% | 56 B |         1 | `.async_ids_stack Node / AsyncHooks`         |
+| 14.3% | 56 B |         1 | `.async_id_fields Node / AsyncHooks`         |
+| 14.3% | 56 B |         1 | `.stats_field_array Node / BindingData`      |
+| 14.3% | 56 B |         1 | `.statfs_field_array Node / BindingData`     |
+| 14.3% | 56 B |         1 | `.heap_statistics_buffer Node / BindingData` |
+
+##### `Node / AliasedUint32Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                                        |
+| ----: | ---: | --------: | ------------------------------------------- |
+| 16.7% | 56 B |         1 | `(GC root)`                                 |
+| 16.7% | 56 B |         1 | `.fields Node / AsyncHooks`                 |
+| 16.7% | 56 B |         1 | `.fields Node / ImmediateInfo`              |
+| 16.7% | 56 B |         1 | `.hrtime_buffer Node / BindingData`         |
+| 16.7% | 56 B |         1 | `.url_components_buffer Node / BindingData` |
+
+##### `Int32Array` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 288 B |         3 | `(GC root)` |
+
+##### `Node / AsyncHooks` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 240 B |         1 | `(GC root)` |
+
+##### `BigInt64Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                         |
+| ----: | ---: | --------: | ---------------------------- |
+| 50.0% | 96 B |         1 | `.bigintStatValues Object`   |
+| 50.0% | 96 B |         1 | `.bigintStatFsValues Object` |
+
+##### `Node / AliasedInt32Array` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 168 B |         3 | `(GC root)` |
+
+##### `Node / AliasedUint8Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                                              |
+| ----: | ---: | --------: | ------------------------------------------------- |
+| 50.0% | 56 B |         1 | `.fields Node / TickInfo`                         |
+| 50.0% | 56 B |         1 | `.is_building_snapshot_buffer Node / BindingData` |
+
+##### `Node / AliasedBigInt64Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                                            |
+| ----: | ---: | --------: | ----------------------------------------------- |
+| 50.0% | 56 B |         1 | `.stats_field_bigint_array Node / BindingData`  |
+| 50.0% | 56 B |         1 | `.statfs_field_bigint_array Node / BindingData` |
+
+##### `Array Iterator` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 104 B |         2 | `(GC root)` |
+
+##### `BigUint64Array` (`<unknown>`)
+
+|      % | Size | Instances | Path                               |
+| -----: | ---: | --------: | ---------------------------------- |
+| 100.0% | 96 B |         1 | `.hrBigintValues system / Context` |
+
+##### `Float32Array` (`<unknown>`)
+
+|      % | Size | Instances | Path                             |
+| -----: | ---: | --------: | -------------------------------- |
+| 100.0% | 96 B |         1 | `.float32Array system / Context` |
+
+##### `Node / BlobBindingData` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 96 B |         1 | `(GC root)` |
+
+##### `Node / CleanupQueue` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 80 B |         1 | `(GC root)` |
+
+##### `Node / ImmediateInfo` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 64 B |         1 | `(GC root)` |
+
+##### `Node / TickInfo` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 64 B |         1 | `(GC root)` |
+
+##### `Node / NodeArrayBufferAllocator` (`<unknown>`)
+
+|      % | Size | Instances | Path                                 |
+| -----: | ---: | --------: | ------------------------------------ |
+| 100.0% | 32 B |         1 | `.node_allocator Node / IsolateData` |
+
+##### `Node / js_promise_hooks` (`<unknown>`)
+
+|      % | Size | Instances | Path                                  |
+| -----: | ---: | --------: | ------------------------------------- |
+| 100.0% | 32 B |         1 | `.js_promise_hooks Node / AsyncHooks` |
+
+##### `Node / BaseObjectList` (`<unknown>`)
+
+|      % | Size | Instances | Path                                      |
+| -----: | ---: | --------: | ----------------------------------------- |
+| 100.0% | 24 B |         1 | `.base_object_list Node / PrincipalRealm` |
+
 ### Retained size
 
 Constructors ranked by bytes allocated for their instances and all nodes that would be freed if their instances were garbage collected.
@@ -267,6 +541,73 @@ Constructors ranked by bytes allocated for their instances and all nodes that wo
 |  0.3% | 13.3 KiB |         3 | `Duplex`                     | `node:internal/streams/duplex:64:16`      |
 |  0.2% | 12.1 KiB |         1 | `InterfaceConstructor`       | `node:internal/readline/interface:139:30` |
 |  0.2% | 10.4 KiB |        31 | `system / JSArrayBufferData` | `<unknown>`                               |
+
+#### Categories
+
+##### Object
+
+|     % |     Size | Instances | Constructor               | Location                                      |
+| ----: | -------: | --------: | ------------------------- | --------------------------------------------- |
+| 24.8% | 1.28 MiB |     2,176 | `Object`                  | `<unknown>`                                   |
+|  7.7% |  406 KiB |       794 | `system / Context`        | `<unknown>`                                   |
+|  6.8% |  361 KiB |        29 | `Map`                     | `<unknown>`                                   |
+|  3.7% |  195 KiB |       359 | `BuiltinModule`           | `node:internal/bootstrap/realm:239:14`        |
+|  2.0% |  103 KiB |       193 | `Error`                   | `<unknown>`                                   |
+|  1.0% | 52.1 KiB |        97 | `TypeError`               | `<unknown>`                                   |
+|  0.5% | 27.2 KiB |        24 | `Set`                     | `<unknown>`                                   |
+|  0.4% | 20.5 KiB |         2 | `console`                 | `<unknown>`                                   |
+|  0.4% | 19.3 KiB |         1 | `NodeEnvironmentFlagsSet` | `node:internal/process/per_thread:438:16`     |
+|  0.3% | 18.4 KiB |         2 | `Stream`                  | `node:internal/streams/legacy:11:16`          |
+|  0.3% | 16.8 KiB |         1 | `FixedQueue`              | `node:internal/fixed_queue:92:14`             |
+|  0.3% | 16.7 KiB |        31 | `RangeError`              | `<unknown>`                                   |
+|  0.3% | 16.5 KiB |         1 | `FixedCircularBuffer`     | `node:internal/fixed_queue:61:14`             |
+|  0.3% | 16.4 KiB |         8 | `EventEmitter`            | `node:events:220:22`                          |
+|  0.3% | 14.1 KiB |        36 | `ArrayBuffer`             | `<unknown>`                                   |
+|  0.3% | 14.1 KiB |         2 | `global`                  | `<unknown>`                                   |
+|  0.3% | 13.3 KiB |         3 | `Duplex`                  | `node:internal/streams/duplex:64:16`          |
+|  0.2% | 12.1 KiB |         1 | `InterfaceConstructor`    | `node:internal/readline/interface:139:30`     |
+|  0.1% | 7.59 KiB |         2 | `process`                 | `<unknown>`                                   |
+|  0.1% | 6.68 KiB |         2 | `ModuleJobBase`           | `node:internal/modules/esm/module_job:109:14` |
+
+##### Array
+
+|     % |     Size | Instances | Constructor      | Location    |
+| ----: | -------: | --------: | ---------------- | ----------- |
+|  2.6% |  139 KiB |     1,230 | `Array`          | `<unknown>` |
+|  0.1% | 6.15 KiB |         9 | `Uint8Array`     | `<unknown>` |
+|  0.1% |  3.2 KiB |        13 | `Float64Array`   | `<unknown>` |
+| <0.1% | 1.77 KiB |         5 | `Int8Array`      | `<unknown>` |
+| <0.1% | 1.18 KiB |         7 | `Uint32Array`    | `<unknown>` |
+| <0.1% |    712 B |         2 | `BigInt64Array`  | `<unknown>` |
+| <0.1% |    584 B |         3 | `Int32Array`     | `<unknown>` |
+| <0.1% |    304 B |         2 | `Array Iterator` | `<unknown>` |
+| <0.1% |     96 B |         1 | `BigUint64Array` | `<unknown>` |
+| <0.1% |     96 B |         1 | `Float32Array`   | `<unknown>` |
+
+##### Native
+
+|     % |     Size | Instances | Constructor                       | Location    |
+| ----: | -------: | --------: | --------------------------------- | ----------- |
+|  0.2% | 10.4 KiB |        31 | `system / JSArrayBufferData`      | `<unknown>` |
+|  0.1% | 4.76 KiB |         1 | `Node / IsolateData`              | `<unknown>` |
+| <0.1% | 1.89 KiB |         1 | `Node / PrincipalRealm`           | `<unknown>` |
+| <0.1% | 1.79 KiB |         8 | `Node / BindingData`              | `<unknown>` |
+| <0.1% | 1.13 KiB |         1 | `Node / builtins_with_cache`      | `<unknown>` |
+| <0.1% | 1.11 KiB |        50 | `Node / std::basic_string`        | `<unknown>` |
+| <0.1% |    528 B |         1 | `Node / async_wrap_providers`     | `<unknown>` |
+| <0.1% |    448 B |         4 | `Node / ModuleWrap`               | `<unknown>` |
+| <0.1% |    440 B |         1 | `Node / AsyncHooks`               | `<unknown>` |
+| <0.1% |    392 B |         7 | `Node / AliasedFloat64Array`      | `<unknown>` |
+| <0.1% |    336 B |         6 | `Node / AliasedUint32Array`       | `<unknown>` |
+| <0.1% |    168 B |         3 | `Node / AliasedInt32Array`        | `<unknown>` |
+| <0.1% |    120 B |         1 | `Node / ImmediateInfo`            | `<unknown>` |
+| <0.1% |    120 B |         1 | `Node / TickInfo`                 | `<unknown>` |
+| <0.1% |    112 B |         2 | `Node / AliasedUint8Array`        | `<unknown>` |
+| <0.1% |    112 B |         2 | `Node / AliasedBigInt64Array`     | `<unknown>` |
+| <0.1% |     96 B |         1 | `Node / BlobBindingData`          | `<unknown>` |
+| <0.1% |     80 B |         1 | `Node / CleanupQueue`             | `<unknown>` |
+| <0.1% |     32 B |         1 | `Node / NodeArrayBufferAllocator` | `<unknown>` |
+| <0.1% |     32 B |         1 | `Node / js_promise_hooks`         | `<unknown>` |
 
 #### Instances
 
@@ -440,6 +781,215 @@ Instances ranked by contribution to each constructor's retained size.
 |  2.7% | 288 B |         1 | `.backing_store ArrayBuffer ← .buffer BigInt64Array ← .bigintStatValues Object` |
 |  2.4% | 256 B |         1 | `.backing_store ArrayBuffer ← .buffer Int8Array`                                |
 |  2.4% | 256 B |         1 | `.backing_store ArrayBuffer ← .buffer Int8Array ← .unhexTable system / Context` |
+
+##### `process` (`<unknown>`)
+
+|     % |     Size | Instances | Path        |
+| ----: | -------: | --------: | ----------- |
+| 99.7% | 7.57 KiB |         1 | `(GC root)` |
+|  0.3% |     24 B |         1 | `.28 array` |
+
+##### `ModuleJobBase` (`node:internal/modules/esm/module_job:109:14`)
+
+|     % |     Size | Instances | Path                                                                                                                                                                                                                                                   |
+| ----: | -------: | --------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 88.0% | 5.88 KiB |         1 | `(GC root)`                                                                                                                                                                                                                                            |
+| 12.0% |    824 B |         1 | `.prototype ModuleJobSync (node:internal/modules/esm/module_job:374:14) ← .ModuleJobSync Object ← .exports BuiltinModule (node:internal/bootstrap/realm:239:14) ← .800 array ← .table Map ← .map BuiltinModule (node:internal/bootstrap/realm:239:14)` |
+
+##### `Uint8Array` (`<unknown>`)
+
+|     % |    Size | Instances | Path                                                                                                                                                                                                                    |
+| ----: | ------: | --------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 89.5% | 5.5 KiB |         5 | `(GC root)`                                                                                                                                                                                                             |
+|  4.6% |   288 B |         1 | `.prototype SlowBuffer (node:buffer:428:20) ← .SlowBuffer Object ← .exports BuiltinModule (node:internal/bootstrap/realm:239:14) ← .311 array ← .table Map ← .map BuiltinModule (node:internal/bootstrap/realm:239:14)` |
+|  2.9% |   184 B |         1 | `.empty system / Context`                                                                                                                                                                                               |
+|  1.5% |    96 B |         1 | `.uInt8Float64Array system / Context`                                                                                                                                                                                   |
+|  1.5% |    96 B |         1 | `.uInt8Float32Array system / Context`                                                                                                                                                                                   |
+
+##### `Node / IsolateData` (`<unknown>`)
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 4.76 KiB |         1 | `(GC root)` |
+
+##### `Float64Array` (`<unknown>`)
+
+|     % |     Size | Instances | Path                               |
+| ----: | -------: | --------: | ---------------------------------- |
+| 56.7% | 1.81 KiB |         6 | `(GC root)`                        |
+|  9.5% |    312 B |         1 | `.resourceValues system / Context` |
+|  7.3% |    240 B |         1 | `.statFsValues Object`             |
+|  7.3% |    240 B |         1 | `.memValues system / Context`      |
+|  6.6% |    216 B |         1 | `.cpuValues system / Context`      |
+
+##### `Node / PrincipalRealm` (`<unknown>`)
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 1.89 KiB |         1 | `(GC root)` |
+
+##### `Node / BindingData` (`<unknown>`)
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 1.79 KiB |         8 | `(GC root)` |
+
+##### `Int8Array` (`<unknown>`)
+
+|     % |  Size | Instances | Path                                                                                                                                                                                    |
+| ----: | ----: | --------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 34.4% | 624 B |         2 | `.noEscape system / Context`                                                                                                                                                            |
+| 24.2% | 440 B |         1 | `(GC root)`                                                                                                                                                                             |
+| 24.2% | 440 B |         1 | `.unhexTable system / Context`                                                                                                                                                          |
+| 17.2% | 312 B |         1 | `.noEscapeAuth system / Context ← .exports BuiltinModule (node:internal/bootstrap/realm:239:14) ← .1313 array ← .table Map ← .map BuiltinModule (node:internal/bootstrap/realm:239:14)` |
+
+##### `Uint32Array` (`<unknown>`)
+
+|     % |  Size | Instances | Path                    |
+| ----: | ----: | --------: | ----------------------- |
+| 81.8% | 988 B |         6 | `(GC root)`             |
+| 18.2% | 220 B |         1 | `.urlComponents Object` |
+
+##### `Node / builtins_with_cache` (`<unknown>`)
+
+|      % |     Size | Instances | Path                                         |
+| -----: | -------: | --------: | -------------------------------------------- |
+| 100.0% | 1.13 KiB |         1 | `.builtins_with_cache Node / PrincipalRealm` |
+
+##### `Node / std::basic_string` (`<unknown>`)
+
+|    % | Size | Instances | Path                                                                           |
+| ---: | ---: | --------: | ------------------------------------------------------------------------------ |
+| 2.9% | 33 B |         1 | `[28] Node / builtins_with_cache ← .builtins_with_cache Node / PrincipalRealm` |
+| 2.8% | 32 B |         1 | `[18] Node / builtins_with_cache ← .builtins_with_cache Node / PrincipalRealm` |
+| 2.7% | 31 B |         1 | `[12] Node / builtins_with_cache ← .builtins_with_cache Node / PrincipalRealm` |
+| 2.7% | 31 B |         1 | `[15] Node / builtins_with_cache ← .builtins_with_cache Node / PrincipalRealm` |
+| 2.7% | 31 B |         1 | `[16] Node / builtins_with_cache ← .builtins_with_cache Node / PrincipalRealm` |
+
+##### `BigInt64Array` (`<unknown>`)
+
+|     % |  Size | Instances | Path                         |
+| ----: | ----: | --------: | ---------------------------- |
+| 66.3% | 472 B |         1 | `.bigintStatValues Object`   |
+| 33.7% | 240 B |         1 | `.bigintStatFsValues Object` |
+
+##### `Int32Array` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 584 B |         3 | `(GC root)` |
+
+##### `Node / async_wrap_providers` (`<unknown>`)
+
+|      % |  Size | Instances | Path                                       |
+| -----: | ----: | --------: | ------------------------------------------ |
+| 100.0% | 528 B |         1 | `.async_wrap_providers Node / IsolateData` |
+
+##### `Node / ModuleWrap` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 448 B |         4 | `(GC root)` |
+
+##### `Node / AsyncHooks` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 440 B |         1 | `(GC root)` |
+
+##### `Node / AliasedFloat64Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                                         |
+| ----: | ---: | --------: | -------------------------------------------- |
+| 14.3% | 56 B |         1 | `.async_ids_stack Node / AsyncHooks`         |
+| 14.3% | 56 B |         1 | `.async_id_fields Node / AsyncHooks`         |
+| 14.3% | 56 B |         1 | `.stats_field_array Node / BindingData`      |
+| 14.3% | 56 B |         1 | `.statfs_field_array Node / BindingData`     |
+| 14.3% | 56 B |         1 | `.heap_statistics_buffer Node / BindingData` |
+
+##### `Node / AliasedUint32Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                                        |
+| ----: | ---: | --------: | ------------------------------------------- |
+| 16.7% | 56 B |         1 | `(GC root)`                                 |
+| 16.7% | 56 B |         1 | `.fields Node / AsyncHooks`                 |
+| 16.7% | 56 B |         1 | `.fields Node / ImmediateInfo`              |
+| 16.7% | 56 B |         1 | `.hrtime_buffer Node / BindingData`         |
+| 16.7% | 56 B |         1 | `.url_components_buffer Node / BindingData` |
+
+##### `Array Iterator` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 304 B |         2 | `(GC root)` |
+
+##### `Node / AliasedInt32Array` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 168 B |         3 | `(GC root)` |
+
+##### `Node / ImmediateInfo` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 120 B |         1 | `(GC root)` |
+
+##### `Node / TickInfo` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 120 B |         1 | `(GC root)` |
+
+##### `Node / AliasedUint8Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                                              |
+| ----: | ---: | --------: | ------------------------------------------------- |
+| 50.0% | 56 B |         1 | `.fields Node / TickInfo`                         |
+| 50.0% | 56 B |         1 | `.is_building_snapshot_buffer Node / BindingData` |
+
+##### `Node / AliasedBigInt64Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                                            |
+| ----: | ---: | --------: | ----------------------------------------------- |
+| 50.0% | 56 B |         1 | `.stats_field_bigint_array Node / BindingData`  |
+| 50.0% | 56 B |         1 | `.statfs_field_bigint_array Node / BindingData` |
+
+##### `BigUint64Array` (`<unknown>`)
+
+|      % | Size | Instances | Path                               |
+| -----: | ---: | --------: | ---------------------------------- |
+| 100.0% | 96 B |         1 | `.hrBigintValues system / Context` |
+
+##### `Float32Array` (`<unknown>`)
+
+|      % | Size | Instances | Path                             |
+| -----: | ---: | --------: | -------------------------------- |
+| 100.0% | 96 B |         1 | `.float32Array system / Context` |
+
+##### `Node / BlobBindingData` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 96 B |         1 | `(GC root)` |
+
+##### `Node / CleanupQueue` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 80 B |         1 | `(GC root)` |
+
+##### `Node / NodeArrayBufferAllocator` (`<unknown>`)
+
+|      % | Size | Instances | Path                                 |
+| -----: | ---: | --------: | ------------------------------------ |
+| 100.0% | 32 B |         1 | `.node_allocator Node / IsolateData` |
+
+##### `Node / js_promise_hooks` (`<unknown>`)
+
+|      % | Size | Instances | Path                                  |
+| -----: | ---: | --------: | ------------------------------------- |
+| 100.0% | 32 B |         1 | `.js_promise_hooks Node / AsyncHooks` |
 
 ## Largest functions
 
@@ -636,6 +1186,10 @@ Nodes ranked by contribution to each function's retained size.
 
 Strings ranked by bytes allocated for them.
 
+### Categories
+
+#### String
+
 |     % |     Size | Value                                                    | Path                                                            |
 | ----: | -------: | -------------------------------------------------------- | --------------------------------------------------------------- |
 | <0.1% | 1.91 KiB | `import { readFileSync } from 'node:fs'\nimport { a…`    | `.source heap-snapshot.mjs ← .script (shared function info)`    |
@@ -658,3 +1212,28 @@ Strings ranked by bytes allocated for them.
 | <0.1% |    296 B | `RT @shiawaseomamori: 一に止まると書いて、正しいという意味だなんて、この年にな…`     | `.text Object`                                                  |
 | <0.1% |    296 B | `RT @shiawaseomamori: 一に止まると書いて、正しいという意味だなんて、この年にな…`     | `.text Object`                                                  |
 | <0.1% |    296 B | `RT @shiawaseomamori: 一に止まると書いて、正しいという意味だなんて、この年にな…`     | `.text Object`                                                  |
+
+#### Concatenated string
+
+|     % | Size | Value                   | Path        |
+| ----: | ---: | ----------------------- | ----------- |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |

--- a/examples/output/javascript.node.current.heapsnapshot.md
+++ b/examples/output/javascript.node.current.heapsnapshot.md
@@ -49,6 +49,73 @@ Constructors ranked by bytes allocated for their instances, excluding nodes kept
 | <0.1% |    752 B |         1 | `Node / PrincipalRealm`      | `<unknown>`                            |
 | <0.1% |    744 B |        31 | `RangeError`                 | `<unknown>`                            |
 
+#### Categories
+
+##### Object
+
+|     % |     Size | Instances | Constructor        | Location                                      |
+| ----: | -------: | --------: | ------------------ | --------------------------------------------- |
+|  3.4% |  178 KiB |     2,176 | `Object`           | `<unknown>`                                   |
+|  1.4% | 75.1 KiB |       794 | `system / Context` | `<unknown>`                                   |
+|  0.5% |   28 KiB |       359 | `BuiltinModule`    | `node:internal/bootstrap/realm:239:14`        |
+|  0.1% | 4.84 KiB |       193 | `Error`            | `<unknown>`                                   |
+|  0.1% | 3.06 KiB |        36 | `ArrayBuffer`      | `<unknown>`                                   |
+| <0.1% | 2.27 KiB |        97 | `TypeError`        | `<unknown>`                                   |
+| <0.1% |    904 B |        29 | `Map`              | `<unknown>`                                   |
+| <0.1% |    896 B |        19 | `Promise`          | `<unknown>`                                   |
+| <0.1% |    864 B |        18 | `Channel`          | `node:diagnostics_channel:182:14`             |
+| <0.1% |    864 B |        18 | `WeakReference`    | `node:internal/util:889:14`                   |
+| <0.1% |    776 B |        24 | `Set`              | `<unknown>`                                   |
+| <0.1% |    744 B |        31 | `RangeError`       | `<unknown>`                                   |
+| <0.1% |    728 B |        13 | `AsyncWrap`        | `<unknown>`                                   |
+| <0.1% |    704 B |         4 | `ModuleJob`        | `node:internal/modules/esm/module_job:133:14` |
+| <0.1% |    656 B |        20 | `WeakRef`          | `<unknown>`                                   |
+| <0.1% |    616 B |        11 | `TypedArray`       | `<unknown>`                                   |
+| <0.1% |    512 B |         1 | `ReadStream`       | `node:tty:51:20`                              |
+| <0.1% |    504 B |         6 | `Generator`        | `heap-snapshot.mjs:1:1`                       |
+| <0.1% |    456 B |         3 | `WritableState`    | `node:internal/streams/writable:304:23`       |
+| <0.1% |    400 B |         5 | `ModuleWrap`       | `<unknown>`                                   |
+
+##### Array
+
+|     % |     Size | Instances | Constructor      | Location    |
+| ----: | -------: | --------: | ---------------- | ----------- |
+|  0.7% | 38.5 KiB |     1,230 | `Array`          | `<unknown>` |
+| <0.1% | 1.22 KiB |        13 | `Float64Array`   | `<unknown>` |
+| <0.1% |    752 B |         9 | `Uint8Array`     | `<unknown>` |
+| <0.1% |    672 B |         7 | `Uint32Array`    | `<unknown>` |
+| <0.1% |    480 B |         5 | `Int8Array`      | `<unknown>` |
+| <0.1% |    288 B |         3 | `Int32Array`     | `<unknown>` |
+| <0.1% |    192 B |         2 | `BigInt64Array`  | `<unknown>` |
+| <0.1% |    104 B |         2 | `Array Iterator` | `<unknown>` |
+| <0.1% |     96 B |         1 | `BigUint64Array` | `<unknown>` |
+| <0.1% |     96 B |         1 | `Float32Array`   | `<unknown>` |
+
+##### Native
+
+|     % |     Size | Instances | Constructor                       | Location    |
+| ----: | -------: | --------: | --------------------------------- | ----------- |
+|  0.2% | 10.4 KiB |        31 | `system / JSArrayBufferData`      | `<unknown>` |
+|  0.1% |  4.2 KiB |         1 | `Node / IsolateData`              | `<unknown>` |
+| <0.1% | 1.19 KiB |         8 | `Node / BindingData`              | `<unknown>` |
+| <0.1% | 1.11 KiB |        50 | `Node / std::basic_string`        | `<unknown>` |
+| <0.1% |    752 B |         1 | `Node / PrincipalRealm`           | `<unknown>` |
+| <0.1% |    528 B |         1 | `Node / async_wrap_providers`     | `<unknown>` |
+| <0.1% |    448 B |         4 | `Node / ModuleWrap`               | `<unknown>` |
+| <0.1% |    392 B |         7 | `Node / AliasedFloat64Array`      | `<unknown>` |
+| <0.1% |    336 B |         6 | `Node / AliasedUint32Array`       | `<unknown>` |
+| <0.1% |    240 B |         1 | `Node / AsyncHooks`               | `<unknown>` |
+| <0.1% |    168 B |         3 | `Node / AliasedInt32Array`        | `<unknown>` |
+| <0.1% |    112 B |         2 | `Node / AliasedUint8Array`        | `<unknown>` |
+| <0.1% |    112 B |         2 | `Node / AliasedBigInt64Array`     | `<unknown>` |
+| <0.1% |     96 B |         1 | `Node / BlobBindingData`          | `<unknown>` |
+| <0.1% |     80 B |         1 | `Node / CleanupQueue`             | `<unknown>` |
+| <0.1% |     64 B |         1 | `Node / ImmediateInfo`            | `<unknown>` |
+| <0.1% |     64 B |         1 | `Node / TickInfo`                 | `<unknown>` |
+| <0.1% |     32 B |         1 | `Node / NodeArrayBufferAllocator` | `<unknown>` |
+| <0.1% |     32 B |         1 | `Node / js_promise_hooks`         | `<unknown>` |
+| <0.1% |     24 B |         1 | `Node / BaseObjectList`           | `<unknown>` |
+
 #### Instances
 
 Instances ranked by contribution to each constructor's self size.
@@ -241,6 +308,213 @@ Instances ranked by contribution to each constructor's self size.
 | 3.2% | 24 B |         1 | `.prototype HideStackFramesError (node:internal/errors:407:16) ← .HideStackFramesError NodeError (node:internal/errors:466:20) ← .RangeError NodeError (node:internal/errors:466:20)` |
 | 3.2% | 24 B |         1 | `.prototype NodeError (node:internal/errors:498:20)`                                                                                                                                  |
 
+##### `AsyncWrap` (`<unknown>`)
+
+|    % | Size | Instances | Path                      |
+| ---: | ---: | --------: | ------------------------- |
+| 7.7% | 56 B |         1 | `(GC root)`               |
+| 7.7% | 56 B |         1 | `.prototype DirHandle`    |
+| 7.7% | 56 B |         1 | `.prototype QueryReqWrap` |
+| 7.7% | 56 B |         1 | `.prototype ChannelWrap`  |
+| 7.7% | 56 B |         1 | `.prototype ShutdownWrap` |
+
+##### `ModuleJob` (`node:internal/modules/esm/module_job:133:14`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 704 B |         4 | `(GC root)` |
+
+##### `Uint32Array` (`<unknown>`)
+
+|     % |  Size | Instances | Path                    |
+| ----: | ----: | --------: | ----------------------- |
+| 85.7% | 576 B |         6 | `(GC root)`             |
+| 14.3% |  96 B |         1 | `.urlComponents Object` |
+
+##### `WeakRef` (`<unknown>`)
+
+|    % | Size | Instances | Path                                                                                                                                            |
+| ---: | ---: | --------: | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 8.5% | 56 B |         1 | `(GC root)`                                                                                                                                     |
+| 4.9% | 32 B |         1 | `.#weak WeakReference (node:internal/util:889:14) ← .38 array ← .table WeakRefMap (node:diagnostics_channel:38:1) ← .channels system / Context` |
+| 4.9% | 32 B |         1 | `.#weak WeakReference (node:internal/util:889:14) ← .41 array ← .table WeakRefMap (node:diagnostics_channel:38:1) ← .channels system / Context` |
+| 4.9% | 32 B |         1 | `.#weak WeakReference (node:internal/util:889:14) ← .44 array ← .table WeakRefMap (node:diagnostics_channel:38:1) ← .channels system / Context` |
+| 4.9% | 32 B |         1 | `.#weak WeakReference (node:internal/util:889:14) ← .47 array ← .table WeakRefMap (node:diagnostics_channel:38:1) ← .channels system / Context` |
+
+##### `TypedArray` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 616 B |        11 | `(GC root)` |
+
+##### `Node / async_wrap_providers` (`<unknown>`)
+
+|      % |  Size | Instances | Path                                       |
+| -----: | ----: | --------: | ------------------------------------------ |
+| 100.0% | 528 B |         1 | `.async_wrap_providers Node / IsolateData` |
+
+##### `ReadStream` (`node:tty:51:20`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 512 B |         1 | `(GC root)` |
+
+##### `Generator` (`heap-snapshot.mjs:1:1`)
+
+|     % |  Size | Instances | Path                                                                                                                                                                                                                                                                                                                                                |
+| ----: | ----: | --------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 65.1% | 328 B |         4 | `(GC root)`                                                                                                                                                                                                                                                                                                                                         |
+| 17.5% |  88 B |         1 | `.extension system / Context ← .reactions_or_result Promise ← .(Bootstrapper) system / PromiseReaction ← .reactions_or_result Promise ← .(Bootstrapper) Generator (node:internal/modules/esm/loader:679:34) ← .extension system / Context ← .reactions_or_result Promise ← .(Bootstrapper) Generator (node:internal/modules/esm/module_job:332:12)` |
+| 17.5% |  88 B |         1 | `.extension system / Context ← .reactions_or_result Promise ← .(Bootstrapper) Generator (node:internal/modules/esm/module_job:332:12)`                                                                                                                                                                                                              |
+
+##### `Int8Array` (`<unknown>`)
+
+|     % |  Size | Instances | Path                                                                                                                                                                                    |
+| ----: | ----: | --------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 40.0% | 192 B |         2 | `.noEscape system / Context`                                                                                                                                                            |
+| 20.0% |  96 B |         1 | `(GC root)`                                                                                                                                                                             |
+| 20.0% |  96 B |         1 | `.noEscapeAuth system / Context ← .exports BuiltinModule (node:internal/bootstrap/realm:239:14) ← .1313 array ← .table Map ← .map BuiltinModule (node:internal/bootstrap/realm:239:14)` |
+| 20.0% |  96 B |         1 | `.unhexTable system / Context`                                                                                                                                                          |
+
+##### `WritableState` (`node:internal/streams/writable:304:23`)
+
+|     % |  Size | Instances | Path                                                                         |
+| ----: | ----: | --------: | ---------------------------------------------------------------------------- |
+| 66.7% | 304 B |         2 | `._writableState SyncWriteStream (node:internal/fs/sync_write_stream:12:25)` |
+| 33.3% | 152 B |         1 | `._writableState ReadStream (node:tty:51:20)`                                |
+
+##### `Node / ModuleWrap` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 448 B |         4 | `(GC root)` |
+
+##### `ModuleWrap` (`<unknown>`)
+
+|     % |  Size | Instances | Path         |
+| ----: | ----: | --------: | ------------ |
+| 80.0% | 320 B |         4 | `(GC root)`  |
+| 20.0% |  80 B |         1 | `.439 array` |
+
+##### `Node / AliasedFloat64Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                                         |
+| ----: | ---: | --------: | -------------------------------------------- |
+| 14.3% | 56 B |         1 | `.async_ids_stack Node / AsyncHooks`         |
+| 14.3% | 56 B |         1 | `.async_id_fields Node / AsyncHooks`         |
+| 14.3% | 56 B |         1 | `.stats_field_array Node / BindingData`      |
+| 14.3% | 56 B |         1 | `.statfs_field_array Node / BindingData`     |
+| 14.3% | 56 B |         1 | `.heap_statistics_buffer Node / BindingData` |
+
+##### `Node / AliasedUint32Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                                        |
+| ----: | ---: | --------: | ------------------------------------------- |
+| 16.7% | 56 B |         1 | `(GC root)`                                 |
+| 16.7% | 56 B |         1 | `.fields Node / AsyncHooks`                 |
+| 16.7% | 56 B |         1 | `.fields Node / ImmediateInfo`              |
+| 16.7% | 56 B |         1 | `.hrtime_buffer Node / BindingData`         |
+| 16.7% | 56 B |         1 | `.url_components_buffer Node / BindingData` |
+
+##### `Int32Array` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 288 B |         3 | `(GC root)` |
+
+##### `Node / AsyncHooks` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 240 B |         1 | `(GC root)` |
+
+##### `BigInt64Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                         |
+| ----: | ---: | --------: | ---------------------------- |
+| 50.0% | 96 B |         1 | `.bigintStatValues Object`   |
+| 50.0% | 96 B |         1 | `.bigintStatFsValues Object` |
+
+##### `Node / AliasedInt32Array` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 168 B |         3 | `(GC root)` |
+
+##### `Node / AliasedUint8Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                                              |
+| ----: | ---: | --------: | ------------------------------------------------- |
+| 50.0% | 56 B |         1 | `.fields Node / TickInfo`                         |
+| 50.0% | 56 B |         1 | `.is_building_snapshot_buffer Node / BindingData` |
+
+##### `Node / AliasedBigInt64Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                                            |
+| ----: | ---: | --------: | ----------------------------------------------- |
+| 50.0% | 56 B |         1 | `.stats_field_bigint_array Node / BindingData`  |
+| 50.0% | 56 B |         1 | `.statfs_field_bigint_array Node / BindingData` |
+
+##### `Array Iterator` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 104 B |         2 | `(GC root)` |
+
+##### `BigUint64Array` (`<unknown>`)
+
+|      % | Size | Instances | Path                               |
+| -----: | ---: | --------: | ---------------------------------- |
+| 100.0% | 96 B |         1 | `.hrBigintValues system / Context` |
+
+##### `Float32Array` (`<unknown>`)
+
+|      % | Size | Instances | Path                             |
+| -----: | ---: | --------: | -------------------------------- |
+| 100.0% | 96 B |         1 | `.float32Array system / Context` |
+
+##### `Node / BlobBindingData` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 96 B |         1 | `(GC root)` |
+
+##### `Node / CleanupQueue` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 80 B |         1 | `(GC root)` |
+
+##### `Node / ImmediateInfo` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 64 B |         1 | `(GC root)` |
+
+##### `Node / TickInfo` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 64 B |         1 | `(GC root)` |
+
+##### `Node / NodeArrayBufferAllocator` (`<unknown>`)
+
+|      % | Size | Instances | Path                                 |
+| -----: | ---: | --------: | ------------------------------------ |
+| 100.0% | 32 B |         1 | `.node_allocator Node / IsolateData` |
+
+##### `Node / js_promise_hooks` (`<unknown>`)
+
+|      % | Size | Instances | Path                                  |
+| -----: | ---: | --------: | ------------------------------------- |
+| 100.0% | 32 B |         1 | `.js_promise_hooks Node / AsyncHooks` |
+
+##### `Node / BaseObjectList` (`<unknown>`)
+
+|      % | Size | Instances | Path                                      |
+| -----: | ---: | --------: | ----------------------------------------- |
+| 100.0% | 24 B |         1 | `.base_object_list Node / PrincipalRealm` |
+
 ### Retained size
 
 Constructors ranked by bytes allocated for their instances and all nodes that would be freed if their instances were garbage collected.
@@ -267,6 +541,73 @@ Constructors ranked by bytes allocated for their instances and all nodes that wo
 |  0.3% | 13.3 KiB |         3 | `Duplex`                     | `node:internal/streams/duplex:64:16`      |
 |  0.2% | 12.1 KiB |         1 | `InterfaceConstructor`       | `node:internal/readline/interface:139:30` |
 |  0.2% | 10.4 KiB |        31 | `system / JSArrayBufferData` | `<unknown>`                               |
+
+#### Categories
+
+##### Object
+
+|     % |     Size | Instances | Constructor               | Location                                      |
+| ----: | -------: | --------: | ------------------------- | --------------------------------------------- |
+| 24.8% | 1.28 MiB |     2,176 | `Object`                  | `<unknown>`                                   |
+|  7.7% |  406 KiB |       794 | `system / Context`        | `<unknown>`                                   |
+|  6.8% |  361 KiB |        29 | `Map`                     | `<unknown>`                                   |
+|  3.7% |  195 KiB |       359 | `BuiltinModule`           | `node:internal/bootstrap/realm:239:14`        |
+|  2.0% |  103 KiB |       193 | `Error`                   | `<unknown>`                                   |
+|  1.0% | 52.1 KiB |        97 | `TypeError`               | `<unknown>`                                   |
+|  0.5% | 27.2 KiB |        24 | `Set`                     | `<unknown>`                                   |
+|  0.4% | 20.5 KiB |         2 | `console`                 | `<unknown>`                                   |
+|  0.4% | 19.3 KiB |         1 | `NodeEnvironmentFlagsSet` | `node:internal/process/per_thread:438:16`     |
+|  0.3% | 18.4 KiB |         2 | `Stream`                  | `node:internal/streams/legacy:11:16`          |
+|  0.3% | 16.8 KiB |         1 | `FixedQueue`              | `node:internal/fixed_queue:92:14`             |
+|  0.3% | 16.7 KiB |        31 | `RangeError`              | `<unknown>`                                   |
+|  0.3% | 16.5 KiB |         1 | `FixedCircularBuffer`     | `node:internal/fixed_queue:61:14`             |
+|  0.3% | 16.4 KiB |         8 | `EventEmitter`            | `node:events:220:22`                          |
+|  0.3% | 14.1 KiB |        36 | `ArrayBuffer`             | `<unknown>`                                   |
+|  0.3% | 14.1 KiB |         2 | `global`                  | `<unknown>`                                   |
+|  0.3% | 13.3 KiB |         3 | `Duplex`                  | `node:internal/streams/duplex:64:16`          |
+|  0.2% | 12.1 KiB |         1 | `InterfaceConstructor`    | `node:internal/readline/interface:139:30`     |
+|  0.1% | 7.59 KiB |         2 | `process`                 | `<unknown>`                                   |
+|  0.1% | 6.68 KiB |         2 | `ModuleJobBase`           | `node:internal/modules/esm/module_job:109:14` |
+
+##### Array
+
+|     % |     Size | Instances | Constructor      | Location    |
+| ----: | -------: | --------: | ---------------- | ----------- |
+|  2.6% |  139 KiB |     1,230 | `Array`          | `<unknown>` |
+|  0.1% | 6.15 KiB |         9 | `Uint8Array`     | `<unknown>` |
+|  0.1% |  3.2 KiB |        13 | `Float64Array`   | `<unknown>` |
+| <0.1% | 1.77 KiB |         5 | `Int8Array`      | `<unknown>` |
+| <0.1% | 1.18 KiB |         7 | `Uint32Array`    | `<unknown>` |
+| <0.1% |    712 B |         2 | `BigInt64Array`  | `<unknown>` |
+| <0.1% |    584 B |         3 | `Int32Array`     | `<unknown>` |
+| <0.1% |    304 B |         2 | `Array Iterator` | `<unknown>` |
+| <0.1% |     96 B |         1 | `BigUint64Array` | `<unknown>` |
+| <0.1% |     96 B |         1 | `Float32Array`   | `<unknown>` |
+
+##### Native
+
+|     % |     Size | Instances | Constructor                       | Location    |
+| ----: | -------: | --------: | --------------------------------- | ----------- |
+|  0.2% | 10.4 KiB |        31 | `system / JSArrayBufferData`      | `<unknown>` |
+|  0.1% | 4.76 KiB |         1 | `Node / IsolateData`              | `<unknown>` |
+| <0.1% | 1.89 KiB |         1 | `Node / PrincipalRealm`           | `<unknown>` |
+| <0.1% | 1.79 KiB |         8 | `Node / BindingData`              | `<unknown>` |
+| <0.1% | 1.13 KiB |         1 | `Node / builtins_with_cache`      | `<unknown>` |
+| <0.1% | 1.11 KiB |        50 | `Node / std::basic_string`        | `<unknown>` |
+| <0.1% |    528 B |         1 | `Node / async_wrap_providers`     | `<unknown>` |
+| <0.1% |    448 B |         4 | `Node / ModuleWrap`               | `<unknown>` |
+| <0.1% |    440 B |         1 | `Node / AsyncHooks`               | `<unknown>` |
+| <0.1% |    392 B |         7 | `Node / AliasedFloat64Array`      | `<unknown>` |
+| <0.1% |    336 B |         6 | `Node / AliasedUint32Array`       | `<unknown>` |
+| <0.1% |    168 B |         3 | `Node / AliasedInt32Array`        | `<unknown>` |
+| <0.1% |    120 B |         1 | `Node / ImmediateInfo`            | `<unknown>` |
+| <0.1% |    120 B |         1 | `Node / TickInfo`                 | `<unknown>` |
+| <0.1% |    112 B |         2 | `Node / AliasedUint8Array`        | `<unknown>` |
+| <0.1% |    112 B |         2 | `Node / AliasedBigInt64Array`     | `<unknown>` |
+| <0.1% |     96 B |         1 | `Node / BlobBindingData`          | `<unknown>` |
+| <0.1% |     80 B |         1 | `Node / CleanupQueue`             | `<unknown>` |
+| <0.1% |     32 B |         1 | `Node / NodeArrayBufferAllocator` | `<unknown>` |
+| <0.1% |     32 B |         1 | `Node / js_promise_hooks`         | `<unknown>` |
 
 #### Instances
 
@@ -440,6 +781,215 @@ Instances ranked by contribution to each constructor's retained size.
 |  2.7% | 288 B |         1 | `.backing_store ArrayBuffer ← .buffer BigInt64Array ← .bigintStatValues Object` |
 |  2.4% | 256 B |         1 | `.backing_store ArrayBuffer ← .buffer Int8Array`                                |
 |  2.4% | 256 B |         1 | `.backing_store ArrayBuffer ← .buffer Int8Array ← .unhexTable system / Context` |
+
+##### `process` (`<unknown>`)
+
+|     % |     Size | Instances | Path        |
+| ----: | -------: | --------: | ----------- |
+| 99.7% | 7.57 KiB |         1 | `(GC root)` |
+|  0.3% |     24 B |         1 | `.28 array` |
+
+##### `ModuleJobBase` (`node:internal/modules/esm/module_job:109:14`)
+
+|     % |     Size | Instances | Path                                                                                                                                                                                                                                                   |
+| ----: | -------: | --------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 88.0% | 5.88 KiB |         1 | `(GC root)`                                                                                                                                                                                                                                            |
+| 12.0% |    824 B |         1 | `.prototype ModuleJobSync (node:internal/modules/esm/module_job:374:14) ← .ModuleJobSync Object ← .exports BuiltinModule (node:internal/bootstrap/realm:239:14) ← .800 array ← .table Map ← .map BuiltinModule (node:internal/bootstrap/realm:239:14)` |
+
+##### `Uint8Array` (`<unknown>`)
+
+|     % |    Size | Instances | Path                                                                                                                                                                                                                    |
+| ----: | ------: | --------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 89.5% | 5.5 KiB |         5 | `(GC root)`                                                                                                                                                                                                             |
+|  4.6% |   288 B |         1 | `.prototype SlowBuffer (node:buffer:428:20) ← .SlowBuffer Object ← .exports BuiltinModule (node:internal/bootstrap/realm:239:14) ← .311 array ← .table Map ← .map BuiltinModule (node:internal/bootstrap/realm:239:14)` |
+|  2.9% |   184 B |         1 | `.empty system / Context`                                                                                                                                                                                               |
+|  1.5% |    96 B |         1 | `.uInt8Float64Array system / Context`                                                                                                                                                                                   |
+|  1.5% |    96 B |         1 | `.uInt8Float32Array system / Context`                                                                                                                                                                                   |
+
+##### `Node / IsolateData` (`<unknown>`)
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 4.76 KiB |         1 | `(GC root)` |
+
+##### `Float64Array` (`<unknown>`)
+
+|     % |     Size | Instances | Path                               |
+| ----: | -------: | --------: | ---------------------------------- |
+| 56.7% | 1.81 KiB |         6 | `(GC root)`                        |
+|  9.5% |    312 B |         1 | `.resourceValues system / Context` |
+|  7.3% |    240 B |         1 | `.statFsValues Object`             |
+|  7.3% |    240 B |         1 | `.memValues system / Context`      |
+|  6.6% |    216 B |         1 | `.cpuValues system / Context`      |
+
+##### `Node / PrincipalRealm` (`<unknown>`)
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 1.89 KiB |         1 | `(GC root)` |
+
+##### `Node / BindingData` (`<unknown>`)
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 1.79 KiB |         8 | `(GC root)` |
+
+##### `Int8Array` (`<unknown>`)
+
+|     % |  Size | Instances | Path                                                                                                                                                                                    |
+| ----: | ----: | --------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 34.4% | 624 B |         2 | `.noEscape system / Context`                                                                                                                                                            |
+| 24.2% | 440 B |         1 | `(GC root)`                                                                                                                                                                             |
+| 24.2% | 440 B |         1 | `.unhexTable system / Context`                                                                                                                                                          |
+| 17.2% | 312 B |         1 | `.noEscapeAuth system / Context ← .exports BuiltinModule (node:internal/bootstrap/realm:239:14) ← .1313 array ← .table Map ← .map BuiltinModule (node:internal/bootstrap/realm:239:14)` |
+
+##### `Uint32Array` (`<unknown>`)
+
+|     % |  Size | Instances | Path                    |
+| ----: | ----: | --------: | ----------------------- |
+| 81.8% | 988 B |         6 | `(GC root)`             |
+| 18.2% | 220 B |         1 | `.urlComponents Object` |
+
+##### `Node / builtins_with_cache` (`<unknown>`)
+
+|      % |     Size | Instances | Path                                         |
+| -----: | -------: | --------: | -------------------------------------------- |
+| 100.0% | 1.13 KiB |         1 | `.builtins_with_cache Node / PrincipalRealm` |
+
+##### `Node / std::basic_string` (`<unknown>`)
+
+|    % | Size | Instances | Path                                                                           |
+| ---: | ---: | --------: | ------------------------------------------------------------------------------ |
+| 2.9% | 33 B |         1 | `[28] Node / builtins_with_cache ← .builtins_with_cache Node / PrincipalRealm` |
+| 2.8% | 32 B |         1 | `[18] Node / builtins_with_cache ← .builtins_with_cache Node / PrincipalRealm` |
+| 2.7% | 31 B |         1 | `[12] Node / builtins_with_cache ← .builtins_with_cache Node / PrincipalRealm` |
+| 2.7% | 31 B |         1 | `[15] Node / builtins_with_cache ← .builtins_with_cache Node / PrincipalRealm` |
+| 2.7% | 31 B |         1 | `[16] Node / builtins_with_cache ← .builtins_with_cache Node / PrincipalRealm` |
+
+##### `BigInt64Array` (`<unknown>`)
+
+|     % |  Size | Instances | Path                         |
+| ----: | ----: | --------: | ---------------------------- |
+| 66.3% | 472 B |         1 | `.bigintStatValues Object`   |
+| 33.7% | 240 B |         1 | `.bigintStatFsValues Object` |
+
+##### `Int32Array` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 584 B |         3 | `(GC root)` |
+
+##### `Node / async_wrap_providers` (`<unknown>`)
+
+|      % |  Size | Instances | Path                                       |
+| -----: | ----: | --------: | ------------------------------------------ |
+| 100.0% | 528 B |         1 | `.async_wrap_providers Node / IsolateData` |
+
+##### `Node / ModuleWrap` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 448 B |         4 | `(GC root)` |
+
+##### `Node / AsyncHooks` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 440 B |         1 | `(GC root)` |
+
+##### `Node / AliasedFloat64Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                                         |
+| ----: | ---: | --------: | -------------------------------------------- |
+| 14.3% | 56 B |         1 | `.async_ids_stack Node / AsyncHooks`         |
+| 14.3% | 56 B |         1 | `.async_id_fields Node / AsyncHooks`         |
+| 14.3% | 56 B |         1 | `.stats_field_array Node / BindingData`      |
+| 14.3% | 56 B |         1 | `.statfs_field_array Node / BindingData`     |
+| 14.3% | 56 B |         1 | `.heap_statistics_buffer Node / BindingData` |
+
+##### `Node / AliasedUint32Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                                        |
+| ----: | ---: | --------: | ------------------------------------------- |
+| 16.7% | 56 B |         1 | `(GC root)`                                 |
+| 16.7% | 56 B |         1 | `.fields Node / AsyncHooks`                 |
+| 16.7% | 56 B |         1 | `.fields Node / ImmediateInfo`              |
+| 16.7% | 56 B |         1 | `.hrtime_buffer Node / BindingData`         |
+| 16.7% | 56 B |         1 | `.url_components_buffer Node / BindingData` |
+
+##### `Array Iterator` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 304 B |         2 | `(GC root)` |
+
+##### `Node / AliasedInt32Array` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 168 B |         3 | `(GC root)` |
+
+##### `Node / ImmediateInfo` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 120 B |         1 | `(GC root)` |
+
+##### `Node / TickInfo` (`<unknown>`)
+
+|      % |  Size | Instances | Path        |
+| -----: | ----: | --------: | ----------- |
+| 100.0% | 120 B |         1 | `(GC root)` |
+
+##### `Node / AliasedUint8Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                                              |
+| ----: | ---: | --------: | ------------------------------------------------- |
+| 50.0% | 56 B |         1 | `.fields Node / TickInfo`                         |
+| 50.0% | 56 B |         1 | `.is_building_snapshot_buffer Node / BindingData` |
+
+##### `Node / AliasedBigInt64Array` (`<unknown>`)
+
+|     % | Size | Instances | Path                                            |
+| ----: | ---: | --------: | ----------------------------------------------- |
+| 50.0% | 56 B |         1 | `.stats_field_bigint_array Node / BindingData`  |
+| 50.0% | 56 B |         1 | `.statfs_field_bigint_array Node / BindingData` |
+
+##### `BigUint64Array` (`<unknown>`)
+
+|      % | Size | Instances | Path                               |
+| -----: | ---: | --------: | ---------------------------------- |
+| 100.0% | 96 B |         1 | `.hrBigintValues system / Context` |
+
+##### `Float32Array` (`<unknown>`)
+
+|      % | Size | Instances | Path                             |
+| -----: | ---: | --------: | -------------------------------- |
+| 100.0% | 96 B |         1 | `.float32Array system / Context` |
+
+##### `Node / BlobBindingData` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 96 B |         1 | `(GC root)` |
+
+##### `Node / CleanupQueue` (`<unknown>`)
+
+|      % | Size | Instances | Path        |
+| -----: | ---: | --------: | ----------- |
+| 100.0% | 80 B |         1 | `(GC root)` |
+
+##### `Node / NodeArrayBufferAllocator` (`<unknown>`)
+
+|      % | Size | Instances | Path                                 |
+| -----: | ---: | --------: | ------------------------------------ |
+| 100.0% | 32 B |         1 | `.node_allocator Node / IsolateData` |
+
+##### `Node / js_promise_hooks` (`<unknown>`)
+
+|      % | Size | Instances | Path                                  |
+| -----: | ---: | --------: | ------------------------------------- |
+| 100.0% | 32 B |         1 | `.js_promise_hooks Node / AsyncHooks` |
 
 ## Largest functions
 
@@ -636,6 +1186,10 @@ Nodes ranked by contribution to each function's retained size.
 
 Strings ranked by bytes allocated for them.
 
+### Categories
+
+#### String
+
 |     % |     Size | Value                                                    | Path                                                            |
 | ----: | -------: | -------------------------------------------------------- | --------------------------------------------------------------- |
 | <0.1% | 1.91 KiB | `import { readFileSync } from 'node:fs'\nimport { a…`    | `.source heap-snapshot.mjs ← .script (shared function info)`    |
@@ -658,3 +1212,28 @@ Strings ranked by bytes allocated for them.
 | <0.1% |    296 B | `RT @shiawaseomamori: 一に止まると書いて、正しいという意味だなんて、この年にな…`     | `.text Object`                                                  |
 | <0.1% |    296 B | `RT @shiawaseomamori: 一に止まると書いて、正しいという意味だなんて、この年にな…`     | `.text Object`                                                  |
 | <0.1% |    296 B | `RT @shiawaseomamori: 一に止まると書いて、正しいという意味だなんて、この年にな…`     | `.text Object`                                                  |
+
+#### Concatenated string
+
+|     % | Size | Value                   | Path        |
+| ----: | ---: | ----------------------- | ----------- |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |
+| <0.1% | 32 B | `(concatenated string)` | `(GC root)` |

--- a/examples/output/javascript.safari.base.jsc-heap-snapshot.json.md
+++ b/examples/output/javascript.safari.base.jsc-heap-snapshot.json.md
@@ -44,6 +44,99 @@ Constructors ranked by bytes allocated for their instances, excluding nodes kept
 |  0.3% | 32.4 KiB |        87 | `UnlinkedEvalCodeBlock`      |
 |  0.2% | 24.9 KiB |        14 | `Window`                     |
 
+#### Categories
+
+##### Code
+
+|     % |     Size | Instances | Constructor                  |
+| ----: | -------: | --------: | ---------------------------- |
+|  9.0% |  962 KiB |     1,660 | `UnlinkedFunctionCodeBlock`  |
+|  8.9% |  950 KiB |     7,600 | `FunctionExecutable`         |
+|  5.3% |  566 KiB |     6,041 | `UnlinkedFunctionExecutable` |
+|  5.0% |  533 KiB |       162 | `FunctionCodeBlock`          |
+|  0.6% | 59.9 KiB |       767 | `NativeExecutable`           |
+| <0.1% | 1.64 KiB |        15 | `ProgramExecutable`          |
+
+##### Object shape
+
+|     % |    Size | Instances | Constructor |
+| ----: | ------: | --------: | ----------- |
+| 12.5% | 1.3 MiB |    12,175 | `Structure` |
+
+##### Internal
+
+|     % |     Size | Instances | Constructor                  |
+| ----: | -------: | --------: | ---------------------------- |
+|  4.5% |  479 KiB |    10,225 | `DOMAttributeGetterSetter`   |
+|  1.2% |  124 KiB |     2,030 | `JSLexicalEnvironment`       |
+|  1.0% |  104 KiB |     2,226 | `PropertyTable`              |
+|  0.8% | 85.3 KiB |     1,364 | `SymbolTable`                |
+|  0.8% | 83.7 KiB |       893 | `StructureRareData`          |
+|  0.6% | 67.5 KiB |     2,159 | `CustomGetterSetter`         |
+|  0.3% | 32.4 KiB |        87 | `UnlinkedEvalCodeBlock`      |
+|  0.2% | 18.1 KiB |       232 | `FunctionRareData`           |
+|  0.2% | 17.5 KiB |       160 | `EvalExecutable`             |
+|  0.1% | 15.7 KiB |        14 | `UnlinkedProgramCodeBlock`   |
+|  0.1% | 9.28 KiB |       297 | `GetterSetter`               |
+| <0.1% | 4.73 KiB |       101 | `JSPropertyNameEnumerator`   |
+| <0.1% | 4.41 KiB |       282 | `StructureChain`             |
+| <0.1% | 1.02 KiB |        29 | `HashMapBucket`              |
+| <0.1% |    448 B |         7 | `JSGlobalLexicalEnvironment` |
+| <0.1% |    402 B |        12 | `InjectedScriptHost`         |
+| <0.1% |    336 B |        12 | `CommandLineAPIHost`         |
+| <0.1% |    192 B |         6 | `JSWindowProxy`              |
+
+##### Object
+
+|     % |     Size | Instances | Constructor           |
+| ----: | -------: | --------: | --------------------- |
+|  6.5% |  697 KiB |    11,833 | `Object`              |
+|  0.4% | 41.6 KiB |     1,330 | `DOMRect`             |
+|  0.2% | 24.9 KiB |        14 | `Window`              |
+|  0.2% | 22.2 KiB |       468 | `HTMLSpanElement`     |
+|  0.2% | 19.7 KiB |       418 | `HTMLDivElement`      |
+|  0.1% | 13.4 KiB |       283 | `HTMLLIElement`       |
+|  0.1% | 10.5 KiB |       205 | `HTMLElement`         |
+|  0.1% | 9.29 KiB |       108 | `HTMLCollection`      |
+|  0.1% | 8.05 KiB |       170 | `HTMLAnchorElement`   |
+|  0.1% |  6.3 KiB |        20 | `CSSStyleDeclaration` |
+| <0.1% |  5.1 KiB |       160 | `Text`                |
+| <0.1% | 4.45 KiB |        95 | `jQuery`              |
+| <0.1% | 4.38 KiB |       140 | `DOMTokenList`        |
+| <0.1% | 3.83 KiB |        77 | `HTMLInputElement`    |
+| <0.1% | 3.66 KiB |        76 | `HTMLButtonElement`   |
+| <0.1% | 3.61 KiB |        78 | `HTMLUListElement`    |
+| <0.1% |  2.3 KiB |        51 | `HTMLLabelElement`    |
+| <0.1% | 2.03 KiB |        26 | `TooltippedElement`   |
+| <0.1% | 1.95 KiB |         9 | `Set`                 |
+| <0.1% | 1.78 KiB |         9 | `Document`            |
+
+##### Function
+
+|     % |    Size | Instances | Constructor              |
+| ----: | ------: | --------: | ------------------------ |
+|  4.1% | 434 KiB |    13,414 | `Function`               |
+| <0.1% |   490 B |        14 | `GeneratorFunction`      |
+| <0.1% |   490 B |        14 | `AsyncGeneratorFunction` |
+| <0.1% |   483 B |        14 | `AsyncFunction`          |
+| <0.1% |   450 B |        14 | `CallbackObject`         |
+| <0.1% |   448 B |        14 | `Callee`                 |
+
+##### Array
+
+|     % |    Size | Instances | Constructor           |
+| ----: | ------: | --------: | --------------------- |
+|  1.4% | 154 KiB |     3,780 | `Immutable Butterfly` |
+|  1.1% | 116 KiB |     7,409 | `Array`               |
+| <0.1% |   256 B |         8 | `SparseArrayValueMap` |
+| <0.1% |   126 B |         7 | `Array Iterator`      |
+
+##### Regular expression
+
+|    % |    Size | Instances | Constructor |
+| ---: | ------: | --------: | ----------- |
+| 1.0% | 108 KiB |       453 | `RegExp`    |
+
 #### Instances
 
 Instances ranked by contribution to each constructor's self size.
@@ -241,6 +334,327 @@ Instances ranked by contribution to each constructor's self size.
 | 28.7% | 7.14 KiB |         2 | `<root>`                      |
 |  0.1% |     17 B |         1 | `Structure ← Window ← <root>` |
 
+##### `HTMLSpanElement`
+
+|    % | Size | Instances | Path          |
+| ---: | ---: | --------: | ------------- |
+| 0.2% | 49 B |         1 | `[22] Array`  |
+| 0.2% | 49 B |         1 | `[863] Array` |
+| 0.2% | 49 B |         1 | `[865] Array` |
+| 0.2% | 49 B |         1 | `[32] Array`  |
+| 0.2% | 49 B |         1 | `[866] Array` |
+
+##### `HTMLDivElement`
+
+|    % |  Size | Instances | Path                                                                            |
+| ---: | ----: | --------: | ------------------------------------------------------------------------------- |
+| 2.5% | 500 B |        10 | `(GC root)`                                                                     |
+| 0.2% |  50 B |         1 | `._formElement Object ← .FormMetadataJS Window`                                 |
+| 0.2% |  50 B |         1 | `._backingElement Object ← .FormMetadataJS Window`                              |
+| 0.2% |  50 B |         1 | `._backingElement Object ← [9] Array ← ._forms Object ← .FormMetadataJS Window` |
+| 0.2% |  50 B |         1 | `[672] Array`                                                                   |
+
+##### `FunctionRareData`
+
+|    % |  Size | Instances | Path                                                                                    |
+| ---: | ----: | --------: | --------------------------------------------------------------------------------------- |
+| 0.9% | 160 B |         2 | `Function`                                                                              |
+| 0.4% |  80 B |         1 | `Function ← .resources/skins.vector.js/skin.js Object ← .files Object ← .script Object` |
+| 0.4% |  80 B |         1 | `Function ← .toggleDocClasses Object`                                                   |
+| 0.4% |  80 B |         1 | `Function ← .updatePinnableClasses JSLexicalEnvironment ← JSLexicalEnvironment`         |
+| 0.4% |  80 B |         1 | `Function ← .register Object`                                                           |
+
+##### `EvalExecutable`
+
+|    % |  Size | Instances | Path                                                                                 |
+| ---: | ----: | --------: | ------------------------------------------------------------------------------------ |
+| 1.9% | 336 B |         3 | `(GC root)`                                                                          |
+| 0.6% | 112 B |         1 | `.ext.quicksurveys.init Object`                                                      |
+| 0.6% | 112 B |         1 | `FunctionExecutable ← Function ← .declarator Object ← .jquery.spinner.styles Object` |
+| 0.6% | 112 B |         1 | `.ext.checkUser.clientHints Object`                                                  |
+| 0.6% | 112 B |         1 | `.wikibase.client.vector-2022 Object`                                                |
+
+##### `UnlinkedProgramCodeBlock`
+
+|      % |     Size | Instances | Path     |
+| -----: | -------: | --------: | -------- |
+| 100.0% | 15.7 KiB |        14 | `<root>` |
+
+##### `HTMLLIElement`
+
+|    % | Size | Instances | Path          |
+| ---: | ---: | --------: | ------------- |
+| 0.4% | 49 B |         1 | `[48] Array`  |
+| 0.4% | 49 B |         1 | `[55] Array`  |
+| 0.4% | 49 B |         1 | `[61] Array`  |
+| 0.4% | 49 B |         1 | `[709] Array` |
+| 0.4% | 49 B |         1 | `[726] Array` |
+
+##### `HTMLElement`
+
+|     % |     Size | Instances | Path                                             |
+| ----: | -------: | --------: | ------------------------------------------------ |
+| 10.1% | 1.07 KiB |         7 | `(GC root)`                                      |
+|  0.5% |     51 B |         1 | `Window`                                         |
+|  0.5% |     51 B |         1 | `Window ← <root>`                                |
+|  0.5% |     50 B |         1 | `[442] Array`                                    |
+|  0.5% |     49 B |         1 | `.elem JSLexicalEnvironment ← Function ← <root>` |
+
+##### `HTMLCollection`
+
+|     % |     Size | Instances | Path                 |
+| ----: | -------: | --------: | -------------------- |
+| 98.8% | 9.18 KiB |       103 | `<root>`             |
+|  0.5% |     44 B |         2 | `Structure ← Window` |
+|  0.5% |     44 B |         2 | `(GC root)`          |
+|  0.2% |     22 B |         1 | `Structure ← <root>` |
+
+##### `GetterSetter`
+
+|    % | Size | Instances | Path                                                                             |
+| ---: | ---: | --------: | -------------------------------------------------------------------------------- |
+| 0.3% | 32 B |         1 | `.evaluate InjectedScriptHost ← Structure ← InjectedScriptHost ← <root>`         |
+| 0.3% | 32 B |         1 | `.savedResultAlias InjectedScriptHost ← Structure ← InjectedScriptHost ← <root>` |
+| 0.3% | 32 B |         1 | `.size Set`                                                                      |
+| 0.3% | 32 B |         1 | `.altKey Object`                                                                 |
+| 0.3% | 32 B |         1 | `.bubbles Object`                                                                |
+
+##### `HTMLAnchorElement`
+
+|     % |     Size | Instances | Path                                             |
+| ----: | -------: | --------: | ------------------------------------------------ |
+| 13.1% | 1.05 KiB |        22 | `<root>`                                         |
+|  5.3% |    441 B |         9 | `.elem JSLexicalEnvironment ← Function ← <root>` |
+|  0.6% |     51 B |         1 | `Window ← <root>`                                |
+|  0.6% |     49 B |         1 | `(GC root)`                                      |
+|  0.6% |     49 B |         1 | `[6] Array`                                      |
+
+##### `CSSStyleDeclaration`
+
+|     % |     Size | Instances | Path                               |
+| ----: | -------: | --------: | ---------------------------------- |
+| 69.1% | 4.35 KiB |         3 | `(GC root)`                        |
+| 23.0% | 1.45 KiB |         1 | `Structure ← Window`               |
+|  5.5% |    352 B |        11 | `<root>`                           |
+|  0.5% |     32 B |         1 | `.emptyStyle JSLexicalEnvironment` |
+|  0.5% |     32 B |         1 | `._cachedContentTextStyle Object`  |
+
+##### `Text`
+
+|    % | Size | Instances | Path                                              |
+| ---: | ---: | --------: | ------------------------------------------------- |
+| 0.6% | 33 B |         1 | `[1] Array ← .textNodes Object ← .article Object` |
+| 0.6% | 33 B |         1 | `[2] Array ← .textNodes Object ← .article Object` |
+| 0.6% | 33 B |         1 | `[3] Array ← .textNodes Object ← .article Object` |
+| 0.6% | 33 B |         1 | `[4] Array ← .textNodes Object ← .article Object` |
+| 0.6% | 33 B |         1 | `[5] Array ← .textNodes Object ← .article Object` |
+
+##### `JSPropertyNameEnumerator`
+
+|    % | Size | Instances | Path                                                                                                                                                                                                                                        |
+| ---: | ---: | --------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1.0% | 48 B |         1 | `StructureRareData ← Structure ← Structure ← Structure ← Structure ← Structure ← Structure ← Structure ← StructureRareData ← Structure ← Object ← .methods Function ← .CommandLineAPI JSLexicalEnvironment ← JSLexicalEnvironment ← <root>` |
+| 1.0% | 48 B |         1 | `StructureRareData ← Structure ← Object ← .methods Function ← .CommandLineAPI JSLexicalEnvironment ← JSLexicalEnvironment ← <root>`                                                                                                         |
+| 1.0% | 48 B |         1 | `StructureRareData ← Structure ← Object ← .RLCONF Window ← <root>`                                                                                                                                                                          |
+| 1.0% | 48 B |         1 | `StructureRareData ← Structure ← Object ← .RLSTATE Window ← <root>`                                                                                                                                                                         |
+| 1.0% | 48 B |         1 | `StructureRareData ← Structure ← Structure ← Object ← .sources JSLexicalEnvironment`                                                                                                                                                        |
+
+##### `jQuery`
+
+|    % | Size | Instances | Path                                                                                                                                                                        |
+| ---: | ---: | --------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1.1% | 48 B |         1 | `(GC root)`                                                                                                                                                                 |
+| 1.1% | 48 B |         1 | `.$shortenUrlLink JSLexicalEnvironment ← Function ← .handler Object ← [0] Array ← .click Object ← .events Object ← .jQuery371070616879042118561 HTMLAnchorElement ← <root>` |
+| 1.1% | 48 B |         1 | `.$qrCodeLink JSLexicalEnvironment ← Function ← .handler Object ← [0] Array ← .click Object ← .events Object ← .jQuery371070616879042118561 HTMLAnchorElement ← <root>`     |
+| 1.1% | 48 B |         1 | `.$body JSLexicalEnvironment`                                                                                                                                               |
+| 1.1% | 48 B |         1 | `.$window JSLexicalEnvironment`                                                                                                                                             |
+
+##### `StructureChain`
+
+|    % | Size | Instances | Path                                                                                                            |
+| ---: | ---: | --------: | --------------------------------------------------------------------------------------------------------------- |
+| 0.4% | 16 B |         1 | `Structure ← Function ← <root>`                                                                                 |
+| 0.4% | 16 B |         1 | `Structure ← InjectedScript ← <root>`                                                                           |
+| 0.4% | 16 B |         1 | `Structure ← Function ← .CallFrameProxy Function ← <root>`                                                      |
+| 0.4% | 16 B |         1 | `Structure ← Function ← .CommandLineAPI JSLexicalEnvironment ← JSLexicalEnvironment ← <root>`                   |
+| 0.4% | 16 B |         1 | `Structure ← Object ← .methods Function ← .CommandLineAPI JSLexicalEnvironment ← JSLexicalEnvironment ← <root>` |
+
+##### `DOMTokenList`
+
+|     % |     Size | Instances | Path        |
+| ----: | -------: | --------: | ----------- |
+| 97.8% | 4.28 KiB |       137 | `<root>`    |
+|  2.2% |     99 B |         3 | `(GC root)` |
+
+##### `HTMLInputElement`
+
+|    % |  Size | Instances | Path                                                                                  |
+| ---: | ----: | --------: | ------------------------------------------------------------------------------------- |
+| 8.2% | 320 B |         6 | `.FormMetadataJS Window`                                                              |
+| 8.1% | 316 B |         4 | `(GC root)`                                                                           |
+| 1.3% |  52 B |         1 | `[1] Array ← ._controls Object ← [0] Array ← ._forms Object ← .FormMetadataJS Window` |
+| 1.3% |  52 B |         1 | `[1] Array ← ._controls Object ← [1] Array ← ._forms Object ← .FormMetadataJS Window` |
+| 1.3% |  52 B |         1 | `[1] Array ← ._controls Object ← [3] Array ← ._forms Object ← .FormMetadataJS Window` |
+
+##### `HTMLButtonElement`
+
+|     % |     Size | Instances | Path                                                                                  |
+| ----: | -------: | --------: | ------------------------------------------------------------------------------------- |
+| 28.2% | 1.03 KiB |        20 | `.FormMetadataJS Window`                                                              |
+|  1.4% |     51 B |         1 | `Window`                                                                              |
+|  1.4% |     51 B |         1 | `[2] Array ← ._controls Object ← [0] Array ← ._forms Object ← .FormMetadataJS Window` |
+|  1.4% |     51 B |         1 | `[2] Array ← ._controls Object ← [4] Array ← ._forms Object ← .FormMetadataJS Window` |
+|  1.4% |     51 B |         1 | `[1] Array ← ._controls Object ← [9] Array ← ._forms Object ← .FormMetadataJS Window` |
+
+##### `HTMLUListElement`
+
+|    % | Size | Instances | Path          |
+| ---: | ---: | --------: | ------------- |
+| 1.3% | 49 B |         1 | `[47] Array`  |
+| 1.3% | 49 B |         1 | `[54] Array`  |
+| 1.3% | 49 B |         1 | `[60] Array`  |
+| 1.3% | 49 B |         1 | `[125] Array` |
+| 1.3% | 49 B |         1 | `[134] Array` |
+
+##### `HTMLLabelElement`
+
+|    % | Size | Instances | Path          |
+| ---: | ---: | --------: | ------------- |
+| 2.2% | 51 B |         1 | `Window`      |
+| 2.1% | 49 B |         1 | `[253] Array` |
+| 2.1% | 49 B |         1 | `[330] Array` |
+| 2.1% | 49 B |         1 | `[348] Array` |
+| 2.1% | 49 B |         1 | `[353] Array` |
+
+##### `TooltippedElement`
+
+|      % |     Size | Instances | Path                                                                                                                                    |
+| -----: | -------: | --------: | --------------------------------------------------------------------------------------------------------------------------------------- |
+| 100.0% | 2.03 KiB |        26 | `.te JSLexicalEnvironment ← .events Object ← .jQuery371070616879042118561 HTMLElement ← .elem JSLexicalEnvironment ← Function ← <root>` |
+
+##### `Set`
+
+|     % |  Size | Instances | Path                                                                                                                                          |
+| ----: | ----: | --------: | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| 41.4% | 824 B |         1 | `.SetOfCandidateTagNamesToIgnore JSGlobalLexicalEnvironment`                                                                                  |
+| 31.3% | 624 B |         2 | `.stacks JSLexicalEnvironment ← Function ← .isFirst JSLexicalEnvironment ← Function ← .maybeLog JSLexicalEnvironment ← .eventInSample Object` |
+| 18.5% | 368 B |         2 | `.exposuresThisPage ExposureLogTracker ← .exposureLogTracker JSLexicalEnvironment ← .tk Object`                                               |
+|  8.8% | 176 B |         4 | `(GC root)`                                                                                                                                   |
+
+##### `Document`
+
+|     % |     Size | Instances | Path              |
+| ----: | -------: | --------: | ----------------- |
+| 94.3% | 1.67 KiB |         7 | `(GC root)`       |
+|  5.7% |    104 B |         2 | `Window ← <root>` |
+
+##### `ProgramExecutable`
+
+|     % |     Size | Instances | Path                                                                      |
+| ----: | -------: | --------: | ------------------------------------------------------------------------- |
+| 66.7% | 1.09 KiB |        10 | `(GC root)`                                                               |
+| 13.3% |    224 B |         2 | `.user.options Object`                                                    |
+| 13.3% |    224 B |         2 | `.hooks JSLexicalEnvironment`                                             |
+|  6.7% |    112 B |         1 | `FunctionExecutable ← Function ← .extractMediaServiceSubscription Window` |
+
+##### `HashMapBucket`
+
+|    % | Size | Instances | Path                                                                                                  |
+| ---: | ---: | --------: | ----------------------------------------------------------------------------------------------------- |
+| 9.2% | 96 B |         2 | `Map ← .state Object`                                                                                 |
+| 9.2% | 96 B |         2 | `Map ← ._mapOfUniqueIDToOriginalElement Object`                                                       |
+| 9.2% | 96 B |         2 | `Map ← .queues JSLexicalEnvironment`                                                                  |
+| 4.6% | 48 B |         1 | `<root>`                                                                                              |
+| 3.1% | 32 B |         1 | `Set ← .exposuresThisPage ExposureLogTracker ← .exposureLogTracker JSLexicalEnvironment ← .tk Object` |
+
+##### `GeneratorFunction`
+
+|     % |  Size | Instances | Path                                               |
+| ----: | ----: | --------: | -------------------------------------------------- |
+| 52.0% | 255 B |         5 | `.constructor GeneratorFunction ← Window`          |
+| 20.8% | 102 B |         2 | `.constructor GeneratorFunction ← Window ← <root>` |
+| 19.4% |  95 B |         5 | `Window`                                           |
+|  7.8% |  38 B |         2 | `Window ← <root>`                                  |
+
+##### `AsyncGeneratorFunction`
+
+|     % |  Size | Instances | Path                                                    |
+| ----: | ----: | --------: | ------------------------------------------------------- |
+| 52.0% | 255 B |         5 | `.constructor AsyncGeneratorFunction ← Window`          |
+| 20.8% | 102 B |         2 | `.constructor AsyncGeneratorFunction ← Window ← <root>` |
+| 19.4% |  95 B |         5 | `Window`                                                |
+|  7.8% |  38 B |         2 | `Window ← <root>`                                       |
+
+##### `AsyncFunction`
+
+|     % |  Size | Instances | Path                                           |
+| ----: | ----: | --------: | ---------------------------------------------- |
+| 52.8% | 255 B |         5 | `.constructor AsyncFunction ← Window`          |
+| 21.1% | 102 B |         2 | `.constructor AsyncFunction ← Window ← <root>` |
+| 18.6% |  90 B |         5 | `Window`                                       |
+|  7.5% |  36 B |         2 | `Window ← <root>`                              |
+
+##### `CallbackObject`
+
+|    % | Size | Instances | Path                                                                                                              |
+| ---: | ---: | --------: | ----------------------------------------------------------------------------------------------------------------- |
+| 7.3% | 33 B |         1 | `Structure ← CallbackObject ← [0] Array ← ._oneTimeCodeFieldLabelPatternMatchers Object ← .FormMetadataJS Window` |
+| 7.3% | 33 B |         1 | `Structure ← CallbackObject ← .ReaderArticleFinderJSController Window`                                            |
+| 7.1% | 32 B |         1 | `.browser Window ← <root>`                                                                                        |
+| 7.1% | 32 B |         1 | `Structure ← CallbackObject ← .browser Window ← <root>`                                                           |
+| 7.1% | 32 B |         1 | `.pushNotification Object ← .safari Window ← <root>`                                                              |
+
+##### `JSGlobalLexicalEnvironment`
+
+|     % |  Size | Instances | Path        |
+| ----: | ----: | --------: | ----------- |
+| 57.1% | 256 B |         4 | `(GC root)` |
+| 42.9% | 192 B |         3 | `Window`    |
+
+##### `Callee`
+
+|     % |  Size | Instances | Path              |
+| ----: | ----: | --------: | ----------------- |
+| 71.4% | 320 B |        10 | `Window`          |
+| 28.6% | 128 B |         4 | `Window ← <root>` |
+
+##### `InjectedScriptHost`
+
+|     % |  Size | Instances | Path                                      |
+| ----: | ----: | --------: | ----------------------------------------- |
+| 52.2% | 210 B |         6 | `Structure ← InjectedScriptHost ← <root>` |
+| 47.8% | 192 B |         6 | `<root>`                                  |
+
+##### `CommandLineAPIHost`
+
+|     % |  Size | Instances | Path                                      |
+| ----: | ----: | --------: | ----------------------------------------- |
+| 57.1% | 192 B |         6 | `<root>`                                  |
+| 42.9% | 144 B |         6 | `Structure ← CommandLineAPIHost ← <root>` |
+
+##### `SparseArrayValueMap`
+
+|     % | Size | Instances | Path                                                                                                        |
+| ----: | ---: | --------: | ----------------------------------------------------------------------------------------------------------- |
+| 25.0% | 64 B |         2 | `Object`                                                                                                    |
+| 25.0% | 64 B |         2 | `Object ← .xhrSuccessStatus JSLexicalEnvironment`                                                           |
+| 25.0% | 64 B |         2 | `Object ← .ENTRYPOINT_TYPE Object ← .exports Object ← .module Object ← .ext.uls.rewrite.entrypoints Object` |
+| 25.0% | 64 B |         2 | `Object ← .ULS_MODE Object ← .exports Object ← .module Object ← .ext.uls.rewrite.entrypoints Object`        |
+
+##### `JSWindowProxy`
+
+|     % |  Size | Instances | Path        |
+| ----: | ----: | --------: | ----------- |
+| 83.3% | 160 B |         5 | `(GC root)` |
+| 16.7% |  32 B |         1 | `<root>`    |
+
+##### `Array Iterator`
+
+|     % | Size | Instances | Path              |
+| ----: | ---: | --------: | ----------------- |
+| 71.4% | 90 B |         5 | `Window`          |
+| 28.6% | 36 B |         2 | `Window ← <root>` |
+
 ### Retained size
 
 Constructors ranked by bytes allocated for their instances and all nodes that would be freed if their instances were garbage collected.
@@ -267,6 +681,99 @@ Constructors ranked by bytes allocated for their instances and all nodes that wo
 |  1.0% |  104 KiB |        14 | `UnlinkedProgramCodeBlock`   |
 |  1.0% |  102 KiB |     2,226 | `PropertyTable`              |
 |  0.8% | 85.1 KiB |     1,364 | `SymbolTable`                |
+
+#### Categories
+
+##### Code
+
+|     % |     Size | Instances | Constructor                  |
+| ----: | -------: | --------: | ---------------------------- |
+| 18.9% | 1.97 MiB |     7,600 | `FunctionExecutable`         |
+| 15.6% | 1.62 MiB |     6,041 | `UnlinkedFunctionExecutable` |
+| 11.2% | 1.17 MiB |     1,660 | `UnlinkedFunctionCodeBlock`  |
+|  5.0% |  535 KiB |       162 | `FunctionCodeBlock`          |
+|  0.6% | 59.9 KiB |       767 | `NativeExecutable`           |
+| <0.1% | 1.64 KiB |        15 | `ProgramExecutable`          |
+
+##### Object shape
+
+|     % |     Size | Instances | Constructor |
+| ----: | -------: | --------: | ----------- |
+| 17.8% | 1.85 MiB |    12,175 | `Structure` |
+
+##### Internal
+
+|     % |     Size | Instances | Constructor                  |
+| ----: | -------: | --------: | ---------------------------- |
+|  7.6% |  811 KiB |     2,030 | `JSLexicalEnvironment`       |
+|  4.5% |  479 KiB |    10,225 | `DOMAttributeGetterSetter`   |
+|  4.3% |  454 KiB |       893 | `StructureRareData`          |
+|  1.8% |  197 KiB |       232 | `FunctionRareData`           |
+|  1.0% |  104 KiB |        14 | `UnlinkedProgramCodeBlock`   |
+|  1.0% |  102 KiB |     2,226 | `PropertyTable`              |
+|  0.8% | 85.1 KiB |     1,364 | `SymbolTable`                |
+|  0.6% | 67.4 KiB |     2,159 | `CustomGetterSetter`         |
+|  0.5% | 51.7 KiB |       297 | `GetterSetter`               |
+|  0.4% | 37.9 KiB |       101 | `JSPropertyNameEnumerator`   |
+|  0.3% | 32.4 KiB |        87 | `UnlinkedEvalCodeBlock`      |
+|  0.2% | 17.5 KiB |       160 | `EvalExecutable`             |
+|  0.1% | 9.18 KiB |        12 | `InjectedScriptHost`         |
+|  0.1% | 6.73 KiB |         7 | `JSGlobalLexicalEnvironment` |
+| <0.1% | 4.41 KiB |       282 | `StructureChain`             |
+| <0.1% | 4.22 KiB |        12 | `CommandLineAPIHost`         |
+| <0.1% | 1.45 KiB |        29 | `HashMapBucket`              |
+| <0.1% | 1.22 KiB |         6 | `JSWindowProxy`              |
+
+##### Object
+
+|     % |     Size | Instances | Constructor                 |
+| ----: | -------: | --------: | --------------------------- |
+| 55.3% | 5.76 MiB |    11,833 | `Object`                    |
+|  9.7% | 1.01 MiB |        14 | `Window`                    |
+|  2.6% |  272 KiB |        20 | `CSSStyleDeclaration`       |
+|  2.5% |  271 KiB |         6 | `InjectedScript`            |
+|  0.8% | 83.3 KiB |       205 | `HTMLElement`               |
+|  0.8% | 81.8 KiB |         9 | `Document`                  |
+|  0.5% | 56.5 KiB |        10 | `Element`                   |
+|  0.4% | 43.5 KiB |     1,330 | `DOMRect`                   |
+|  0.3% | 35.8 KiB |       418 | `HTMLDivElement`            |
+|  0.3% | 34.9 KiB |       468 | `HTMLSpanElement`           |
+|  0.3% | 32.2 KiB |        20 | `Map`                       |
+|  0.3% | 27.9 KiB |       170 | `HTMLAnchorElement`         |
+|  0.2% | 23.3 KiB |         7 | `String`                    |
+|  0.2% | 22.5 KiB |       283 | `HTMLLIElement`             |
+|  0.2% | 17.2 KiB |        77 | `HTMLInputElement`          |
+|  0.1% | 14.5 KiB |         2 | `MultimediaViewerBootstrap` |
+|  0.1% | 14.2 KiB |        76 | `HTMLButtonElement`         |
+|  0.1% | 13.7 KiB |        14 | `Node`                      |
+|  0.1% |   13 KiB |        20 | `Promise`                   |
+|  0.1% |   13 KiB |        16 | `HTMLDocument`              |
+
+##### Function
+
+|     % |     Size | Instances | Constructor              |
+| ----: | -------: | --------: | ------------------------ |
+| 27.9% | 2.91 MiB |    13,414 | `Function`               |
+| <0.1% |  4.1 KiB |        14 | `AsyncFunction`          |
+| <0.1% | 3.19 KiB |        14 | `AsyncGeneratorFunction` |
+| <0.1% | 3.12 KiB |        14 | `GeneratorFunction`      |
+| <0.1% | 2.65 KiB |        14 | `CallbackObject`         |
+| <0.1% |    448 B |        14 | `Callee`                 |
+
+##### Array
+
+|     % |    Size | Instances | Constructor           |
+| ----: | ------: | --------: | --------------------- |
+|  6.1% | 650 KiB |     7,409 | `Array`               |
+|  1.4% | 154 KiB |     3,780 | `Immutable Butterfly` |
+|  0.1% | 7.5 KiB |         7 | `Array Iterator`      |
+| <0.1% |   294 B |         8 | `SparseArrayValueMap` |
+
+##### Regular expression
+
+|    % |    Size | Instances | Constructor |
+| ---: | ------: | --------: | ----------- |
+| 1.0% | 108 KiB |       453 | `RegExp`    |
 
 #### Instances
 
@@ -461,9 +968,331 @@ Instances ranked by contribution to each constructor's retained size.
 | 0.1% |  64 B |         1 | `JSLexicalEnvironment ← Function ← <root>`                                                                        |
 | 0.1% |  64 B |         1 | `JSLexicalEnvironment ← .methods Function ← .CommandLineAPI JSLexicalEnvironment ← JSLexicalEnvironment ← <root>` |
 
+##### `HTMLElement`
+
+|     % |     Size | Instances | Path                                             |
+| ----: | -------: | --------: | ------------------------------------------------ |
+| 57.3% | 47.7 KiB |         7 | `(GC root)`                                      |
+| 25.6% | 21.3 KiB |        27 | `.elem JSLexicalEnvironment ← Function ← <root>` |
+|  0.7% |    574 B |         1 | `Window`                                         |
+|  0.6% |    526 B |         1 | `Window ← <root>`                                |
+|  0.1% |     82 B |         1 | `[442] Array`                                    |
+
+##### `Document`
+
+|     % |     Size | Instances | Path              |
+| ----: | -------: | --------: | ----------------- |
+| 99.3% | 81.2 KiB |         7 | `(GC root)`       |
+|  0.7% |    578 B |         2 | `Window ← <root>` |
+
+##### `CustomGetterSetter`
+
+|     % | Size | Instances | Path                           |
+| ----: | ---: | --------: | ------------------------------ |
+| <0.1% | 32 B |         1 | `.constructor Element`         |
+| <0.1% | 32 B |         1 | `.constructor HTMLElement`     |
+| <0.1% | 32 B |         1 | `.onmouseenter HTMLElement`    |
+| <0.1% | 32 B |         1 | `.onmouseleave HTMLElement`    |
+| <0.1% | 32 B |         1 | `.constructor HTMLHtmlElement` |
+
+##### `NativeExecutable`
+
+|     % |     Size | Instances | Path                                                                      |
+| ----: | -------: | --------: | ------------------------------------------------------------------------- |
+| 39.2% | 23.5 KiB |       301 | `(GC root)`                                                               |
+|  0.1% |     80 B |         1 | `<root>`                                                                  |
+|  0.1% |     80 B |         1 | `Function ← .next URLSearchParams Iterator ← Structure ← Window ← <root>` |
+|  0.1% |     80 B |         1 | `Function ← .item DOMRectList`                                            |
+|  0.1% |     80 B |         1 | `Function ← .abort AbortController`                                       |
+
+##### `Element`
+
+|     % |     Size | Instances | Path              |
+| ----: | -------: | --------: | ----------------- |
+| 97.1% | 54.9 KiB |         7 | `(GC root)`       |
+|  2.0% | 1.11 KiB |         2 | `Window`          |
+|  0.9% |    522 B |         1 | `Window ← <root>` |
+
+##### `GetterSetter`
+
+|    % |     Size | Instances | Path                                    |
+| ---: | -------: | --------: | --------------------------------------- |
+| 4.9% | 2.55 KiB |         2 | `.eventInSample Object`                 |
+| 2.8% | 1.43 KiB |         2 | `.getCrossSite Object ← .cookie Object` |
+| 2.6% | 1.35 KiB |         2 | `.jqueryMsg Object`                     |
+| 2.4% | 1.22 KiB |         2 | `.newInstrument Object`                 |
+| 1.1% |    577 B |         1 | `.write HTMLDocument`                   |
+
+##### `DOMRect`
+
+|    % |     Size | Instances | Path                                                         |
+| ---: | -------: | --------: | ------------------------------------------------------------ |
+| 2.9% | 1.25 KiB |         2 | `(GC root)`                                                  |
+| 1.0% |    429 B |         1 | `Structure ← Window ← <root>`                                |
+| 0.8% |    367 B |         1 | `Window`                                                     |
+| 0.1% |     32 B |         1 | `._cachedElementBoundingRect HTMLSpanElement ← [1120] Array` |
+| 0.1% |     32 B |         1 | `._cachedElementBoundingRect HTMLElement ← [1121] Array`     |
+
+##### `JSPropertyNameEnumerator`
+
+|     % |     Size | Instances | Path                                                                                                                                                                                                                                        |
+| ----: | -------: | --------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 47.2% | 17.9 KiB |         4 | `StructureRareData ← Structure ← Object ← .mediawiki.base Object`                                                                                                                                                                           |
+|  9.2% | 3.47 KiB |         6 | `StructureRareData ← Structure ← Structure ← Structure ← Structure ← Structure ← Structure ← Structure ← StructureRareData ← Structure ← Object ← .methods Function ← .CommandLineAPI JSLexicalEnvironment ← JSLexicalEnvironment ← <root>` |
+|  5.4% | 2.04 KiB |         2 | `StructureRareData ← Structure ← Object ← .RLCONF Window ← <root>`                                                                                                                                                                          |
+|  2.5% |    958 B |         2 | `StructureRareData ← Structure ← Object ← .messages Object ← .skins.vector.clientPreferences Object`                                                                                                                                        |
+|  1.1% |    438 B |         1 | `StructureRareData ← Structure ← Object`                                                                                                                                                                                                    |
+
+##### `HTMLDivElement`
+
+|     % |     Size | Instances | Path          |
+| ----: | -------: | --------: | ------------- |
+| 21.1% | 7.55 KiB |        15 | `(GC root)`   |
+|  6.0% | 2.16 KiB |         1 | `<root>`      |
+|  0.2% |     82 B |         1 | `[672] Array` |
+|  0.2% |     82 B |         1 | `[666] Array` |
+|  0.2% |     82 B |         1 | `[441] Array` |
+
+##### `HTMLSpanElement`
+
+|    % |  Size | Instances | Path          |
+| ---: | ----: | --------: | ------------- |
+| 2.7% | 964 B |         4 | `(GC root)`   |
+| 0.2% |  81 B |         1 | `[22] Array`  |
+| 0.2% |  81 B |         1 | `[863] Array` |
+| 0.2% |  81 B |         1 | `[865] Array` |
+| 0.2% |  81 B |         1 | `[32] Array`  |
+
+##### `UnlinkedEvalCodeBlock`
+
+|      % |     Size | Instances | Path     |
+| -----: | -------: | --------: | -------- |
+| 100.0% | 32.4 KiB |        87 | `<root>` |
+
+##### `Map`
+
+|     % |     Size | Instances | Path                                      |
+| ----: | -------: | --------: | ----------------------------------------- |
+| 53.9% | 17.4 KiB |         7 | `(GC root)`                               |
+| 33.4% | 10.8 KiB |         2 | `.en Object ← .data Object`               |
+|  4.0% |  1.3 KiB |         2 | `.tokens Object ← .user Object`           |
+|  4.0% | 1.28 KiB |         2 | `.options Object ← .user Object`          |
+|  1.1% |    368 B |         1 | `._mapOfUniqueIDToOriginalElement Object` |
+
+##### `HTMLAnchorElement`
+
+|     % |     Size | Instances | Path                                             |
+| ----: | -------: | --------: | ------------------------------------------------ |
+| 31.1% | 8.65 KiB |        26 | `<root>`                                         |
+| 30.0% | 8.35 KiB |         6 | `(GC root)`                                      |
+| 10.0% | 2.78 KiB |         9 | `.elem JSLexicalEnvironment ← Function ← <root>` |
+|  1.9% |    532 B |         1 | `Window ← <root>`                                |
+|  0.3% |     81 B |         1 | `[6] Array`                                      |
+
+##### `String`
+
+|     % |     Size | Instances | Path        |
+| ----: | -------: | --------: | ----------- |
+| 51.5% |   12 KiB |         4 | `Window`    |
+| 48.5% | 11.3 KiB |         3 | `(GC root)` |
+
+##### `HTMLLIElement`
+
+|    % |  Size | Instances | Path                 |
+| ---: | ----: | --------: | -------------------- |
+| 2.9% | 674 B |         2 | `(GC root)`          |
+| 1.5% | 337 B |         1 | `Structure ← <root>` |
+| 1.5% | 337 B |         1 | `Structure ← Window` |
+| 0.4% |  81 B |         1 | `[48] Array`         |
+| 0.4% |  81 B |         1 | `[55] Array`         |
+
+##### `EvalExecutable`
+
+|    % |  Size | Instances | Path                                                                                 |
+| ---: | ----: | --------: | ------------------------------------------------------------------------------------ |
+| 1.9% | 336 B |         3 | `(GC root)`                                                                          |
+| 0.6% | 112 B |         1 | `.ext.quicksurveys.init Object`                                                      |
+| 0.6% | 112 B |         1 | `FunctionExecutable ← Function ← .declarator Object ← .jquery.spinner.styles Object` |
+| 0.6% | 112 B |         1 | `.ext.checkUser.clientHints Object`                                                  |
+| 0.6% | 112 B |         1 | `.wikibase.client.vector-2022 Object`                                                |
+
+##### `HTMLInputElement`
+
+|     % |     Size | Instances | Path                     |
+| ----: | -------: | --------: | ------------------------ |
+| 70.9% | 12.2 KiB |         4 | `(GC root)`              |
+|  3.8% |    675 B |         1 | `Window`                 |
+|  1.8% |    325 B |         1 | `.FormMetadataJS Window` |
+|  0.5% |     81 B |         1 | `[252] Array`            |
+|  0.5% |     81 B |         1 | `[317] Array`            |
+
+##### `MultimediaViewerBootstrap`
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 14.5 KiB |         2 | `(GC root)` |
+
+##### `HTMLButtonElement`
+
+|     % |     Size | Instances | Path                     |
+| ----: | -------: | --------: | ------------------------ |
+| 63.4% | 9.02 KiB |        13 | `(GC root)`              |
+| 10.0% | 1.42 KiB |        10 | `.FormMetadataJS Window` |
+|  4.0% |    580 B |         1 | `Window`                 |
+|  0.6% |     81 B |         1 | `[261] Array`            |
+|  0.6% |     81 B |         1 | `[262] Array`            |
+
+##### `Node`
+
+|     % |     Size | Instances | Path              |
+| ----: | -------: | --------: | ----------------- |
+| 88.0% |   12 KiB |         7 | `(GC root)`       |
+|  8.4% | 1.15 KiB |         5 | `Window`          |
+|  3.6% |    498 B |         2 | `Window ← <root>` |
+
+##### `Promise`
+
+|     % |     Size | Instances | Path                                                                                                                                                                   |
+| ----: | -------: | --------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 50.7% | 6.61 KiB |         1 | `.promise Object ← .preview Object ← .u JSLexicalEnvironment`                                                                                                          |
+| 46.4% | 6.05 KiB |         1 | `.i JSLexicalEnvironment ← Function ← .abort Promise ← .promise Object ← .preview Object ← .u JSLexicalEnvironment`                                                    |
+| 22.0% | 2.88 KiB |         1 | `.capturedPromise JSLexicalEnvironment ← Function ← .t JSLexicalEnvironment ← Function ← <root>`                                                                       |
+|  9.7% | 1.27 KiB |         1 | `.promise Object ← .globalContext Object ← .context Object ← Promise ← .capturedPromise JSLexicalEnvironment ← Function ← .t JSLexicalEnvironment ← Function ← <root>` |
+|  7.8% | 1.01 KiB |         1 | `(GC root)`                                                                                                                                                            |
+
+##### `HTMLDocument`
+
+|     % |     Size | Instances | Path                 |
+| ----: | -------: | --------: | -------------------- |
+| 83.1% | 10.8 KiB |         6 | `(GC root)`          |
+|  8.3% | 1.08 KiB |         2 | `Window ← <root>`    |
+|  7.1% |    952 B |         4 | `Structure ← Window` |
+|  1.4% |    192 B |         4 | `.document Window`   |
+
+##### `InjectedScriptHost`
+
+|      % |     Size | Instances | Path                                      |
+| -----: | -------: | --------: | ----------------------------------------- |
+| 100.0% | 9.18 KiB |         6 | `<root>`                                  |
+|  90.8% | 8.34 KiB |         6 | `Structure ← InjectedScriptHost ← <root>` |
+
+##### `Array Iterator`
+
+|     % |     Size | Instances | Path              |
+| ----: | -------: | --------: | ----------------- |
+| 84.4% | 6.33 KiB |         5 | `Window`          |
+| 15.6% | 1.17 KiB |         2 | `Window ← <root>` |
+
+##### `JSGlobalLexicalEnvironment`
+
+|     % |     Size | Instances | Path        |
+| ----: | -------: | --------: | ----------- |
+| 89.5% | 6.02 KiB |         4 | `(GC root)` |
+| 10.5% |    720 B |         3 | `Window`    |
+
+##### `StructureChain`
+
+|    % | Size | Instances | Path                                                                                                            |
+| ---: | ---: | --------: | --------------------------------------------------------------------------------------------------------------- |
+| 0.4% | 16 B |         1 | `Structure ← Function ← <root>`                                                                                 |
+| 0.4% | 16 B |         1 | `Structure ← InjectedScript ← <root>`                                                                           |
+| 0.4% | 16 B |         1 | `Structure ← Function ← .CallFrameProxy Function ← <root>`                                                      |
+| 0.4% | 16 B |         1 | `Structure ← Function ← .CommandLineAPI JSLexicalEnvironment ← JSLexicalEnvironment ← <root>`                   |
+| 0.4% | 16 B |         1 | `Structure ← Object ← .methods Function ← .CommandLineAPI JSLexicalEnvironment ← JSLexicalEnvironment ← <root>` |
+
+##### `CommandLineAPIHost`
+
+|      % |     Size | Instances | Path                                      |
+| -----: | -------: | --------: | ----------------------------------------- |
+| 100.0% | 4.22 KiB |         6 | `<root>`                                  |
+|  80.0% | 3.38 KiB |         6 | `Structure ← CommandLineAPIHost ← <root>` |
+
+##### `AsyncFunction`
+
+|     % |     Size | Instances | Path                                           |
+| ----: | -------: | --------: | ---------------------------------------------- |
+| 72.2% | 2.96 KiB |         5 | `Window`                                       |
+| 28.6% | 1.17 KiB |         5 | `.constructor AsyncFunction ← Window`          |
+| 27.8% | 1.14 KiB |         2 | `Window ← <root>`                              |
+| 11.4% |    480 B |         2 | `.constructor AsyncFunction ← Window ← <root>` |
+
+##### `AsyncGeneratorFunction`
+
+|     % |     Size | Instances | Path                                                    |
+| ----: | -------: | --------: | ------------------------------------------------------- |
+| 71.4% | 2.28 KiB |         5 | `Window`                                                |
+| 38.2% | 1.22 KiB |         5 | `.constructor AsyncGeneratorFunction ← Window`          |
+| 28.6% |    932 B |         2 | `Window ← <root>`                                       |
+| 15.3% |    498 B |         2 | `.constructor AsyncGeneratorFunction ← Window ← <root>` |
+
+##### `GeneratorFunction`
+
+|     % |     Size | Instances | Path                                               |
+| ----: | -------: | --------: | -------------------------------------------------- |
+| 71.4% | 2.23 KiB |         5 | `Window`                                           |
+| 38.2% | 1.19 KiB |         5 | `.constructor GeneratorFunction ← Window`          |
+| 28.6% |    912 B |         2 | `Window ← <root>`                                  |
+| 15.3% |    488 B |         2 | `.constructor GeneratorFunction ← Window ← <root>` |
+
+##### `CallbackObject`
+
+|     % |  Size | Instances | Path                                                                                                              |
+| ----: | ----: | --------: | ----------------------------------------------------------------------------------------------------------------- |
+| 31.4% | 854 B |         1 | `.ReaderArticleFinderJSController Window`                                                                         |
+| 27.3% | 742 B |         1 | `[0] Array ← ._oneTimeCodeFieldLabelPatternMatchers Object ← .FormMetadataJS Window`                              |
+| 24.4% | 662 B |         1 | `Structure ← CallbackObject ← .ReaderArticleFinderJSController Window`                                            |
+| 20.3% | 550 B |         1 | `Structure ← CallbackObject ← [0] Array ← ._oneTimeCodeFieldLabelPatternMatchers Object ← .FormMetadataJS Window` |
+|  8.2% | 224 B |         1 | `.browser Window ← <root>`                                                                                        |
+
+##### `ProgramExecutable`
+
+|     % |     Size | Instances | Path                                                                      |
+| ----: | -------: | --------: | ------------------------------------------------------------------------- |
+| 66.7% | 1.09 KiB |        10 | `(GC root)`                                                               |
+| 13.3% |    224 B |         2 | `.user.options Object`                                                    |
+| 13.3% |    224 B |         2 | `.hooks JSLexicalEnvironment`                                             |
+|  6.7% |    112 B |         1 | `FunctionExecutable ← Function ← .extractMediaServiceSubscription Window` |
+
+##### `HashMapBucket`
+
+|     % |  Size | Instances | Path                                                                                                                                                |
+| ----: | ----: | --------: | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 23.0% | 342 B |         2 | `Set ← .stacks JSLexicalEnvironment ← Function ← .isFirst JSLexicalEnvironment ← Function ← .maybeLog JSLexicalEnvironment ← .eventInSample Object` |
+| 15.7% | 234 B |         2 | `.stacks JSLexicalEnvironment ← Function ← .isFirst JSLexicalEnvironment ← Function ← .maybeLog JSLexicalEnvironment ← .eventInSample Object`       |
+|  3.2% |  48 B |         1 | `Map ← .state Object`                                                                                                                               |
+|  3.2% |  48 B |         1 | `Map ← ._mapOfUniqueIDToOriginalElement Object`                                                                                                     |
+|  3.2% |  48 B |         1 | `Map ← .queues JSLexicalEnvironment`                                                                                                                |
+
+##### `JSWindowProxy`
+
+|     % |  Size | Instances | Path        |
+| ----: | ----: | --------: | ----------- |
+| 76.9% | 960 B |         5 | `(GC root)` |
+| 23.1% | 288 B |         1 | `<root>`    |
+
+##### `Callee`
+
+|     % |  Size | Instances | Path              |
+| ----: | ----: | --------: | ----------------- |
+| 71.4% | 320 B |        10 | `Window`          |
+| 28.6% | 128 B |         4 | `Window ← <root>` |
+
+##### `SparseArrayValueMap`
+
+|     % |  Size | Instances | Path                                                                                                        |
+| ----: | ----: | --------: | ----------------------------------------------------------------------------------------------------------- |
+| 34.7% | 102 B |         2 | `Object`                                                                                                    |
+| 21.8% |  64 B |         2 | `Object ← .xhrSuccessStatus JSLexicalEnvironment`                                                           |
+| 21.8% |  64 B |         2 | `Object ← .ENTRYPOINT_TYPE Object ← .exports Object ← .module Object ← .ext.uls.rewrite.entrypoints Object` |
+| 21.8% |  64 B |         2 | `Object ← .ULS_MODE Object ← .exports Object ← .module Object ← .ext.uls.rewrite.entrypoints Object`        |
+
 ## Largest strings
 
 Strings ranked by bytes allocated for them.
+
+### Categories
+
+#### String
 
 |    % |     Size | Path                                                                           |
 | ---: | -------: | ------------------------------------------------------------------------------ |

--- a/examples/output/javascript.safari.current.jsc-heap-snapshot.json.md
+++ b/examples/output/javascript.safari.current.jsc-heap-snapshot.json.md
@@ -44,6 +44,99 @@ Constructors ranked by bytes allocated for their instances, excluding nodes kept
 |  0.3% | 32.4 KiB |        87 | `UnlinkedEvalCodeBlock`      |
 |  0.2% | 24.9 KiB |        14 | `Window`                     |
 
+#### Categories
+
+##### Code
+
+|     % |     Size | Instances | Constructor                  |
+| ----: | -------: | --------: | ---------------------------- |
+|  9.0% |  961 KiB |     1,658 | `UnlinkedFunctionCodeBlock`  |
+|  8.9% |  950 KiB |     7,600 | `FunctionExecutable`         |
+|  5.3% |  566 KiB |     6,041 | `UnlinkedFunctionExecutable` |
+|  5.1% |  545 KiB |       165 | `FunctionCodeBlock`          |
+|  0.6% | 59.9 KiB |       767 | `NativeExecutable`           |
+| <0.1% | 1.64 KiB |        15 | `ProgramExecutable`          |
+
+##### Object shape
+
+|     % |    Size | Instances | Constructor |
+| ----: | ------: | --------: | ----------- |
+| 12.5% | 1.3 MiB |    12,177 | `Structure` |
+
+##### Internal
+
+|     % |     Size | Instances | Constructor                  |
+| ----: | -------: | --------: | ---------------------------- |
+|  4.5% |  479 KiB |    10,225 | `DOMAttributeGetterSetter`   |
+|  1.2% |  124 KiB |     2,030 | `JSLexicalEnvironment`       |
+|  1.0% |  104 KiB |     2,226 | `PropertyTable`              |
+|  0.8% | 85.3 KiB |     1,364 | `SymbolTable`                |
+|  0.8% | 83.7 KiB |       893 | `StructureRareData`          |
+|  0.6% | 67.5 KiB |     2,159 | `CustomGetterSetter`         |
+|  0.3% | 32.4 KiB |        87 | `UnlinkedEvalCodeBlock`      |
+|  0.2% | 21.1 KiB |       270 | `FunctionRareData`           |
+|  0.2% | 17.5 KiB |       160 | `EvalExecutable`             |
+|  0.1% | 15.7 KiB |        14 | `UnlinkedProgramCodeBlock`   |
+|  0.1% | 9.28 KiB |       297 | `GetterSetter`               |
+| <0.1% | 4.73 KiB |       101 | `JSPropertyNameEnumerator`   |
+| <0.1% | 4.39 KiB |       281 | `StructureChain`             |
+| <0.1% | 1.02 KiB |        29 | `HashMapBucket`              |
+| <0.1% |    448 B |         7 | `JSGlobalLexicalEnvironment` |
+| <0.1% |    402 B |        12 | `InjectedScriptHost`         |
+| <0.1% |    336 B |        12 | `CommandLineAPIHost`         |
+| <0.1% |    192 B |         6 | `JSWindowProxy`              |
+
+##### Object
+
+|     % |     Size | Instances | Constructor           |
+| ----: | -------: | --------: | --------------------- |
+|  6.5% |  697 KiB |    11,833 | `Object`              |
+|  0.4% | 41.6 KiB |     1,330 | `DOMRect`             |
+|  0.2% | 24.9 KiB |        14 | `Window`              |
+|  0.2% | 22.2 KiB |       468 | `HTMLSpanElement`     |
+|  0.2% | 19.7 KiB |       418 | `HTMLDivElement`      |
+|  0.1% | 13.4 KiB |       283 | `HTMLLIElement`       |
+|  0.1% | 10.5 KiB |       205 | `HTMLElement`         |
+|  0.1% | 9.29 KiB |       108 | `HTMLCollection`      |
+|  0.1% | 8.05 KiB |       170 | `HTMLAnchorElement`   |
+|  0.1% |  6.3 KiB |        20 | `CSSStyleDeclaration` |
+| <0.1% |  5.1 KiB |       160 | `Text`                |
+| <0.1% | 4.45 KiB |        95 | `jQuery`              |
+| <0.1% | 4.38 KiB |       140 | `DOMTokenList`        |
+| <0.1% | 3.83 KiB |        77 | `HTMLInputElement`    |
+| <0.1% | 3.66 KiB |        76 | `HTMLButtonElement`   |
+| <0.1% | 3.61 KiB |        78 | `HTMLUListElement`    |
+| <0.1% |  2.3 KiB |        51 | `HTMLLabelElement`    |
+| <0.1% | 2.03 KiB |        26 | `TooltippedElement`   |
+| <0.1% | 1.95 KiB |         9 | `Set`                 |
+| <0.1% | 1.78 KiB |         9 | `Document`            |
+
+##### Function
+
+|     % |    Size | Instances | Constructor              |
+| ----: | ------: | --------: | ------------------------ |
+|  4.1% | 434 KiB |    13,414 | `Function`               |
+| <0.1% |   490 B |        14 | `GeneratorFunction`      |
+| <0.1% |   490 B |        14 | `AsyncGeneratorFunction` |
+| <0.1% |   483 B |        14 | `AsyncFunction`          |
+| <0.1% |   450 B |        14 | `CallbackObject`         |
+| <0.1% |   448 B |        14 | `Callee`                 |
+
+##### Array
+
+|     % |    Size | Instances | Constructor           |
+| ----: | ------: | --------: | --------------------- |
+|  1.4% | 154 KiB |     3,780 | `Immutable Butterfly` |
+|  1.1% | 116 KiB |     7,409 | `Array`               |
+| <0.1% |   256 B |         8 | `SparseArrayValueMap` |
+| <0.1% |   126 B |         7 | `Array Iterator`      |
+
+##### Regular expression
+
+|    % |    Size | Instances | Constructor |
+| ---: | ------: | --------: | ----------- |
+| 1.0% | 108 KiB |       453 | `RegExp`    |
+
 #### Instances
 
 Instances ranked by contribution to each constructor's self size.
@@ -241,6 +334,327 @@ Instances ranked by contribution to each constructor's self size.
 | 28.7% | 7.14 KiB |         2 | `<root>`                      |
 |  0.1% |     17 B |         1 | `Structure ← Window ← <root>` |
 
+##### `HTMLSpanElement`
+
+|    % | Size | Instances | Path          |
+| ---: | ---: | --------: | ------------- |
+| 0.2% | 49 B |         1 | `[556] Array` |
+| 0.2% | 49 B |         1 | `[558] Array` |
+| 0.2% | 49 B |         1 | `[560] Array` |
+| 0.2% | 49 B |         1 | `[562] Array` |
+| 0.2% | 49 B |         1 | `[564] Array` |
+
+##### `FunctionRareData`
+
+|    % | Size | Instances | Path                                               |
+| ---: | ---: | --------: | -------------------------------------------------- |
+| 0.4% | 80 B |         1 | `Function`                                         |
+| 0.4% | 80 B |         1 | `Function ← .prependTo Object`                     |
+| 0.4% | 80 B |         1 | `Function ← .toggleElement JSLexicalEnvironment`   |
+| 0.4% | 80 B |         1 | `Function ← .togglingHandler JSLexicalEnvironment` |
+| 0.4% | 80 B |         1 | `Function ← .remove Object ← .event Function`      |
+
+##### `HTMLDivElement`
+
+|    % |  Size | Instances | Path                                                                            |
+| ---: | ----: | --------: | ------------------------------------------------------------------------------- |
+| 2.5% | 500 B |        10 | `(GC root)`                                                                     |
+| 0.2% |  50 B |         1 | `._backingElement Object ← .FormMetadataJS Window`                              |
+| 0.2% |  50 B |         1 | `._formElement Object ← .FormMetadataJS Window`                                 |
+| 0.2% |  50 B |         1 | `._backingElement Object ← [9] Array ← ._forms Object ← .FormMetadataJS Window` |
+| 0.2% |  50 B |         1 | `[672] Array`                                                                   |
+
+##### `EvalExecutable`
+
+|    % |  Size | Instances | Path                                                                                 |
+| ---: | ----: | --------: | ------------------------------------------------------------------------------------ |
+| 1.9% | 336 B |         3 | `(GC root)`                                                                          |
+| 0.6% | 112 B |         1 | `.ext.quicksurveys.init Object`                                                      |
+| 0.6% | 112 B |         1 | `FunctionExecutable ← Function ← .declarator Object ← .jquery.spinner.styles Object` |
+| 0.6% | 112 B |         1 | `.ext.checkUser.clientHints Object`                                                  |
+| 0.6% | 112 B |         1 | `.wikibase.client.vector-2022 Object`                                                |
+
+##### `UnlinkedProgramCodeBlock`
+
+|      % |     Size | Instances | Path     |
+| -----: | -------: | --------: | -------- |
+| 100.0% | 15.7 KiB |        14 | `<root>` |
+
+##### `HTMLLIElement`
+
+|    % | Size | Instances | Path          |
+| ---: | ---: | --------: | ------------- |
+| 0.4% | 49 B |         1 | `[405] Array` |
+| 0.4% | 49 B |         1 | `[419] Array` |
+| 0.4% | 49 B |         1 | `[457] Array` |
+| 0.4% | 49 B |         1 | `[478] Array` |
+| 0.4% | 49 B |         1 | `[497] Array` |
+
+##### `HTMLElement`
+
+|     % |     Size | Instances | Path              |
+| ----: | -------: | --------: | ----------------- |
+| 10.1% | 1.07 KiB |         7 | `(GC root)`       |
+|  0.5% |     51 B |         1 | `Window`          |
+|  0.5% |     51 B |         1 | `Window ← <root>` |
+|  0.5% |     50 B |         1 | `[442] Array`     |
+|  0.5% |     49 B |         1 | `[1064] Array`    |
+
+##### `HTMLCollection`
+
+|     % |     Size | Instances | Path                 |
+| ----: | -------: | --------: | -------------------- |
+| 98.8% | 9.18 KiB |       103 | `<root>`             |
+|  0.7% |     66 B |         3 | `(GC root)`          |
+|  0.5% |     44 B |         2 | `Structure ← Window` |
+
+##### `GetterSetter`
+
+|    % | Size | Instances | Path                                                                             |
+| ---: | ---: | --------: | -------------------------------------------------------------------------------- |
+| 0.3% | 32 B |         1 | `.evaluate InjectedScriptHost ← Structure ← InjectedScriptHost ← <root>`         |
+| 0.3% | 32 B |         1 | `.savedResultAlias InjectedScriptHost ← Structure ← InjectedScriptHost ← <root>` |
+| 0.3% | 32 B |         1 | `.size Set`                                                                      |
+| 0.3% | 32 B |         1 | `.altKey Object`                                                                 |
+| 0.3% | 32 B |         1 | `.bubbles Object`                                                                |
+
+##### `HTMLAnchorElement`
+
+|     % |     Size | Instances | Path                                             |
+| ----: | -------: | --------: | ------------------------------------------------ |
+| 13.1% | 1.05 KiB |        22 | `<root>`                                         |
+|  5.3% |    441 B |         9 | `.elem JSLexicalEnvironment ← Function ← <root>` |
+|  0.6% |     51 B |         1 | `Window ← <root>`                                |
+|  0.6% |     49 B |         1 | `(GC root)`                                      |
+|  0.6% |     49 B |         1 | `[6] Array`                                      |
+
+##### `CSSStyleDeclaration`
+
+|     % |     Size | Instances | Path                               |
+| ----: | -------: | --------: | ---------------------------------- |
+| 69.1% | 4.35 KiB |         3 | `(GC root)`                        |
+| 23.0% | 1.45 KiB |         1 | `Structure ← Window`               |
+|  5.5% |    352 B |        11 | `<root>`                           |
+|  0.5% |     32 B |         1 | `.emptyStyle JSLexicalEnvironment` |
+|  0.5% |     32 B |         1 | `._cachedContentTextStyle Object`  |
+
+##### `Text`
+
+|    % | Size | Instances | Path                                              |
+| ---: | ---: | --------: | ------------------------------------------------- |
+| 0.6% | 33 B |         1 | `[1] Array ← .textNodes Object ← .article Object` |
+| 0.6% | 33 B |         1 | `[2] Array ← .textNodes Object ← .article Object` |
+| 0.6% | 33 B |         1 | `[3] Array ← .textNodes Object ← .article Object` |
+| 0.6% | 33 B |         1 | `[4] Array ← .textNodes Object ← .article Object` |
+| 0.6% | 33 B |         1 | `[5] Array ← .textNodes Object ← .article Object` |
+
+##### `JSPropertyNameEnumerator`
+
+|    % | Size | Instances | Path                                                                                                                                                                                                                                        |
+| ---: | ---: | --------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1.0% | 48 B |         1 | `StructureRareData ← Structure ← Structure ← Structure ← Structure ← Structure ← Structure ← Structure ← StructureRareData ← Structure ← Object ← .methods Function ← .CommandLineAPI JSLexicalEnvironment ← JSLexicalEnvironment ← <root>` |
+| 1.0% | 48 B |         1 | `StructureRareData ← Structure ← Object ← .methods Function ← .CommandLineAPI JSLexicalEnvironment ← JSLexicalEnvironment ← <root>`                                                                                                         |
+| 1.0% | 48 B |         1 | `StructureRareData ← Structure ← Object ← .RLCONF Window ← <root>`                                                                                                                                                                          |
+| 1.0% | 48 B |         1 | `StructureRareData ← Structure ← Object ← .RLSTATE Window ← <root>`                                                                                                                                                                         |
+| 1.0% | 48 B |         1 | `StructureRareData ← Structure ← Structure ← Object ← .sources JSLexicalEnvironment`                                                                                                                                                        |
+
+##### `jQuery`
+
+|    % | Size | Instances | Path                                                                                                                                                                       |
+| ---: | ---: | --------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1.1% | 48 B |         1 | `(GC root)`                                                                                                                                                                |
+| 1.1% | 48 B |         1 | `.$shortenUrlLink JSLexicalEnvironment ← Function ← .handler Object ← [0] Array ← .click Object ← .events Object ← .jQuery37102850593049792911 HTMLAnchorElement ← <root>` |
+| 1.1% | 48 B |         1 | `.$qrCodeLink JSLexicalEnvironment ← Function ← .handler Object ← [0] Array ← .click Object ← .events Object ← .jQuery37102850593049792911 HTMLAnchorElement ← <root>`     |
+| 1.1% | 48 B |         1 | `.$body JSLexicalEnvironment`                                                                                                                                              |
+| 1.1% | 48 B |         1 | `.$window JSLexicalEnvironment`                                                                                                                                            |
+
+##### `StructureChain`
+
+|    % | Size | Instances | Path                                                                                                            |
+| ---: | ---: | --------: | --------------------------------------------------------------------------------------------------------------- |
+| 0.4% | 16 B |         1 | `Structure ← Function ← <root>`                                                                                 |
+| 0.4% | 16 B |         1 | `Structure ← InjectedScript ← <root>`                                                                           |
+| 0.4% | 16 B |         1 | `Structure ← Function ← .CallFrameProxy Function ← <root>`                                                      |
+| 0.4% | 16 B |         1 | `Structure ← Function ← .CommandLineAPI JSLexicalEnvironment ← JSLexicalEnvironment ← <root>`                   |
+| 0.4% | 16 B |         1 | `Structure ← Object ← .methods Function ← .CommandLineAPI JSLexicalEnvironment ← JSLexicalEnvironment ← <root>` |
+
+##### `DOMTokenList`
+
+|     % |     Size | Instances | Path        |
+| ----: | -------: | --------: | ----------- |
+| 97.8% | 4.28 KiB |       137 | `<root>`    |
+|  2.2% |     99 B |         3 | `(GC root)` |
+
+##### `HTMLInputElement`
+
+|    % |  Size | Instances | Path                                                                                  |
+| ---: | ----: | --------: | ------------------------------------------------------------------------------------- |
+| 8.2% | 320 B |         6 | `.FormMetadataJS Window`                                                              |
+| 8.1% | 316 B |         4 | `(GC root)`                                                                           |
+| 1.3% |  52 B |         1 | `[1] Array ← ._controls Object ← [0] Array ← ._forms Object ← .FormMetadataJS Window` |
+| 1.3% |  52 B |         1 | `[1] Array ← ._controls Object ← [1] Array ← ._forms Object ← .FormMetadataJS Window` |
+| 1.3% |  52 B |         1 | `[1] Array ← ._controls Object ← [3] Array ← ._forms Object ← .FormMetadataJS Window` |
+
+##### `HTMLButtonElement`
+
+|     % |     Size | Instances | Path                                                                                  |
+| ----: | -------: | --------: | ------------------------------------------------------------------------------------- |
+| 28.2% | 1.03 KiB |        20 | `.FormMetadataJS Window`                                                              |
+|  1.4% |     51 B |         1 | `Window`                                                                              |
+|  1.4% |     51 B |         1 | `[2] Array ← ._controls Object ← [0] Array ← ._forms Object ← .FormMetadataJS Window` |
+|  1.4% |     51 B |         1 | `[2] Array ← ._controls Object ← [4] Array ← ._forms Object ← .FormMetadataJS Window` |
+|  1.4% |     51 B |         1 | `[1] Array ← ._controls Object ← [9] Array ← ._forms Object ← .FormMetadataJS Window` |
+
+##### `HTMLUListElement`
+
+|    % | Size | Instances | Path          |
+| ---: | ---: | --------: | ------------- |
+| 1.3% | 49 B |         1 | `[47] Array`  |
+| 1.3% | 49 B |         1 | `[54] Array`  |
+| 1.3% | 49 B |         1 | `[60] Array`  |
+| 1.3% | 49 B |         1 | `[125] Array` |
+| 1.3% | 49 B |         1 | `[134] Array` |
+
+##### `HTMLLabelElement`
+
+|    % | Size | Instances | Path          |
+| ---: | ---: | --------: | ------------- |
+| 2.2% | 51 B |         1 | `Window`      |
+| 2.1% | 49 B |         1 | `[253] Array` |
+| 2.1% | 49 B |         1 | `[330] Array` |
+| 2.1% | 49 B |         1 | `[348] Array` |
+| 2.1% | 49 B |         1 | `[353] Array` |
+
+##### `TooltippedElement`
+
+|      % |     Size | Instances | Path                                                                                                                                   |
+| -----: | -------: | --------: | -------------------------------------------------------------------------------------------------------------------------------------- |
+| 100.0% | 2.03 KiB |        26 | `.te JSLexicalEnvironment ← .events Object ← .jQuery37102850593049792911 HTMLElement ← .elem JSLexicalEnvironment ← Function ← <root>` |
+
+##### `Set`
+
+|     % |  Size | Instances | Path                                                                                                                                          |
+| ----: | ----: | --------: | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| 41.4% | 824 B |         1 | `.SetOfCandidateTagNamesToIgnore JSGlobalLexicalEnvironment`                                                                                  |
+| 31.3% | 624 B |         2 | `.stacks JSLexicalEnvironment ← Function ← .isFirst JSLexicalEnvironment ← Function ← .maybeLog JSLexicalEnvironment ← .eventInSample Object` |
+|  9.2% | 184 B |         1 | `.exposuresThisPage ExposureLogTracker ← .exposureLogTracker JSLexicalEnvironment ← .testKitchen Object`                                      |
+|  9.2% | 184 B |         1 | `.exposuresThisPage ExposureLogTracker ← .exposureLogTracker JSLexicalEnvironment ← .tk Object`                                               |
+|  2.2% |  44 B |         1 | `(GC root)`                                                                                                                                   |
+
+##### `Document`
+
+|     % |     Size | Instances | Path              |
+| ----: | -------: | --------: | ----------------- |
+| 94.3% | 1.67 KiB |         7 | `(GC root)`       |
+|  5.7% |    104 B |         2 | `Window ← <root>` |
+
+##### `ProgramExecutable`
+
+|     % |     Size | Instances | Path                                                                      |
+| ----: | -------: | --------: | ------------------------------------------------------------------------- |
+| 66.7% | 1.09 KiB |        10 | `(GC root)`                                                               |
+| 13.3% |    224 B |         2 | `.user.options Object`                                                    |
+| 13.3% |    224 B |         2 | `.hooks JSLexicalEnvironment`                                             |
+|  6.7% |    112 B |         1 | `FunctionExecutable ← Function ← .extractMediaServiceSubscription Window` |
+
+##### `HashMapBucket`
+
+|    % | Size | Instances | Path                                                                                                           |
+| ---: | ---: | --------: | -------------------------------------------------------------------------------------------------------------- |
+| 9.2% | 96 B |         2 | `Map ← .state Object`                                                                                          |
+| 9.2% | 96 B |         2 | `Map ← ._mapOfUniqueIDToOriginalElement Object`                                                                |
+| 9.2% | 96 B |         2 | `Map ← .queues JSLexicalEnvironment`                                                                           |
+| 4.6% | 48 B |         1 | `<root>`                                                                                                       |
+| 3.1% | 32 B |         1 | `Set ← .exposuresThisPage ExposureLogTracker ← .exposureLogTracker JSLexicalEnvironment ← .testKitchen Object` |
+
+##### `GeneratorFunction`
+
+|     % |  Size | Instances | Path                                               |
+| ----: | ----: | --------: | -------------------------------------------------- |
+| 52.0% | 255 B |         5 | `.constructor GeneratorFunction ← Window`          |
+| 20.8% | 102 B |         2 | `.constructor GeneratorFunction ← Window ← <root>` |
+| 19.4% |  95 B |         5 | `Window`                                           |
+|  7.8% |  38 B |         2 | `Window ← <root>`                                  |
+
+##### `AsyncGeneratorFunction`
+
+|     % |  Size | Instances | Path                                                    |
+| ----: | ----: | --------: | ------------------------------------------------------- |
+| 52.0% | 255 B |         5 | `.constructor AsyncGeneratorFunction ← Window`          |
+| 20.8% | 102 B |         2 | `.constructor AsyncGeneratorFunction ← Window ← <root>` |
+| 19.4% |  95 B |         5 | `Window`                                                |
+|  7.8% |  38 B |         2 | `Window ← <root>`                                       |
+
+##### `AsyncFunction`
+
+|     % |  Size | Instances | Path                                           |
+| ----: | ----: | --------: | ---------------------------------------------- |
+| 52.8% | 255 B |         5 | `.constructor AsyncFunction ← Window`          |
+| 21.1% | 102 B |         2 | `.constructor AsyncFunction ← Window ← <root>` |
+| 18.6% |  90 B |         5 | `Window`                                       |
+|  7.5% |  36 B |         2 | `Window ← <root>`                              |
+
+##### `CallbackObject`
+
+|    % | Size | Instances | Path                                                                                                              |
+| ---: | ---: | --------: | ----------------------------------------------------------------------------------------------------------------- |
+| 7.3% | 33 B |         1 | `Structure ← CallbackObject ← [0] Array ← ._oneTimeCodeFieldLabelPatternMatchers Object ← .FormMetadataJS Window` |
+| 7.3% | 33 B |         1 | `Structure ← CallbackObject ← .ReaderArticleFinderJSController Window`                                            |
+| 7.1% | 32 B |         1 | `.browser Window ← <root>`                                                                                        |
+| 7.1% | 32 B |         1 | `Structure ← CallbackObject ← .browser Window ← <root>`                                                           |
+| 7.1% | 32 B |         1 | `.pushNotification Object ← .safari Window ← <root>`                                                              |
+
+##### `JSGlobalLexicalEnvironment`
+
+|     % |  Size | Instances | Path        |
+| ----: | ----: | --------: | ----------- |
+| 57.1% | 256 B |         4 | `(GC root)` |
+| 42.9% | 192 B |         3 | `Window`    |
+
+##### `Callee`
+
+|     % |  Size | Instances | Path              |
+| ----: | ----: | --------: | ----------------- |
+| 71.4% | 320 B |        10 | `Window`          |
+| 28.6% | 128 B |         4 | `Window ← <root>` |
+
+##### `InjectedScriptHost`
+
+|     % |  Size | Instances | Path                                      |
+| ----: | ----: | --------: | ----------------------------------------- |
+| 52.2% | 210 B |         6 | `Structure ← InjectedScriptHost ← <root>` |
+| 47.8% | 192 B |         6 | `<root>`                                  |
+
+##### `CommandLineAPIHost`
+
+|     % |  Size | Instances | Path                                      |
+| ----: | ----: | --------: | ----------------------------------------- |
+| 57.1% | 192 B |         6 | `<root>`                                  |
+| 42.9% | 144 B |         6 | `Structure ← CommandLineAPIHost ← <root>` |
+
+##### `SparseArrayValueMap`
+
+|     % | Size | Instances | Path                                                                                                        |
+| ----: | ---: | --------: | ----------------------------------------------------------------------------------------------------------- |
+| 25.0% | 64 B |         2 | `Object`                                                                                                    |
+| 25.0% | 64 B |         2 | `Object ← .xhrSuccessStatus JSLexicalEnvironment`                                                           |
+| 25.0% | 64 B |         2 | `Object ← .ENTRYPOINT_TYPE Object ← .exports Object ← .module Object ← .ext.uls.rewrite.entrypoints Object` |
+| 25.0% | 64 B |         2 | `Object ← .ULS_MODE Object ← .exports Object ← .module Object ← .ext.uls.rewrite.entrypoints Object`        |
+
+##### `JSWindowProxy`
+
+|     % |  Size | Instances | Path        |
+| ----: | ----: | --------: | ----------- |
+| 83.3% | 160 B |         5 | `(GC root)` |
+| 16.7% |  32 B |         1 | `<root>`    |
+
+##### `Array Iterator`
+
+|     % | Size | Instances | Path              |
+| ----: | ---: | --------: | ----------------- |
+| 71.4% | 90 B |         5 | `Window`          |
+| 28.6% | 36 B |         2 | `Window ← <root>` |
+
 ### Retained size
 
 Constructors ranked by bytes allocated for their instances and all nodes that would be freed if their instances were garbage collected.
@@ -267,6 +681,99 @@ Constructors ranked by bytes allocated for their instances and all nodes that wo
 |  1.0% |  104 KiB |        14 | `UnlinkedProgramCodeBlock`   |
 |  1.0% |  102 KiB |     2,226 | `PropertyTable`              |
 |  0.8% | 85.1 KiB |     1,364 | `SymbolTable`                |
+
+#### Categories
+
+##### Code
+
+|     % |     Size | Instances | Constructor                  |
+| ----: | -------: | --------: | ---------------------------- |
+| 19.3% | 2.01 MiB |     7,600 | `FunctionExecutable`         |
+| 15.6% | 1.62 MiB |     6,041 | `UnlinkedFunctionExecutable` |
+| 11.2% | 1.17 MiB |     1,658 | `UnlinkedFunctionCodeBlock`  |
+|  5.1% |  547 KiB |       165 | `FunctionCodeBlock`          |
+|  0.6% | 59.9 KiB |       767 | `NativeExecutable`           |
+| <0.1% | 1.64 KiB |        15 | `ProgramExecutable`          |
+
+##### Object shape
+
+|     % |     Size | Instances | Constructor |
+| ----: | -------: | --------: | ----------- |
+| 17.7% | 1.85 MiB |    12,177 | `Structure` |
+
+##### Internal
+
+|     % |     Size | Instances | Constructor                  |
+| ----: | -------: | --------: | ---------------------------- |
+|  7.8% |  837 KiB |     2,030 | `JSLexicalEnvironment`       |
+|  4.5% |  479 KiB |    10,225 | `DOMAttributeGetterSetter`   |
+|  4.2% |  454 KiB |       893 | `StructureRareData`          |
+|  2.0% |  210 KiB |       270 | `FunctionRareData`           |
+|  1.0% |  104 KiB |        14 | `UnlinkedProgramCodeBlock`   |
+|  1.0% |  102 KiB |     2,226 | `PropertyTable`              |
+|  0.8% | 85.1 KiB |     1,364 | `SymbolTable`                |
+|  0.6% | 67.4 KiB |     2,159 | `CustomGetterSetter`         |
+|  0.5% | 51.7 KiB |       297 | `GetterSetter`               |
+|  0.4% | 37.9 KiB |       101 | `JSPropertyNameEnumerator`   |
+|  0.3% | 32.4 KiB |        87 | `UnlinkedEvalCodeBlock`      |
+|  0.2% | 17.5 KiB |       160 | `EvalExecutable`             |
+|  0.1% | 9.18 KiB |        12 | `InjectedScriptHost`         |
+|  0.1% | 6.73 KiB |         7 | `JSGlobalLexicalEnvironment` |
+| <0.1% | 4.39 KiB |       281 | `StructureChain`             |
+| <0.1% | 4.22 KiB |        12 | `CommandLineAPIHost`         |
+| <0.1% | 1.45 KiB |        29 | `HashMapBucket`              |
+| <0.1% | 1.22 KiB |         6 | `JSWindowProxy`              |
+
+##### Object
+
+|     % |     Size | Instances | Constructor                 |
+| ----: | -------: | --------: | --------------------------- |
+| 55.2% | 5.76 MiB |    11,833 | `Object`                    |
+|  9.5% | 1015 KiB |        14 | `Window`                    |
+|  2.5% |  272 KiB |        20 | `CSSStyleDeclaration`       |
+|  2.5% |  271 KiB |         6 | `InjectedScript`            |
+|  0.8% | 83.5 KiB |       205 | `HTMLElement`               |
+|  0.8% | 81.8 KiB |         9 | `Document`                  |
+|  0.5% | 56.7 KiB |        10 | `Element`                   |
+|  0.4% | 43.4 KiB |     1,330 | `DOMRect`                   |
+|  0.3% | 35.8 KiB |       418 | `HTMLDivElement`            |
+|  0.3% | 34.9 KiB |       468 | `HTMLSpanElement`           |
+|  0.3% | 32.3 KiB |        20 | `Map`                       |
+|  0.3% | 27.9 KiB |       170 | `HTMLAnchorElement`         |
+|  0.2% | 23.3 KiB |         7 | `String`                    |
+|  0.2% | 22.5 KiB |       283 | `HTMLLIElement`             |
+|  0.2% | 17.2 KiB |        77 | `HTMLInputElement`          |
+|  0.1% | 14.5 KiB |         2 | `MultimediaViewerBootstrap` |
+|  0.1% | 14.2 KiB |        76 | `HTMLButtonElement`         |
+|  0.1% | 14.2 KiB |        14 | `Node`                      |
+|  0.1% |   13 KiB |        20 | `Promise`                   |
+|  0.1% |   13 KiB |        16 | `HTMLDocument`              |
+
+##### Function
+
+|     % |     Size | Instances | Constructor              |
+| ----: | -------: | --------: | ------------------------ |
+| 28.1% | 2.93 MiB |    13,414 | `Function`               |
+| <0.1% |  4.1 KiB |        14 | `AsyncFunction`          |
+| <0.1% | 3.19 KiB |        14 | `AsyncGeneratorFunction` |
+| <0.1% | 3.12 KiB |        14 | `GeneratorFunction`      |
+| <0.1% | 2.65 KiB |        14 | `CallbackObject`         |
+| <0.1% |    448 B |        14 | `Callee`                 |
+
+##### Array
+
+|     % |    Size | Instances | Constructor           |
+| ----: | ------: | --------: | --------------------- |
+|  6.1% | 649 KiB |     7,409 | `Array`               |
+|  1.4% | 154 KiB |     3,780 | `Immutable Butterfly` |
+|  0.1% | 7.5 KiB |         7 | `Array Iterator`      |
+| <0.1% |   294 B |         8 | `SparseArrayValueMap` |
+
+##### Regular expression
+
+|    % |    Size | Instances | Constructor |
+| ---: | ------: | --------: | ----------- |
+| 1.0% | 108 KiB |       453 | `RegExp`    |
 
 #### Instances
 
@@ -461,9 +968,331 @@ Instances ranked by contribution to each constructor's retained size.
 | 0.1% |  64 B |         1 | `JSLexicalEnvironment ← Function ← <root>`                                                                        |
 | 0.1% |  64 B |         1 | `JSLexicalEnvironment ← .methods Function ← .CommandLineAPI JSLexicalEnvironment ← JSLexicalEnvironment ← <root>` |
 
+##### `HTMLElement`
+
+|     % |     Size | Instances | Path                                             |
+| ----: | -------: | --------: | ------------------------------------------------ |
+| 57.4% |   48 KiB |         7 | `(GC root)`                                      |
+| 25.5% | 21.3 KiB |        27 | `.elem JSLexicalEnvironment ← Function ← <root>` |
+|  0.7% |    574 B |         1 | `Window`                                         |
+|  0.6% |    526 B |         1 | `Window ← <root>`                                |
+|  0.1% |     82 B |         1 | `[442] Array`                                    |
+
+##### `Document`
+
+|     % |     Size | Instances | Path              |
+| ----: | -------: | --------: | ----------------- |
+| 99.3% | 81.2 KiB |         7 | `(GC root)`       |
+|  0.7% |    578 B |         2 | `Window ← <root>` |
+
+##### `CustomGetterSetter`
+
+|     % | Size | Instances | Path                            |
+| ----: | ---: | --------: | ------------------------------- |
+| <0.1% | 32 B |         1 | `.AudioBufferSourceNode Window` |
+| <0.1% | 32 B |         1 | `.AudioContext Window`          |
+| <0.1% | 32 B |         1 | `.AudioDestinationNode Window`  |
+| <0.1% | 32 B |         1 | `.AudioListener Window`         |
+| <0.1% | 32 B |         1 | `.AudioNode Window`             |
+
+##### `NativeExecutable`
+
+|     % |     Size | Instances | Path                                                                      |
+| ----: | -------: | --------: | ------------------------------------------------------------------------- |
+| 39.2% | 23.5 KiB |       301 | `(GC root)`                                                               |
+|  0.1% |     80 B |         1 | `<root>`                                                                  |
+|  0.1% |     80 B |         1 | `Function ← .next URLSearchParams Iterator ← Structure ← Window ← <root>` |
+|  0.1% |     80 B |         1 | `Function ← .item DOMRectList`                                            |
+|  0.1% |     80 B |         1 | `Function ← .abort AbortController`                                       |
+
+##### `Element`
+
+|     % |     Size | Instances | Path              |
+| ----: | -------: | --------: | ----------------- |
+| 97.1% | 55.1 KiB |         7 | `(GC root)`       |
+|  2.0% | 1.11 KiB |         2 | `Window`          |
+|  0.9% |    522 B |         1 | `Window ← <root>` |
+
+##### `GetterSetter`
+
+|    % |     Size | Instances | Path                                    |
+| ---: | -------: | --------: | --------------------------------------- |
+| 4.9% | 2.55 KiB |         2 | `.eventInSample Object`                 |
+| 2.8% | 1.43 KiB |         2 | `.getCrossSite Object ← .cookie Object` |
+| 2.6% | 1.35 KiB |         2 | `.jqueryMsg Object`                     |
+| 2.4% | 1.22 KiB |         2 | `.newInstrument Object`                 |
+| 1.1% |    577 B |         1 | `.write HTMLDocument`                   |
+
+##### `DOMRect`
+
+|    % |    Size | Instances | Path                                                       |
+| ---: | ------: | --------: | ---------------------------------------------------------- |
+| 2.8% | 1.2 KiB |         2 | `(GC root)`                                                |
+| 1.0% |   429 B |         1 | `Structure ← Window ← <root>`                              |
+| 0.8% |   367 B |         1 | `Window`                                                   |
+| 0.1% |    32 B |         1 | `._cachedElementBoundingRect HTMLDivElement`               |
+| 0.1% |    32 B |         1 | `._cachedElementBoundingRect HTMLTableElement ← [1] Array` |
+
+##### `JSPropertyNameEnumerator`
+
+|     % |     Size | Instances | Path                                                                                                                                                                                                                                        |
+| ----: | -------: | --------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 47.2% | 17.9 KiB |         4 | `StructureRareData ← Structure ← Object ← .mediawiki.base Object`                                                                                                                                                                           |
+|  9.2% | 3.47 KiB |         6 | `StructureRareData ← Structure ← Structure ← Structure ← Structure ← Structure ← Structure ← Structure ← StructureRareData ← Structure ← Object ← .methods Function ← .CommandLineAPI JSLexicalEnvironment ← JSLexicalEnvironment ← <root>` |
+|  5.4% | 2.04 KiB |         2 | `StructureRareData ← Structure ← Object ← .RLCONF Window ← <root>`                                                                                                                                                                          |
+|  2.5% |    958 B |         2 | `StructureRareData ← Structure ← Object ← .messages Object ← .skins.vector.clientPreferences Object`                                                                                                                                        |
+|  1.1% |    438 B |         1 | `StructureRareData ← Structure ← Object`                                                                                                                                                                                                    |
+
+##### `HTMLDivElement`
+
+|     % |     Size | Instances | Path          |
+| ----: | -------: | --------: | ------------- |
+| 21.1% | 7.55 KiB |        15 | `(GC root)`   |
+|  6.0% | 2.16 KiB |         1 | `<root>`      |
+|  0.2% |     82 B |         1 | `[672] Array` |
+|  0.2% |     82 B |         1 | `[666] Array` |
+|  0.2% |     82 B |         1 | `[441] Array` |
+
+##### `HTMLSpanElement`
+
+|    % |  Size | Instances | Path          |
+| ---: | ----: | --------: | ------------- |
+| 2.7% | 964 B |         4 | `(GC root)`   |
+| 0.2% |  81 B |         1 | `[556] Array` |
+| 0.2% |  81 B |         1 | `[558] Array` |
+| 0.2% |  81 B |         1 | `[560] Array` |
+| 0.2% |  81 B |         1 | `[562] Array` |
+
+##### `UnlinkedEvalCodeBlock`
+
+|      % |     Size | Instances | Path     |
+| -----: | -------: | --------: | -------- |
+| 100.0% | 32.4 KiB |        87 | `<root>` |
+
+##### `Map`
+
+|     % |     Size | Instances | Path                                      |
+| ----: | -------: | --------: | ----------------------------------------- |
+| 54.1% | 17.5 KiB |         7 | `(GC root)`                               |
+| 33.3% | 10.8 KiB |         2 | `.en Object ← .data Object`               |
+|  4.0% |  1.3 KiB |         2 | `.tokens Object ← .user Object`           |
+|  4.0% | 1.28 KiB |         2 | `.options Object ← .user Object`          |
+|  1.1% |    368 B |         1 | `._mapOfUniqueIDToOriginalElement Object` |
+
+##### `HTMLAnchorElement`
+
+|     % |     Size | Instances | Path                                             |
+| ----: | -------: | --------: | ------------------------------------------------ |
+| 31.1% | 8.65 KiB |        26 | `<root>`                                         |
+| 30.0% | 8.35 KiB |         6 | `(GC root)`                                      |
+| 10.0% | 2.78 KiB |         9 | `.elem JSLexicalEnvironment ← Function ← <root>` |
+|  1.9% |    532 B |         1 | `Window ← <root>`                                |
+|  0.3% |     81 B |         1 | `[6] Array`                                      |
+
+##### `String`
+
+|     % |     Size | Instances | Path        |
+| ----: | -------: | --------: | ----------- |
+| 51.5% |   12 KiB |         4 | `Window`    |
+| 48.5% | 11.3 KiB |         3 | `(GC root)` |
+
+##### `HTMLLIElement`
+
+|    % |   Size | Instances | Path                 |
+| ---: | -----: | --------: | -------------------- |
+| 4.4% | 1011 B |         3 | `(GC root)`          |
+| 1.5% |  337 B |         1 | `Structure ← Window` |
+| 0.4% |   81 B |         1 | `[405] Array`        |
+| 0.4% |   81 B |         1 | `[419] Array`        |
+| 0.4% |   81 B |         1 | `[457] Array`        |
+
+##### `EvalExecutable`
+
+|    % |  Size | Instances | Path                                                                                 |
+| ---: | ----: | --------: | ------------------------------------------------------------------------------------ |
+| 1.9% | 336 B |         3 | `(GC root)`                                                                          |
+| 0.6% | 112 B |         1 | `.ext.quicksurveys.init Object`                                                      |
+| 0.6% | 112 B |         1 | `FunctionExecutable ← Function ← .declarator Object ← .jquery.spinner.styles Object` |
+| 0.6% | 112 B |         1 | `.ext.checkUser.clientHints Object`                                                  |
+| 0.6% | 112 B |         1 | `.wikibase.client.vector-2022 Object`                                                |
+
+##### `HTMLInputElement`
+
+|     % |     Size | Instances | Path                     |
+| ----: | -------: | --------: | ------------------------ |
+| 70.9% | 12.2 KiB |         4 | `(GC root)`              |
+|  3.8% |    675 B |         1 | `Window`                 |
+|  1.8% |    325 B |         1 | `.FormMetadataJS Window` |
+|  0.5% |     81 B |         1 | `[252] Array`            |
+|  0.5% |     81 B |         1 | `[317] Array`            |
+
+##### `MultimediaViewerBootstrap`
+
+|      % |     Size | Instances | Path        |
+| -----: | -------: | --------: | ----------- |
+| 100.0% | 14.5 KiB |         2 | `(GC root)` |
+
+##### `HTMLButtonElement`
+
+|     % |     Size | Instances | Path                     |
+| ----: | -------: | --------: | ------------------------ |
+| 63.4% | 9.02 KiB |        13 | `(GC root)`              |
+| 10.0% | 1.42 KiB |        10 | `.FormMetadataJS Window` |
+|  4.0% |    580 B |         1 | `Window`                 |
+|  0.6% |     81 B |         1 | `[261] Array`            |
+|  0.6% |     81 B |         1 | `[262] Array`            |
+
+##### `Node`
+
+|     % |     Size | Instances | Path              |
+| ----: | -------: | --------: | ----------------- |
+| 86.7% | 12.3 KiB |         7 | `(GC root)`       |
+|  9.9% |  1.4 KiB |         5 | `Window`          |
+|  3.4% |    498 B |         2 | `Window ← <root>` |
+
+##### `Promise`
+
+|     % |     Size | Instances | Path                                                                                                                                                                   |
+| ----: | -------: | --------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 50.7% | 6.61 KiB |         1 | `.promise Object ← .preview Object ← .u JSLexicalEnvironment`                                                                                                          |
+| 46.4% | 6.05 KiB |         1 | `.i JSLexicalEnvironment ← Function ← .abort Promise ← .promise Object ← .preview Object ← .u JSLexicalEnvironment`                                                    |
+| 22.0% | 2.88 KiB |         1 | `.capturedPromise JSLexicalEnvironment ← Function ← .t JSLexicalEnvironment ← Function ← <root>`                                                                       |
+|  9.7% | 1.27 KiB |         1 | `.promise Object ← .globalContext Object ← .context Object ← Promise ← .capturedPromise JSLexicalEnvironment ← Function ← .t JSLexicalEnvironment ← Function ← <root>` |
+|  7.8% | 1.01 KiB |         1 | `(GC root)`                                                                                                                                                            |
+
+##### `HTMLDocument`
+
+|     % |     Size | Instances | Path                 |
+| ----: | -------: | --------: | -------------------- |
+| 83.1% | 10.8 KiB |         6 | `(GC root)`          |
+|  8.3% | 1.08 KiB |         2 | `Window ← <root>`    |
+|  7.1% |    952 B |         4 | `Structure ← Window` |
+|  1.4% |    192 B |         4 | `.document Window`   |
+
+##### `InjectedScriptHost`
+
+|      % |     Size | Instances | Path                                      |
+| -----: | -------: | --------: | ----------------------------------------- |
+| 100.0% | 9.18 KiB |         6 | `<root>`                                  |
+|  90.8% | 8.34 KiB |         6 | `Structure ← InjectedScriptHost ← <root>` |
+
+##### `Array Iterator`
+
+|     % |     Size | Instances | Path              |
+| ----: | -------: | --------: | ----------------- |
+| 84.4% | 6.33 KiB |         5 | `Window`          |
+| 15.6% | 1.17 KiB |         2 | `Window ← <root>` |
+
+##### `JSGlobalLexicalEnvironment`
+
+|     % |     Size | Instances | Path        |
+| ----: | -------: | --------: | ----------- |
+| 89.5% | 6.02 KiB |         4 | `(GC root)` |
+| 10.5% |    720 B |         3 | `Window`    |
+
+##### `StructureChain`
+
+|    % | Size | Instances | Path                                                                                                            |
+| ---: | ---: | --------: | --------------------------------------------------------------------------------------------------------------- |
+| 0.4% | 16 B |         1 | `Structure ← Function ← <root>`                                                                                 |
+| 0.4% | 16 B |         1 | `Structure ← InjectedScript ← <root>`                                                                           |
+| 0.4% | 16 B |         1 | `Structure ← Function ← .CallFrameProxy Function ← <root>`                                                      |
+| 0.4% | 16 B |         1 | `Structure ← Function ← .CommandLineAPI JSLexicalEnvironment ← JSLexicalEnvironment ← <root>`                   |
+| 0.4% | 16 B |         1 | `Structure ← Object ← .methods Function ← .CommandLineAPI JSLexicalEnvironment ← JSLexicalEnvironment ← <root>` |
+
+##### `CommandLineAPIHost`
+
+|      % |     Size | Instances | Path                                      |
+| -----: | -------: | --------: | ----------------------------------------- |
+| 100.0% | 4.22 KiB |         6 | `<root>`                                  |
+|  80.0% | 3.38 KiB |         6 | `Structure ← CommandLineAPIHost ← <root>` |
+
+##### `AsyncFunction`
+
+|     % |     Size | Instances | Path                                           |
+| ----: | -------: | --------: | ---------------------------------------------- |
+| 72.2% | 2.96 KiB |         5 | `Window`                                       |
+| 28.6% | 1.17 KiB |         5 | `.constructor AsyncFunction ← Window`          |
+| 27.8% | 1.14 KiB |         2 | `Window ← <root>`                              |
+| 11.4% |    480 B |         2 | `.constructor AsyncFunction ← Window ← <root>` |
+
+##### `AsyncGeneratorFunction`
+
+|     % |     Size | Instances | Path                                                    |
+| ----: | -------: | --------: | ------------------------------------------------------- |
+| 71.4% | 2.28 KiB |         5 | `Window`                                                |
+| 38.2% | 1.22 KiB |         5 | `.constructor AsyncGeneratorFunction ← Window`          |
+| 28.6% |    932 B |         2 | `Window ← <root>`                                       |
+| 15.3% |    498 B |         2 | `.constructor AsyncGeneratorFunction ← Window ← <root>` |
+
+##### `GeneratorFunction`
+
+|     % |     Size | Instances | Path                                               |
+| ----: | -------: | --------: | -------------------------------------------------- |
+| 71.4% | 2.23 KiB |         5 | `Window`                                           |
+| 38.2% | 1.19 KiB |         5 | `.constructor GeneratorFunction ← Window`          |
+| 28.6% |    912 B |         2 | `Window ← <root>`                                  |
+| 15.3% |    488 B |         2 | `.constructor GeneratorFunction ← Window ← <root>` |
+
+##### `CallbackObject`
+
+|     % |  Size | Instances | Path                                                                                                              |
+| ----: | ----: | --------: | ----------------------------------------------------------------------------------------------------------------- |
+| 31.4% | 854 B |         1 | `.ReaderArticleFinderJSController Window`                                                                         |
+| 27.3% | 742 B |         1 | `[0] Array ← ._oneTimeCodeFieldLabelPatternMatchers Object ← .FormMetadataJS Window`                              |
+| 24.4% | 662 B |         1 | `Structure ← CallbackObject ← .ReaderArticleFinderJSController Window`                                            |
+| 20.3% | 550 B |         1 | `Structure ← CallbackObject ← [0] Array ← ._oneTimeCodeFieldLabelPatternMatchers Object ← .FormMetadataJS Window` |
+|  8.2% | 224 B |         1 | `.browser Window ← <root>`                                                                                        |
+
+##### `ProgramExecutable`
+
+|     % |     Size | Instances | Path                                                                      |
+| ----: | -------: | --------: | ------------------------------------------------------------------------- |
+| 66.7% | 1.09 KiB |        10 | `(GC root)`                                                               |
+| 13.3% |    224 B |         2 | `.user.options Object`                                                    |
+| 13.3% |    224 B |         2 | `.hooks JSLexicalEnvironment`                                             |
+|  6.7% |    112 B |         1 | `FunctionExecutable ← Function ← .extractMediaServiceSubscription Window` |
+
+##### `HashMapBucket`
+
+|     % |  Size | Instances | Path                                                                                                                                                |
+| ----: | ----: | --------: | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 23.0% | 342 B |         2 | `Set ← .stacks JSLexicalEnvironment ← Function ← .isFirst JSLexicalEnvironment ← Function ← .maybeLog JSLexicalEnvironment ← .eventInSample Object` |
+| 15.7% | 234 B |         2 | `.stacks JSLexicalEnvironment ← Function ← .isFirst JSLexicalEnvironment ← Function ← .maybeLog JSLexicalEnvironment ← .eventInSample Object`       |
+|  3.2% |  48 B |         1 | `Map ← .state Object`                                                                                                                               |
+|  3.2% |  48 B |         1 | `Map ← ._mapOfUniqueIDToOriginalElement Object`                                                                                                     |
+|  3.2% |  48 B |         1 | `Map ← .queues JSLexicalEnvironment`                                                                                                                |
+
+##### `JSWindowProxy`
+
+|     % |  Size | Instances | Path        |
+| ----: | ----: | --------: | ----------- |
+| 76.9% | 960 B |         5 | `(GC root)` |
+| 23.1% | 288 B |         1 | `<root>`    |
+
+##### `Callee`
+
+|     % |  Size | Instances | Path              |
+| ----: | ----: | --------: | ----------------- |
+| 71.4% | 320 B |        10 | `Window`          |
+| 28.6% | 128 B |         4 | `Window ← <root>` |
+
+##### `SparseArrayValueMap`
+
+|     % |  Size | Instances | Path                                                                                                        |
+| ----: | ----: | --------: | ----------------------------------------------------------------------------------------------------------- |
+| 34.7% | 102 B |         2 | `Object`                                                                                                    |
+| 21.8% |  64 B |         2 | `Object ← .xhrSuccessStatus JSLexicalEnvironment`                                                           |
+| 21.8% |  64 B |         2 | `Object ← .ENTRYPOINT_TYPE Object ← .exports Object ← .module Object ← .ext.uls.rewrite.entrypoints Object` |
+| 21.8% |  64 B |         2 | `Object ← .ULS_MODE Object ← .exports Object ← .module Object ← .ext.uls.rewrite.entrypoints Object`        |
+
 ## Largest strings
 
 Strings ranked by bytes allocated for them.
+
+### Categories
+
+#### String
 
 |    % |     Size | Path                                                                           |
 | ---: | -------: | ------------------------------------------------------------------------------ |

--- a/examples/output/javascript.safari.diff.jsc-heap-snapshot.json.md
+++ b/examples/output/javascript.safari.diff.jsc-heap-snapshot.json.md
@@ -32,6 +32,30 @@ Constructors with the largest increase in self size.
 |    ~0% |      +224 B |       12.5% |             1.3 MiB | 12,175 → 12,177 | `Structure`         |
 |    ~0% |       +37 B |        4.1% |             434 KiB |          13,414 | `Function`          |
 
+##### Code
+
+| Change |       Delta |           % |              Size | Instances | Constructor         |
+| -----: | ----------: | ----------: | ----------------: | --------: | ------------------- |
+|  +2.2% | +11.824 KiB | 5.0% → 5.1% | 533 KiB → 545 KiB | 162 → 165 | `FunctionCodeBlock` |
+
+##### Object shape
+
+| Change |  Delta |     % |    Size |       Instances | Constructor |
+| -----: | -----: | ----: | ------: | --------------: | ----------- |
+|    ~0% | +224 B | 12.5% | 1.3 MiB | 12,175 → 12,177 | `Structure` |
+
+##### Internal
+
+| Change |      Delta |    % |                Size | Instances | Constructor        |
+| -----: | ---------: | ---: | ------------------: | --------: | ------------------ |
+| +16.4% | +2.968 KiB | 0.2% | 18.1 KiB → 21.1 KiB | 232 → 270 | `FunctionRareData` |
+
+##### Function
+
+| Change | Delta |    % |    Size | Instances | Constructor |
+| -----: | ----: | ---: | ------: | --------: | ----------- |
+|    ~0% | +37 B | 4.1% | 434 KiB |    13,414 | `Function`  |
+
 #### Improvements
 
 Constructors with the largest decrease in self size.
@@ -40,6 +64,18 @@ Constructors with the largest decrease in self size.
 | -----: | ---------: | ----: | ------------------: | ------------: | --------------------------- |
 |  -0.1% | -1.085 KiB |  9.0% |   962 KiB → 961 KiB | 1,660 → 1,658 | `UnlinkedFunctionCodeBlock` |
 |  -0.4% |      -16 B | <0.1% | 4.41 KiB → 4.39 KiB |     282 → 281 | `StructureChain`            |
+
+##### Code
+
+| Change |      Delta |    % |              Size |     Instances | Constructor                 |
+| -----: | ---------: | ---: | ----------------: | ------------: | --------------------------- |
+|  -0.1% | -1.085 KiB | 9.0% | 962 KiB → 961 KiB | 1,660 → 1,658 | `UnlinkedFunctionCodeBlock` |
+
+##### Internal
+
+| Change | Delta |     % |                Size | Instances | Constructor      |
+| -----: | ----: | ----: | ------------------: | --------: | ---------------- |
+|  -0.4% | -16 B | <0.1% | 4.41 KiB → 4.39 KiB | 282 → 281 | `StructureChain` |
 
 ### Retained size
 
@@ -65,6 +101,39 @@ Constructors with the largest increase in retained size.
 |  +0.3% |       +98 B |          0.3% | 32.2 KiB → 32.3 KiB |        20 | `Map`                  |
 |  +1.2% |       +48 B |         <0.1% | 3.85 KiB → 3.89 KiB |         4 | `CharacterData`        |
 
+##### Code
+
+| Change |       Delta |             % |                Size | Instances | Constructor          |
+| -----: | ----------: | ------------: | ------------------: | --------: | -------------------- |
+|  +2.2% | +44.456 KiB | 18.9% → 19.3% | 1.97 MiB → 2.01 MiB |     7,600 | `FunctionExecutable` |
+|  +2.2% | +11.825 KiB |   5.0% → 5.1% |   535 KiB → 547 KiB | 162 → 165 | `FunctionCodeBlock`  |
+
+##### Internal
+
+| Change |       Delta |           % |              Size | Instances | Constructor            |
+| -----: | ----------: | ----------: | ----------------: | --------: | ---------------------- |
+|  +3.2% | +25.972 KiB | 7.6% → 7.8% | 811 KiB → 837 KiB |     2,030 | `JSLexicalEnvironment` |
+|  +6.7% | +13.175 KiB | 1.8% → 2.0% | 197 KiB → 210 KiB | 232 → 270 | `FunctionRareData`     |
+|    ~0% |      +112 B | 4.3% → 4.2% |           454 KiB |       893 | `StructureRareData`    |
+
+##### Object
+
+| Change |  Delta |     % |                Size | Instances | Constructor          |
+| -----: | -----: | ----: | ------------------: | --------: | -------------------- |
+|  +4.0% | +560 B |  0.1% | 13.7 KiB → 14.2 KiB |        14 | `Node`               |
+|  +0.4% | +256 B |  0.5% | 56.5 KiB → 56.7 KiB |        10 | `Element`            |
+|  +0.3% | +256 B |  0.8% | 83.3 KiB → 83.5 KiB |       205 | `HTMLElement`        |
+|  +2.5% | +160 B |  0.1% | 6.35 KiB → 6.51 KiB |        14 | `EventTarget`        |
+|  +5.8% | +144 B | <0.1% | 2.44 KiB → 2.58 KiB |        23 | `HTMLHeadingElement` |
+|  +0.3% |  +98 B |  0.3% | 32.2 KiB → 32.3 KiB |        20 | `Map`                |
+|  +1.2% |  +48 B | <0.1% | 3.85 KiB → 3.89 KiB |         4 | `CharacterData`      |
+
+##### Function
+
+| Change |       Delta |             % |                Size | Instances | Constructor |
+| -----: | ----------: | ------------: | ------------------: | --------: | ----------- |
+|  +0.7% | +20.129 KiB | 27.9% → 28.1% | 2.91 MiB → 2.93 MiB |    13,414 | `Function`  |
+
 #### Improvements
 
 Constructors with the largest decrease in retained size.
@@ -80,3 +149,37 @@ Constructors with the largest decrease in retained size.
 |  -4.2% |      -160 B |         <0.1% | 3.71 KiB → 3.55 KiB |               1 | `Range`                      |
 |  -0.1% |       -48 B |          0.4% | 43.5 KiB → 43.4 KiB |           1,330 | `DOMRect`                    |
 |  -0.4% |       -16 B |         <0.1% | 4.41 KiB → 4.39 KiB |       282 → 281 | `StructureChain`             |
+
+##### Code
+
+| Change |      Delta |     % |     Size |     Instances | Constructor                  |
+| -----: | ---------: | ----: | -------: | ------------: | ---------------------------- |
+|  -0.1% | -1.351 KiB | 15.6% | 1.62 MiB |         6,041 | `UnlinkedFunctionExecutable` |
+|  -0.1% | -1.261 KiB | 11.2% | 1.17 MiB | 1,660 → 1,658 | `UnlinkedFunctionCodeBlock`  |
+
+##### Object shape
+
+| Change |      Delta |             % |     Size |       Instances | Constructor |
+| -----: | ---------: | ------------: | -------: | --------------: | ----------- |
+|  -0.2% | -3.481 KiB | 17.8% → 17.7% | 1.85 MiB | 12,175 → 12,177 | `Structure` |
+
+##### Internal
+
+| Change | Delta |     % |                Size | Instances | Constructor      |
+| -----: | ----: | ----: | ------------------: | --------: | ---------------- |
+|  -0.4% | -16 B | <0.1% | 4.41 KiB → 4.39 KiB | 282 → 281 | `StructureChain` |
+
+##### Object
+
+| Change |       Delta |             % |                Size | Instances | Constructor |
+| -----: | ----------: | ------------: | ------------------: | --------: | ----------- |
+|  -2.1% | -22.077 KiB |   9.7% → 9.5% | 1.01 MiB → 1015 KiB |        14 | `Window`    |
+|    ~0% |  -1.354 KiB | 55.3% → 55.2% |            5.76 MiB |    11,833 | `Object`    |
+|  -4.2% |      -160 B |         <0.1% | 3.71 KiB → 3.55 KiB |         1 | `Range`     |
+|  -0.1% |       -48 B |          0.4% | 43.5 KiB → 43.4 KiB |     1,330 | `DOMRect`   |
+
+##### Array
+
+| Change |  Delta |    % |              Size | Instances | Constructor |
+| -----: | -----: | ---: | ----------------: | --------: | ----------- |
+|  -0.1% | -708 B | 6.1% | 650 KiB → 649 KiB |     7,409 | `Array`     |

--- a/examples/output/julia.profile-jl.base.heapsnapshot.md
+++ b/examples/output/julia.profile-jl.base.heapsnapshot.md
@@ -22,6 +22,10 @@ Allocated 155 MiB across 1,797,991 nodes and 5,735,164 edges.
 
 Constructors ranked by bytes allocated for their instances, excluding nodes kept reachable by them.
 
+#### Categories
+
+##### Object
+
 |     % |     Size | Instances | Constructor                                                                                                   |
 | ----: | -------: | --------: | ------------------------------------------------------------------------------------------------------------- |
 |  6.4% | 9.88 MiB |   120,343 | `<generic memory - inline alloc>`                                                                             |
@@ -184,6 +188,10 @@ Instances ranked by contribution to each constructor's self size.
 ### Retained size
 
 Constructors ranked by bytes allocated for their instances and all nodes that would be freed if their instances were garbage collected.
+
+#### Categories
+
+##### Object
 
 |     % |     Size | Instances | Constructor                                                                                                   |
 | ----: | -------: | --------: | ------------------------------------------------------------------------------------------------------------- |

--- a/examples/output/julia.profile-jl.current.heapsnapshot.md
+++ b/examples/output/julia.profile-jl.current.heapsnapshot.md
@@ -22,6 +22,10 @@ Allocated 155 MiB across 1,797,991 nodes and 5,735,169 edges.
 
 Constructors ranked by bytes allocated for their instances, excluding nodes kept reachable by them.
 
+#### Categories
+
+##### Object
+
 |     % |     Size | Instances | Constructor                                                                                                   |
 | ----: | -------: | --------: | ------------------------------------------------------------------------------------------------------------- |
 |  6.4% | 9.88 MiB |   120,343 | `<generic memory - inline alloc>`                                                                             |
@@ -184,6 +188,10 @@ Instances ranked by contribution to each constructor's self size.
 ### Retained size
 
 Constructors ranked by bytes allocated for their instances and all nodes that would be freed if their instances were garbage collected.
+
+#### Categories
+
+##### Object
 
 |     % |     Size | Instances | Constructor                                                                                                   |
 | ----: | -------: | --------: | ------------------------------------------------------------------------------------------------------------- |

--- a/examples/output/julia.profile-jl.diff.heapsnapshot.md
+++ b/examples/output/julia.profile-jl.diff.heapsnapshot.md
@@ -26,6 +26,8 @@ Constructors ranked by bytes allocated for their instances, excluding nodes kept
 
 Constructors with the largest decrease in self size.
 
+##### Object
+
 | Change |  Delta |    % |     Size | Instances | Constructor                       |
 | -----: | -----: | ---: | -------: | --------: | --------------------------------- |
 |    ~0% | -128 B | 6.4% | 9.88 MiB |   120,343 | `<generic memory - inline alloc>` |
@@ -37,6 +39,8 @@ Constructors ranked by bytes allocated for their instances and all nodes that wo
 #### Improvements
 
 Constructors with the largest decrease in retained size.
+
+##### Object
 
 | Change |  Delta |    % |     Size | Instances | Constructor                       |
 | -----: | -----: | ---: | -------: | --------: | --------------------------------- |

--- a/src/formats/jsc-heap-snapshot/index.test.ts
+++ b/src/formats/jsc-heap-snapshot/index.test.ts
@@ -5,7 +5,7 @@ import {
   selfSizeTables,
 } from '../../modalities/heap-snapshot/testing.ts'
 import { normalizeProfileToMdOptions } from '../../options.ts'
-import { categoryTables } from '../../testing.ts'
+import { categorySectionTables, categoryTables } from '../../testing.ts'
 import { convertJsonToMd } from '../testing.ts'
 import { jscHeapSnapshotConverter } from './index.ts'
 import {
@@ -221,6 +221,50 @@ describe(`convert`, () => {
     expect(
       largestStringsTables(md).map(table => table.map(row => row.Path)),
     ).toEqual([[`Structure`]])
+  })
+
+  test(`categorizes a constructor whose nodes all report zero self size by its first node`, () => {
+    const snapshot = makeJSCSnapshot({
+      nodes: [
+        ...makeJSCNode({ id: 0, size: 0, nameIndex: 0, flags: NODE_INTERNAL }),
+        ...makeJSCNode({ id: 1, size: 0, nameIndex: 1 }),
+        ...makeJSCNode({
+          id: 2,
+          size: 0,
+          nameIndex: 1,
+          flags: NODE_INTERNAL,
+        }),
+        ...makeJSCNode({ id: 3, size: 1000, nameIndex: 2 }),
+        ...makeJSCNode({ id: 4, size: 300, nameIndex: 3 }),
+      ],
+      nodeClassNames: [`<root>`, `Widget`, `Payload`, `string`],
+      edges: [
+        ...makeJSCEdge({ from: 0, to: 1, type: EDGE_PROPERTY, nameIndex: 0 }),
+        ...makeJSCEdge({ from: 0, to: 2, type: EDGE_PROPERTY, nameIndex: 0 }),
+        ...makeJSCEdge({ from: 0, to: 3, type: EDGE_PROPERTY, nameIndex: 0 }),
+        ...makeJSCEdge({ from: 1, to: 4, type: EDGE_PROPERTY, nameIndex: 0 }),
+      ],
+      edgeNames: [`ref`],
+    })
+
+    const md = convertJsonToMd(
+      jscHeapSnapshotConverter,
+      snapshot,
+      normalizeProfileToMdOptions(),
+    )
+
+    // `Widget` holds no bytes of its own, so no node of it outweighs another.
+    expect(categorySectionTables(md, `Retained size`)).toEqual({
+      Object: [
+        {
+          '%': `76.9%`,
+          Size: `1000 B`,
+          Instances: `1`,
+          Constructor: `Payload`,
+        },
+        { '%': `23.1%`, Size: `300 B`, Instances: `2`, Constructor: `Widget` },
+      ],
+    })
   })
 
   test(`out-of-bounds edge ordinal does not crash`, () => {

--- a/src/modalities/call-graph/format.ts
+++ b/src/modalities/call-graph/format.ts
@@ -14,7 +14,7 @@ import {
 import type { FormattingProfileToMdOptions } from '../../options.ts'
 import {
   formatRankingTables,
-  rankFunctions,
+  rankEntities,
   subsectionCategories,
   subsectionDiffCategories,
 } from '../category.ts'
@@ -198,19 +198,19 @@ const formatHottestSelfFunctions = ({
 }): RootContent[] => {
   const { metric, index } = measure
   const valueOf = (func: AggregatedCallGraphFunction) => func.selfValues[index]!
-  const ranking = rankFunctions({
-    functions: graph.functions.filter(
+  const ranking = rankEntities({
+    entities: graph.functions.filter(
       func => options.showEntry(func) && valueOf(func) > 0,
     ),
     categories,
     valueOf,
     topN: options.topN,
   })
-  if (ranking.hottestFunctions.length === 0) {
+  if (ranking.rankedEntities.length === 0) {
     return []
   }
 
-  const hottestLinesSections = ranking.displayedFunctions
+  const hottestLinesSections = ranking.displayedEntities
     .filter(func => func.lineToMetrics.size > 0)
     .flatMap(func =>
       formatHottestLines({
@@ -228,7 +228,7 @@ const formatHottestSelfFunctions = ({
     ),
     ...formatRankingTables({
       ranking,
-      formatFunctionTable: functions =>
+      formatEntityTable: functions =>
         formatFunctionTable({
           functions,
           metric,
@@ -319,21 +319,21 @@ const formatHottestTotalFunctions = ({
   const { metric, index } = measure
   const valueOf = (func: AggregatedCallGraphFunction) =>
     func.totalValues[index]!
-  const ranking = rankFunctions({
-    functions: graph.functions.filter(
+  const ranking = rankEntities({
+    entities: graph.functions.filter(
       func => options.showEntry(func) && valueOf(func) > 0,
     ),
     categories,
     valueOf,
     topN: options.topN,
   })
-  if (ranking.hottestFunctions.length === 0) {
+  if (ranking.rankedEntities.length === 0) {
     return []
   }
 
-  const { displayedFunctions } = ranking
+  const { displayedEntities } = ranking
   const hasCallCounts = graphHasCallCounts(graph)
-  const callerSections = displayedFunctions.flatMap(func =>
+  const callerSections = displayedEntities.flatMap(func =>
     formatHottestArcs({
       measure,
       func,
@@ -343,7 +343,7 @@ const formatHottestTotalFunctions = ({
       headingLevel: headingLevel + 2,
     }),
   )
-  const calleeSections = displayedFunctions.flatMap(func =>
+  const calleeSections = displayedEntities.flatMap(func =>
     formatHottestArcs({
       measure,
       func,
@@ -361,7 +361,7 @@ const formatHottestTotalFunctions = ({
     ),
     ...formatRankingTables({
       ranking,
-      formatFunctionTable: functions =>
+      formatEntityTable: functions =>
         formatFunctionTable({
           functions,
           metric,

--- a/src/modalities/call-stack-profile/format.ts
+++ b/src/modalities/call-stack-profile/format.ts
@@ -21,7 +21,7 @@ import {
 import type { FormattingProfileToMdOptions } from '../../options.ts'
 import {
   formatRankingTables,
-  rankFunctions,
+  rankEntities,
   subsectionCategories,
   subsectionDiffCategories,
 } from '../category.ts'
@@ -333,21 +333,21 @@ const formatHottestSelfFunctions = ({
   const valueOf = (func: AggregatedCallStackProfileFunction) =>
     selfValueOf(measure, func)
   const countOf = (func: AggregatedCallStackProfileFunction) => func.selfCount
-  const ranking = rankFunctions({
-    functions: profile.functions.filter(
+  const ranking = rankEntities({
+    entities: profile.functions.filter(
       func => options.showEntry(func) && valueOf(func) > 0,
     ),
     categories,
     valueOf,
     topN: options.topN,
   })
-  if (ranking.hottestFunctions.length === 0) {
+  if (ranking.rankedEntities.length === 0) {
     return []
   }
 
   const { metric } = measure
-  const { displayedFunctions } = ranking
-  const hottestLinesSections = displayedFunctions
+  const { displayedEntities } = ranking
+  const hottestLinesSections = displayedEntities
     .filter(func => func.lineToMetrics.size > 0)
     .flatMap(func =>
       formatHottestLines({
@@ -357,7 +357,7 @@ const formatHottestSelfFunctions = ({
         headingLevel: headingLevel + 2,
       }),
     )
-  const hottestCallersSections = displayedFunctions.flatMap(func =>
+  const hottestCallersSections = displayedEntities.flatMap(func =>
     formatHottestCallers({
       measure,
       func,
@@ -373,7 +373,7 @@ const formatHottestSelfFunctions = ({
     ),
     ...formatRankingTables({
       ranking,
-      formatFunctionTable: functions =>
+      formatEntityTable: functions =>
         formatFunctionTable({ functions, measure, valueOf, countOf, options }),
       headingLevel: headingLevel + 1,
     }),
@@ -510,20 +510,20 @@ const formatHottestTotalFunctions = ({
   const valueOf = (func: AggregatedCallStackProfileFunction) =>
     totalValueOf(measure, func)
   const countOf = (func: AggregatedCallStackProfileFunction) => func.totalCount
-  const ranking = rankFunctions({
-    functions: profile.functions.filter(
+  const ranking = rankEntities({
+    entities: profile.functions.filter(
       func => options.showEntry(func) && valueOf(func) > 0,
     ),
     categories,
     valueOf,
     topN: options.topN,
   })
-  if (ranking.hottestFunctions.length === 0) {
+  if (ranking.rankedEntities.length === 0) {
     return []
   }
 
   const { metric } = measure
-  const calleeSections = ranking.displayedFunctions.flatMap(func =>
+  const calleeSections = ranking.displayedEntities.flatMap(func =>
     formatHottestCallees({
       measure,
       func,
@@ -539,7 +539,7 @@ const formatHottestTotalFunctions = ({
     ),
     ...formatRankingTables({
       ranking,
-      formatFunctionTable: functions =>
+      formatEntityTable: functions =>
         formatFunctionTable({ functions, measure, valueOf, countOf, options }),
       headingLevel: headingLevel + 1,
     }),

--- a/src/modalities/category.ts
+++ b/src/modalities/category.ts
@@ -1,6 +1,6 @@
 /**
  * Splitting a ranking into per-category subsections, shared by the modalities
- * that categorize functions.
+ * that categorize the entities they rank.
  */
 
 import type { RootContent } from 'mdast'
@@ -83,82 +83,81 @@ export const subsectionDiffCategories = <Entry, Category extends string>({
     minCategoryShare,
   )
 
-/** The functions a ranking displays, overall and within each category. */
-export type FunctionRanking<Func> = {
-  hottestFunctions: Func[]
-  categoryRankings: { category: Category; functions: Func[] }[]
-  displayedFunctions: Func[]
+/** The entities a ranking displays, overall and within each category. */
+export type EntityRanking<Entity> = {
+  rankedEntities: Entity[]
+  categoryRankings: { category: Category; entities: Entity[] }[]
+  displayedEntities: Entity[]
 }
 
 /**
- * Ranks {@link functions} by {@link valueOf}, overall and within each of
+ * Ranks {@link entities} by {@link valueOf}, overall and within each of
  * {@link categories}, keeping the top {@link topN} of each.
  *
- * Every ranked function has the same breakdowns below it, whichever ranking
- * displays it, so {@link FunctionRanking.displayedFunctions} contains each
- * function once, sorted by {@link valueOf} like the rankings above it.
+ * Every ranked entity has the same breakdowns below it, whichever ranking
+ * displays it, so {@link EntityRanking.displayedEntities} contains each entity
+ * once, sorted by {@link valueOf} like the rankings above it.
  */
-export const rankFunctions = <Func extends { category: Category }>({
-  functions,
+export const rankEntities = <Entity extends { category: Category }>({
+  entities,
   categories,
   valueOf,
   topN,
 }: {
-  functions: Func[]
+  entities: Entity[]
   categories: Category[]
-  valueOf: (func: Func) => number
+  valueOf: (entity: Entity) => number
   topN: number
-}): FunctionRanking<Func> => {
-  const hottestFunctions = selectTopN(functions, topN, valueOf)
+}): EntityRanking<Entity> => {
+  const rankedEntities = selectTopN(entities, topN, valueOf)
   const categoryRankings = categories.map(category => ({
     category,
-    functions: selectTopN(
-      functions.filter(func => func.category === category),
+    entities: selectTopN(
+      entities.filter(entity => entity.category === category),
       topN,
       valueOf,
     ),
   }))
-  const displayedFunctions = [
+  const displayedEntities = [
     ...new Set([
-      ...hottestFunctions,
-      ...categoryRankings.flatMap(({ functions }) => functions),
+      ...rankedEntities,
+      ...categoryRankings.flatMap(({ entities }) => entities),
     ]),
-  ].sort((func1, func2) => valueOf(func2) - valueOf(func1))
-  return { hottestFunctions, categoryRankings, displayedFunctions }
+  ].sort((entity1, entity2) => valueOf(entity2) - valueOf(entity1))
+  return { rankedEntities, categoryRankings, displayedEntities }
 }
 
 /**
- * The table ranking {@link FunctionRanking.hottestFunctions}, followed by the
+ * The table ranking {@link EntityRanking.rankedEntities}, followed by the
  * per-category subsections repeating that ranking within each category.
- * {@link formatFunctionTable} builds every table.
+ * {@link formatEntityTable} builds every table.
  *
- * A category subsection ranking exactly the hottest functions repeats the
- * overall table, so the table shows once, under the heading naming that
- * category.
+ * A category subsection ranking exactly the ranked entities repeats the overall
+ * table, so the table shows once, under the heading naming that category.
  */
-export const formatRankingTables = <Func>({
-  ranking: { hottestFunctions, categoryRankings },
-  formatFunctionTable,
+export const formatRankingTables = <Entity>({
+  ranking: { rankedEntities, categoryRankings },
+  formatEntityTable,
   headingLevel,
 }: {
-  ranking: FunctionRanking<Func>
-  formatFunctionTable: (functions: Func[]) => RootContent
+  ranking: EntityRanking<Entity>
+  formatEntityTable: (entities: Entity[]) => RootContent
   headingLevel: number
 }): RootContent[] => [
   ...(isRepeatedByCategory(
-    hottestFunctions,
-    categoryRankings.map(({ functions }) => functions),
+    rankedEntities,
+    categoryRankings.map(({ entities }) => entities),
   )
     ? []
-    : [formatFunctionTable(hottestFunctions)]),
+    : [formatEntityTable(rankedEntities)]),
   ...formatSectionGroup(
     [heading(headingLevel, `Categories`)],
-    categoryRankings.flatMap(({ category, functions }) =>
-      functions.length === 0
+    categoryRankings.flatMap(({ category, entities }) =>
+      entities.length === 0
         ? []
         : [
             heading(headingLevel + 1, formatCategory(category)),
-            formatFunctionTable(functions),
+            formatEntityTable(entities),
           ],
     ),
   ),

--- a/src/modalities/format.ts
+++ b/src/modalities/format.ts
@@ -164,7 +164,7 @@ export const formatDiffFunctionSections = <Entity, Row>({
 }): RootContent[] => {
   const sections = [
     ...formatDiffRankingSections({
-      headingLevel,
+      headingLevel: headingLevel + 1,
       subtitle: `Regressions`,
       sentence: `Functions with the largest increase in ${description}.`,
       columns,
@@ -174,7 +174,7 @@ export const formatDiffFunctionSections = <Entity, Row>({
       rowOf,
     }),
     ...formatDiffRankingSections({
-      headingLevel,
+      headingLevel: headingLevel + 1,
       subtitle: `Improvements`,
       sentence: `Functions with the largest decrease in ${description}.`,
       columns,
@@ -196,10 +196,11 @@ export const formatDiffFunctionSections = <Entity, Row>({
 }
 
 /**
- * One ranking's subsection: the {@link subtitle} heading, the {@link sentence}
- * introducing it, and the tables ranking {@link entities}.
+ * One ranking's subsection: the {@link subtitle} heading at
+ * {@link headingLevel}, the {@link sentence} introducing it, and the tables
+ * ranking {@link entities}.
  */
-const formatDiffRankingSections = <Entity, Row>({
+export const formatDiffRankingSections = <Entity, Row>({
   headingLevel,
   subtitle,
   sentence,
@@ -221,10 +222,10 @@ const formatDiffRankingSections = <Entity, Row>({
   entities.length === 0
     ? []
     : [
-        heading(headingLevel + 1, subtitle),
+        heading(headingLevel, subtitle),
         paragraph(sentence),
         ...formatDiffRankingTables({
-          headingLevel: headingLevel + 2,
+          headingLevel: headingLevel + 1,
           columns,
           entities,
           categoryEntities: categoryRankings.map(ranking => ({

--- a/src/modalities/heap-snapshot/aggregate.ts
+++ b/src/modalities/heap-snapshot/aggregate.ts
@@ -6,12 +6,9 @@ import type {
   ProfileEntry,
   ProfileToMdContext,
 } from '../../options.ts'
-import {
-  categorizeHeapSnapshotConstructorForOrigin,
-  categorizeHeapSnapshotDeclaredTypeForOrigin,
-} from '../../origins/index.ts'
-import type { Origin, OriginDetector } from '../../origins/index.ts'
+import type { OriginDetector } from '../../origins/index.ts'
 import type { InputAggregator } from '../aggregator.ts'
+import { EntityCategorizer, NodeCategoryStatsAggregator } from './categorize.ts'
 import { computeImmediateDominatorGraph } from './graph.ts'
 import type { ImmediateDominatorGraph, NodeAdjacencyGraph } from './graph.ts'
 import {
@@ -63,7 +60,9 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
   readonly #keyToFunctionIndex = new Map<string, number>()
   readonly #nodeOrdinalToFunctionIndex: Int32Array
 
-  readonly #strings: AggregatedHeapSnapshotNode[] = []
+  readonly #strings: AggregatedHeapSnapshotString[] = []
+
+  readonly #entityCategorizer = new EntityCategorizer()
 
   readonly #entries: ProfileEntry[]
 
@@ -103,18 +102,13 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
       this.#addCategoryNode(nodeOrdinal, node)
       switch (node.type) {
         case `constructor`:
-          this.#addConstructorNode(
-            nodeOrdinal,
-            node.name,
-            node.location,
-            node.nameLocation,
-          )
+          this.#addConstructorNode(nodeOrdinal, node)
           break
         case `function`:
           this.#addFunctionNode(nodeOrdinal, node.name, node.location)
           break
         case `string`:
-          this.#addStringNode(nodeOrdinal, node.name)
+          this.#addStringNode(nodeOrdinal, node)
           break
         case undefined:
           break
@@ -141,10 +135,9 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
 
   #addConstructorNode(
     nodeOrdinal: number,
-    name: string,
-    location?: SourceLocation,
-    nameLocation?: FileReference,
+    node: Extract<HeapSnapshotNode, { type: `constructor` }>,
   ): void {
+    const { name, location, nameLocation } = node
     const selfSize = this.#selfSizeOf(nodeOrdinal)
     const retainedSize = this.#nodeOrdinalToRetainedSize[nodeOrdinal]!
     let constructorIndex = this.#nameToConstructorIndex.get(name)
@@ -157,6 +150,8 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
         name,
         nameLocation,
         location,
+        // Assigned in `aggregate`, where the origin is known.
+        category: `object`,
         selfSize: 0,
         retainedSize: 0,
         instances: [],
@@ -169,6 +164,7 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
     }
 
     constructor.selfSize += selfSize
+    this.#entityCategorizer.addConstructorNode(constructorIndex, node, selfSize)
     constructor.instances.push({
       type: `node`,
       id: nodeOrdinal,
@@ -214,15 +210,21 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
     this.#nodeOrdinalToFunctionIndex[nodeOrdinal] = functionIndex
   }
 
-  #addStringNode(nodeOrdinal: number, name?: string): void {
+  #addStringNode(
+    nodeOrdinal: number,
+    node: Extract<HeapSnapshotNode, { type: `string` }>,
+  ): void {
     const selfSize = this.#selfSizeOf(nodeOrdinal)
     this.#strings.push({
       type: `node`,
       id: nodeOrdinal,
-      name,
+      name: node.name,
+      // Assigned in `aggregate`, where the origin is known.
+      category: `string`,
       selfSize,
       retainedSize: selfSize,
     })
+    this.#entityCategorizer.addStringNode(node)
   }
 
   public aggregate(
@@ -242,13 +244,20 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
       this.#functions,
     )
 
+    const { origin } = context
+    this.#entityCategorizer.categorize(
+      this.#constructors,
+      this.#strings,
+      origin,
+    )
+
     return {
       type: `heap-snapshot`,
       context,
       totalSize: this.#totalSize,
       nodeCount: this.#nodeCount,
       edgeCount: this.#edgeCount,
-      nodeCategoryToStats: this.#nodeCategoryStats.aggregate(context.origin),
+      nodeCategoryToStats: this.#nodeCategoryStats.aggregate(origin),
       constructors: this.#constructors,
       functions: this.#functions,
       strings: this.#strings,
@@ -272,154 +281,6 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
         ),
     }
   }
-}
-
-/**
- * Aggregates each node's self size and count into its category's stats.
- *
- * A constructor's stats stay keyed by its name until {@link aggregate}, since
- * the origin categorizes it by the class name its language defines and is
- * detected only after the nodes are consumed.
- */
-class NodeCategoryStatsAggregator {
-  /** Stats of the nodes the format categorized, by the category it derived. */
-  readonly #byCategory = new KeyedNodeStats<HeapSnapshotNodeCategory>()
-
-  /**
-   * The same, for a node the format left uncategorized, by the type name it
-   * declared instead.
-   *
-   * Kept separate from the stats above rather than sharing one map keyed by
-   * either, because a format may declare a type name equal to a category name,
-   * and the two mean different things.
-   */
-  readonly #byDeclaredType = new KeyedNodeStats<string>()
-
-  public add(node: HeapSnapshotNode, selfSize: number): void {
-    if (node.category === undefined && node.declaredType !== undefined) {
-      this.#byDeclaredType.add(node, node.declaredType, selfSize)
-    } else {
-      this.#byCategory.add(node, node.category ?? `unknown`, selfSize)
-    }
-  }
-
-  /**
-   * Resolves each node's category: the origin categorizes a constructor by the
-   * class name its language defines, falling back to the category the format
-   * derived from the engine's own node classification.
-   */
-  public aggregate(
-    origin: Origin,
-  ): Map<HeapSnapshotNodeCategory, NodeCategoryStats> {
-    const nodeCategoryToStats = new Map<
-      HeapSnapshotNodeCategory,
-      NodeCategoryStats
-    >()
-
-    this.#byCategory.aggregateInto(
-      nodeCategoryToStats,
-      origin,
-      category => category,
-    )
-    this.#byDeclaredType.aggregateInto(
-      nodeCategoryToStats,
-      origin,
-      declaredType =>
-        categorizeHeapSnapshotDeclaredTypeForOrigin(declaredType, origin) ??
-        `object`,
-    )
-
-    return nodeCategoryToStats
-  }
-}
-
-/**
- * Size and count stats of the nodes sharing a key, which resolves to a category
- * only once the origin is known.
- *
- * A constructor node's stats stay keyed by its name under that key, since the
- * origin categorizes it by the class name its language defines.
- */
-class KeyedNodeStats<Key> {
-  readonly #keyToStats = new Map<Key, NodeCategoryStats>()
-  readonly #keyToConstructorNameToStats = new Map<
-    Key,
-    Map<string, NodeCategoryStats>
-  >()
-
-  public add(node: HeapSnapshotNode, key: Key, selfSize: number): void {
-    const stats = this.#statsOf(node, key)
-    stats.size += selfSize
-    stats.nodeCount++
-  }
-
-  /**
-   * Adds every key's stats to {@link nodeCategoryToStats} under the category
-   * {@link categoryOf} resolves the key to, or the one the origin gives a
-   * constructor's name.
-   */
-  public aggregateInto(
-    nodeCategoryToStats: Map<HeapSnapshotNodeCategory, NodeCategoryStats>,
-    origin: Origin,
-    categoryOf: (key: Key) => HeapSnapshotNodeCategory,
-  ): void {
-    for (const [key, stats] of this.#keyToStats) {
-      addStats(nodeCategoryToStats, categoryOf(key), stats)
-    }
-    for (const [key, nameToStats] of this.#keyToConstructorNameToStats) {
-      // `categoryOf` runs once per key rather than per constructor name, since
-      // one key can have thousands of them.
-      const category = categoryOf(key)
-      for (const [name, stats] of nameToStats) {
-        addStats(
-          nodeCategoryToStats,
-          categorizeHeapSnapshotConstructorForOrigin(name, origin) ?? category,
-          stats,
-        )
-      }
-    }
-  }
-
-  /**
-   * The stats {@link node} aggregates into under {@link key}: its constructor
-   * name's when it has one, and the key's own otherwise.
-   */
-  #statsOf(node: HeapSnapshotNode, key: Key): NodeCategoryStats {
-    if (node.type !== `constructor`) {
-      return statsOf(this.#keyToStats, key)
-    }
-
-    let nameToStats = this.#keyToConstructorNameToStats.get(key)
-    if (!nameToStats) {
-      nameToStats = new Map()
-      this.#keyToConstructorNameToStats.set(key, nameToStats)
-    }
-    return statsOf(nameToStats, node.name)
-  }
-}
-
-/** Adds {@link stats} to the stats {@link key} aggregates into. */
-const addStats = <Key>(
-  keyToStats: Map<Key, NodeCategoryStats>,
-  key: Key,
-  { size, nodeCount }: NodeCategoryStats,
-): void => {
-  const stats = statsOf(keyToStats, key)
-  stats.size += size
-  stats.nodeCount += nodeCount
-}
-
-/** The stats {@link key} aggregates into, inserted empty when it has none. */
-const statsOf = <Key>(
-  keyToStats: Map<Key, NodeCategoryStats>,
-  key: Key,
-): NodeCategoryStats => {
-  let stats = keyToStats.get(key)
-  if (!stats) {
-    stats = { size: 0, nodeCount: 0 }
-    keyToStats.set(key, stats)
-  }
-  return stats
 }
 
 /**
@@ -571,6 +432,13 @@ export type AggregatedHeapSnapshotNode = {
   selfSize: number
 
   /**
+   * What this node holds, set on the entities a ranking breaks down by
+   * category: constructors and strings. An instance of a constructor has none,
+   * since its constructor's category stands for it.
+   */
+  category?: HeapSnapshotNodeCategory
+
+  /**
    * Bytes allocated for this node, as well as all nodes that would be freed if
    * the node were garbage collected.
    */
@@ -584,8 +452,19 @@ export type AggregatedHeapSnapshotConstructor = AggregatedHeapSnapshotNode & {
   /** A human readable label for this constructor. */
   name: string
 
+  /**
+   * What this constructor's instances hold, taken from the category holding the
+   * most of their self size.
+   */
+  category: HeapSnapshotNodeCategory
+
   /** Instances of this constructor and their sizes. */
   instances: AggregatedHeapSnapshotNode[]
+}
+
+export type AggregatedHeapSnapshotString = AggregatedHeapSnapshotNode & {
+  /** What this string holds: its representation in the heap. */
+  category: HeapSnapshotNodeCategory
 }
 
 export type AggregatedHeapSnapshotFunction = AggregatedHeapSnapshotNode & {
@@ -624,7 +503,7 @@ export type AggregatedHeapSnapshot = {
 
   constructors: AggregatedHeapSnapshotConstructor[]
   functions: AggregatedHeapSnapshotFunction[]
-  strings: AggregatedHeapSnapshotNode[]
+  strings: AggregatedHeapSnapshotString[]
 
   retainerPathOf: (
     nodeOrdinal: number,

--- a/src/modalities/heap-snapshot/categorize.ts
+++ b/src/modalities/heap-snapshot/categorize.ts
@@ -1,0 +1,352 @@
+/**
+ * Categorizing a heap snapshot's nodes and the entities they aggregate into.
+ *
+ * A category resolves only once the origin is known, since the origin
+ * categorizes a constructor by the class name its language defines and maps the
+ * type names a format declares itself. The aggregators here accumulate sizes
+ * under a key while the nodes are consumed, and resolve that key to a category
+ * afterwards.
+ */
+
+import {
+  categorizeHeapSnapshotConstructorForOrigin,
+  categorizeHeapSnapshotDeclaredTypeForOrigin,
+} from '../../origins/index.ts'
+import type { Origin } from '../../origins/index.ts'
+import type { NodeCategoryStats } from './aggregate.ts'
+import { HEAP_SNAPSHOT_NODE_CATEGORIES } from './type.ts'
+import type { HeapSnapshotNode, HeapSnapshotNodeCategory } from './type.ts'
+
+/**
+ * Aggregates each node's self size and count into its category's stats.
+ *
+ * A constructor's stats stay keyed by its name until {@link aggregate}, since
+ * the origin categorizes it by the class name its language defines. The origin
+ * is detected only after the nodes are consumed.
+ */
+export class NodeCategoryStatsAggregator {
+  /** Stats of the nodes the format categorized, by the category it derived. */
+  readonly #byCategory = new KeyedNodeStats<HeapSnapshotNodeCategory>()
+
+  /**
+   * The same, for a node the format left uncategorized, by the type name it
+   * declared instead.
+   *
+   * Kept separate from the stats above rather than sharing one map keyed by
+   * either, because a format may declare a type name equal to a category name,
+   * and the two mean different things.
+   */
+  readonly #byDeclaredType = new KeyedNodeStats<string>()
+
+  public add(node: HeapSnapshotNode, selfSize: number): void {
+    if (node.category === undefined && node.declaredType !== undefined) {
+      this.#byDeclaredType.add(node, node.declaredType, selfSize)
+    } else {
+      this.#byCategory.add(node, node.category ?? `unknown`, selfSize)
+    }
+  }
+
+  /**
+   * Resolves each node's category: the origin categorizes a constructor by the
+   * class name its language defines, falling back to the category the format
+   * derived from the engine's own node classification.
+   */
+  public aggregate(
+    origin: Origin,
+  ): Map<HeapSnapshotNodeCategory, NodeCategoryStats> {
+    const nodeCategoryToStats = new Map<
+      HeapSnapshotNodeCategory,
+      NodeCategoryStats
+    >()
+
+    this.#byCategory.aggregateInto(
+      nodeCategoryToStats,
+      origin,
+      category => category,
+    )
+    this.#byDeclaredType.aggregateInto(
+      nodeCategoryToStats,
+      origin,
+      declaredType =>
+        categorizeHeapSnapshotDeclaredTypeForOrigin(declaredType, origin) ??
+        `object`,
+    )
+
+    return nodeCategoryToStats
+  }
+}
+
+/**
+ * Size and count stats of the nodes sharing a key, which resolves to a category
+ * only once the origin is known.
+ *
+ * A constructor node's stats stay keyed by its name under that key, since the
+ * origin categorizes it by the class name its language defines.
+ */
+class KeyedNodeStats<Key> {
+  readonly #keyToStats = new Map<Key, NodeCategoryStats>()
+  readonly #keyToConstructorNameToStats = new Map<
+    Key,
+    Map<string, NodeCategoryStats>
+  >()
+
+  public add(node: HeapSnapshotNode, key: Key, selfSize: number): void {
+    const stats = this.#statsOf(node, key)
+    stats.size += selfSize
+    stats.nodeCount++
+  }
+
+  /**
+   * Adds every key's stats to {@link nodeCategoryToStats} under the category
+   * {@link categoryOf} resolves the key to, or the one the origin assigns to a
+   * constructor's name.
+   */
+  public aggregateInto(
+    nodeCategoryToStats: Map<HeapSnapshotNodeCategory, NodeCategoryStats>,
+    origin: Origin,
+    categoryOf: (key: Key) => HeapSnapshotNodeCategory,
+  ): void {
+    for (const [key, stats] of this.#keyToStats) {
+      addStats(nodeCategoryToStats, categoryOf(key), stats)
+    }
+    for (const [key, nameToStats] of this.#keyToConstructorNameToStats) {
+      // `categoryOf` runs once per key rather than per constructor name, since
+      // one key can have thousands of them.
+      const category = categoryOf(key)
+      for (const [name, stats] of nameToStats) {
+        addStats(
+          nodeCategoryToStats,
+          categorizeHeapSnapshotConstructorForOrigin(name, origin) ?? category,
+          stats,
+        )
+      }
+    }
+  }
+
+  /**
+   * The stats {@link node} aggregates into under {@link key}: its constructor
+   * name's when it has one, and the key's own otherwise.
+   */
+  #statsOf(node: HeapSnapshotNode, key: Key): NodeCategoryStats {
+    if (node.type !== `constructor`) {
+      return statsOf(this.#keyToStats, key)
+    }
+
+    let nameToStats = this.#keyToConstructorNameToStats.get(key)
+    if (!nameToStats) {
+      nameToStats = new Map()
+      this.#keyToConstructorNameToStats.set(key, nameToStats)
+    }
+    return statsOf(nameToStats, node.name)
+  }
+}
+
+/** Adds {@link stats} to the stats {@link key} aggregates into. */
+const addStats = <Key>(
+  keyToStats: Map<Key, NodeCategoryStats>,
+  key: Key,
+  { size, nodeCount }: NodeCategoryStats,
+): void => {
+  const stats = statsOf(keyToStats, key)
+  stats.size += size
+  stats.nodeCount += nodeCount
+}
+
+/** The stats {@link key} aggregates into, inserted empty when it has none. */
+const statsOf = <Key>(
+  keyToStats: Map<Key, NodeCategoryStats>,
+  key: Key,
+): NodeCategoryStats => {
+  let stats = keyToStats.get(key)
+  if (!stats) {
+    stats = { size: 0, nodeCount: 0 }
+    keyToStats.set(key, stats)
+  }
+  return stats
+}
+
+type CategorizedConstructor = {
+  name: string
+  category: HeapSnapshotNodeCategory
+}
+
+type CategorizedString = { category: HeapSnapshotNodeCategory }
+
+/**
+ * Accumulates the self size each of an entity's nodes contributes to its
+ * category, so {@link categorize} assigns the entity the category holding the
+ * most of it.
+ *
+ * A constructor is addressed by the index it was aggregated under, and a string
+ * by the order it was added in, so nothing is stored per node.
+ */
+export class EntityCategorizer {
+  readonly #categoryKeys = new CategoryKeys()
+  readonly #constructorCategories: DominantCategory[] = []
+  readonly #stringCategoryKeys: number[] = []
+
+  public addConstructorNode(
+    constructorIndex: number,
+    node: HeapSnapshotNode,
+    selfSize: number,
+  ): void {
+    addCategorySize(
+      (this.#constructorCategories[constructorIndex] ??= newDominantCategory()),
+      this.#categoryKeys.keyOf(node),
+      selfSize,
+    )
+  }
+
+  /** Records the category of the next string added to the snapshot. */
+  public addStringNode(node: HeapSnapshotNode): void {
+    this.#stringCategoryKeys.push(this.#categoryKeys.keyOf(node))
+  }
+
+  /**
+   * Assigns each constructor and string the category holding the most of its
+   * self size, resolving the key its nodes accumulated under through
+   * {@link origin}.
+   *
+   * A constructor the origin names by the class its language defines takes that
+   * category instead, since the class name identifies what its instances hold
+   * more precisely than the nodes do.
+   */
+  public categorize(
+    constructors: CategorizedConstructor[],
+    strings: CategorizedString[],
+    origin: Origin,
+  ): void {
+    const categoryOf = this.#categoryKeys.newResolver(origin)
+    for (let index = 0; index < constructors.length; index++) {
+      const constructor = constructors[index]!
+      constructor.category =
+        categorizeHeapSnapshotConstructorForOrigin(constructor.name, origin) ??
+        categoryOf(this.#constructorCategories[index]!.key)
+    }
+    for (let index = 0; index < strings.length; index++) {
+      strings[index]!.category = categoryOf(this.#stringCategoryKeys[index]!)
+    }
+  }
+}
+
+/**
+ * Numbers the key an entity's self size accumulates under: the category the
+ * format derived, or the type name it declared when the format categorized
+ * nothing.
+ *
+ * The two share one key space, since an entity's nodes may report either and
+ * the entity takes the key holding the most of its self size. A category is
+ * numbered from {@link HEAP_SNAPSHOT_NODE_CATEGORIES} and a declared type name
+ * from the order the snapshot declares them in. A key's sign distinguishes the
+ * two, because a format may declare a type name equal to a category name, and
+ * the two mean different things.
+ */
+class CategoryKeys {
+  readonly #declaredTypes: string[] = []
+  readonly #declaredTypeToKey = new Map<string, number>()
+
+  public keyOf(node: HeapSnapshotNode): number {
+    if (node.category !== undefined || node.declaredType === undefined) {
+      return CATEGORY_TO_KEY.get(node.category ?? `unknown`)!
+    }
+
+    let key = this.#declaredTypeToKey.get(node.declaredType)
+    if (key === undefined) {
+      key = -this.#declaredTypes.push(node.declaredType)
+      this.#declaredTypeToKey.set(node.declaredType, key)
+    }
+    return key
+  }
+
+  /**
+   * Resolves a {@link keyOf} key to its category, passing a declared type name
+   * through {@link origin} and falling back to `object` for a type name the
+   * origin doesn't categorize.
+   *
+   * Memoized, since a snapshot declaring its own type names can hold thousands
+   * of them and every entity resolves one.
+   */
+  public newResolver(
+    origin: Origin,
+  ): (key: number) => HeapSnapshotNodeCategory {
+    const declaredTypeCategories = new Array<
+      HeapSnapshotNodeCategory | undefined
+    >(this.#declaredTypes.length)
+    return key => {
+      if (key > 0) {
+        return HEAP_SNAPSHOT_NODE_CATEGORIES[key - 1]!
+      }
+      const index = -key - 1
+      return (declaredTypeCategories[index] ??=
+        categorizeHeapSnapshotDeclaredTypeForOrigin(
+          this.#declaredTypes[index]!,
+          origin,
+        ) ?? `object`)
+    }
+  }
+}
+
+/** The key of each category, numbered from 1 so that no key is 0. */
+const CATEGORY_TO_KEY = new Map<HeapSnapshotNodeCategory, number>(
+  HEAP_SNAPSHOT_NODE_CATEGORIES.map((category, index) => [category, index + 1]),
+)
+
+/**
+ * Which category holds the most of an entity's self size, tracked as its nodes
+ * are accumulated.
+ *
+ * The nodes of most entities report one category, though a DOM wrapper class
+ * exists as both a host-allocated node and a plain object. The sizes of the
+ * categories behind the leading one are recorded only once a second category
+ * appears.
+ */
+type DominantCategory = {
+  /** The leading category's key, {@link NO_CATEGORY_KEY} until the first node. */
+  key: number
+
+  size: number
+  otherSizes?: Map<number, number>
+}
+
+/**
+ * The key of a {@link DominantCategory} no node has contributed to yet, which
+ * {@link CategoryKeys.keyOf} never returns.
+ */
+const NO_CATEGORY_KEY = 0
+
+const newDominantCategory = (): DominantCategory => ({
+  key: NO_CATEGORY_KEY,
+  size: 0,
+})
+
+/**
+ * Adds {@link size} to {@link key}'s share of {@link dominant}, promoting
+ * {@link key} to the leading category when its share passes the leader's.
+ *
+ * An entity whose nodes all report a zero self size keeps the key of the first
+ * node added, since no later key ever passes a zero share.
+ */
+const addCategorySize = (
+  dominant: DominantCategory,
+  key: number,
+  size: number,
+): void => {
+  if (dominant.key === key || dominant.key === NO_CATEGORY_KEY) {
+    dominant.key = key
+    dominant.size += size
+    return
+  }
+
+  dominant.otherSizes ??= new Map<number, number>()
+  const { otherSizes } = dominant
+  const keySize = (otherSizes.get(key) ?? 0) + size
+  if (keySize <= dominant.size) {
+    otherSizes.set(key, keySize)
+    return
+  }
+
+  otherSizes.set(dominant.key, dominant.size)
+  otherSizes.delete(key)
+  dominant.key = key
+  dominant.size = keySize
+}

--- a/src/modalities/heap-snapshot/diff.ts
+++ b/src/modalities/heap-snapshot/diff.ts
@@ -10,6 +10,7 @@ import type {
   AggregatedHeapSnapshotConstructor,
   AggregatedHeapSnapshotFunction,
   AggregatedHeapSnapshotNode,
+  AggregatedHeapSnapshotString,
   NodeCategoryStats,
 } from './aggregate.ts'
 import type { HeapSnapshotNodeCategory } from './type.ts'
@@ -41,6 +42,9 @@ export type DiffedHeapSnapshotEntity = AggregatedHeapSnapshotNode & {
 export type AggregatedHeapSnapshotEntityDiff = {
   /** A human readable label for this entity. */
   name: string
+
+  /** What this entity holds, set on the entities a ranking breaks down. */
+  category?: HeapSnapshotNodeCategory
 
   /** The file reference the {@link name} parses as, when it is URL-shaped. */
   nameLocation?: FileReference
@@ -121,6 +125,7 @@ const diffedConstructor = ({
   name,
   nameLocation,
   location,
+  category,
   selfSize,
   retainedSize,
   instances,
@@ -130,6 +135,7 @@ const diffedConstructor = ({
   name,
   nameLocation,
   location,
+  category,
   selfSize,
   retainedSize,
   instanceCount: instances.length,
@@ -173,9 +179,13 @@ const mergeFunctions = (
 /**
  * Merges strings sharing the same value, excluding strings without a known
  * value since they can't be matched across snapshots.
+ *
+ * A merged string takes the category of the first string merged into it, like
+ * its `id`, because same-valued strings differ only in the representation the
+ * engine gave each one.
  */
 const mergeStrings = (
-  strings: AggregatedHeapSnapshotNode[],
+  strings: AggregatedHeapSnapshotString[],
 ): Map<string, DiffedHeapSnapshotEntity> => {
   const valueToString = new Map<string, DiffedHeapSnapshotEntity>()
   for (const string of strings) {
@@ -193,6 +203,7 @@ const mergeStrings = (
         type: `node`,
         id: string.id,
         name: string.name,
+        category: string.category,
         selfSize: string.selfSize,
         retainedSize: string.selfSize,
         instanceCount: 1,
@@ -207,6 +218,6 @@ const entityDiffsFromMatches = (
   diffs: Map<string, Diff<DiffedHeapSnapshotEntity>>,
 ): AggregatedHeapSnapshotEntityDiff[] =>
   Array.from(diffs.values(), ({ base, current }) => {
-    const { name, nameLocation, location } = (current ?? base)!
-    return { name: name!, nameLocation, location, base, current }
+    const { name, nameLocation, location, category } = (current ?? base)!
+    return { name: name!, nameLocation, location, category, base, current }
   })

--- a/src/modalities/heap-snapshot/format.test.ts
+++ b/src/modalities/heap-snapshot/format.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'vitest'
 import { mdastToMarkdown } from '../../helpers/markdown.ts'
 import {
+  categoryRankingTables,
+  categorySectionTables,
   categoryTables,
   improvementsTables,
   profileTitles,
@@ -64,6 +66,137 @@ describe(`formatHeapSnapshot`, () => {
         },
       ],
     ])
+  })
+
+  describe(`category subsections`, () => {
+    const snapshot = makeAggregatedHeapSnapshot({
+      totalSize: 1000,
+      constructors: [
+        makeAggregatedHeapSnapshotConstructor({
+          name: `Widget`,
+          selfSize: 600,
+          retainedSize: 600,
+          instanceCount: 3,
+          category: `object`,
+        }),
+        makeAggregatedHeapSnapshotConstructor({
+          name: `Uint8Array`,
+          selfSize: 390,
+          retainedSize: 390,
+          instanceCount: 2,
+          category: `array`,
+        }),
+        makeAggregatedHeapSnapshotConstructor({
+          name: `Structure`,
+          selfSize: 10,
+          retainedSize: 10,
+          instanceCount: 1,
+          category: `internal`,
+        }),
+      ],
+    })
+
+    test(`splits a ranking into a subsection per covered category`, () => {
+      const md = mdastToMarkdown(formatHeapSnapshot(snapshot, defaultOptions))
+
+      expect(categorySectionTables(md, `Self size`)).toEqual({
+        Object: [
+          {
+            '%': `60.0%`,
+            Size: `600 B`,
+            Instances: `3`,
+            Constructor: `Widget`,
+          },
+        ],
+        Array: [
+          {
+            '%': `39.0%`,
+            Size: `390 B`,
+            Instances: `2`,
+            Constructor: `Uint8Array`,
+          },
+        ],
+        Internal: [
+          {
+            '%': `1.0%`,
+            Size: `10 B`,
+            Instances: `1`,
+            Constructor: `Structure`,
+          },
+        ],
+      })
+    })
+
+    test(`drops a category covering less than minCategoryShare`, () => {
+      const md = mdastToMarkdown(
+        formatHeapSnapshot(
+          snapshot,
+          resolveProfileToMdOptions({
+            baseURL: `/project`,
+            minCategoryShare: 0.05,
+          }),
+        ),
+      )
+
+      expect(Object.keys(categorySectionTables(md, `Self size`))).toEqual([
+        `Object`,
+        `Array`,
+      ])
+    })
+
+    test(`splits a ranking whose constructors all fall in one category`, () => {
+      const singleCategory = makeAggregatedHeapSnapshot({
+        totalSize: 1000,
+        constructors: [
+          makeAggregatedHeapSnapshotConstructor({
+            name: `Widget`,
+            selfSize: 1000,
+            retainedSize: 1000,
+            instanceCount: 3,
+            category: `object`,
+          }),
+        ],
+      })
+
+      const md = mdastToMarkdown(
+        formatHeapSnapshot(singleCategory, defaultOptions),
+      )
+
+      expect(categorySectionTables(md, `Self size`)).toEqual({
+        Object: [
+          {
+            '%': `100.0%`,
+            Size: `1000 B`,
+            Instances: `3`,
+            Constructor: `Widget`,
+          },
+        ],
+      })
+    })
+
+    test(`splits the strings ranking by the representation of each string`, () => {
+      const strings = makeAggregatedHeapSnapshot({
+        strings: [
+          makeAggregatedHeapSnapshotString({ value: `flat`, selfSize: 600 }),
+          makeAggregatedHeapSnapshotString({
+            value: `joined`,
+            selfSize: 400,
+            category: `concatenated string`,
+          }),
+        ],
+      })
+
+      const md = mdastToMarkdown(formatHeapSnapshot(strings, defaultOptions))
+
+      expect(categorySectionTables(md, `Largest strings`)).toEqual({
+        String: [
+          { '%': `60.0%`, Size: `600 B`, Value: `flat`, Path: `(GC root)` },
+        ],
+        'Concatenated string': [
+          { '%': `40.0%`, Size: `400 B`, Value: `joined`, Path: `(GC root)` },
+        ],
+      })
+    })
   })
 })
 
@@ -574,5 +707,169 @@ describe(`formatHeapSnapshotDiff`, () => {
     expect(md).toContain(
       `No constructor differed in bytes allocated for its instances, excluding nodes kept reachable by them.`,
     )
+  })
+
+  describe(`category subsections`, () => {
+    /**
+     * A snapshot whose size splits between plain objects and a typed array,
+     * with a VM bookkeeping constructor too small to cover a hundredth of it.
+     */
+    const makeMixedSnapshot = (
+      widgetSize: number,
+      bufferSize: number,
+      structureSize: number,
+    ) =>
+      makeAggregatedHeapSnapshot({
+        totalSize: widgetSize + bufferSize + structureSize,
+        constructors: [
+          makeAggregatedHeapSnapshotConstructor({
+            name: `Widget`,
+            selfSize: widgetSize,
+            retainedSize: widgetSize,
+            instanceCount: 3,
+            category: `object`,
+          }),
+          makeAggregatedHeapSnapshotConstructor({
+            name: `Uint8Array`,
+            selfSize: bufferSize,
+            retainedSize: bufferSize,
+            instanceCount: 2,
+            category: `array`,
+          }),
+          makeAggregatedHeapSnapshotConstructor({
+            name: `Structure`,
+            selfSize: structureSize,
+            retainedSize: structureSize,
+            instanceCount: 1,
+            category: `internal`,
+          }),
+        ],
+      })
+
+    const diffMixedSnapshots = (
+      base: [number, number, number],
+      current: [number, number, number],
+    ) =>
+      mdastToMarkdown(
+        formatHeapSnapshotDiff(
+          diffAggregatedHeapSnapshots(
+            makeMixedSnapshot(...base),
+            makeMixedSnapshot(...current),
+            defaultOptions,
+          ),
+          defaultOptions,
+        ),
+      )
+
+    test(`splits each ranking into a subsection per covered category`, () => {
+      const md = diffMixedSnapshots([600, 390, 10], [300, 700, 10])
+
+      expect(categoryRankingTables(md, `Self size`, `Regressions`)).toEqual({
+        Array: [
+          {
+            Change: `+79.5%`,
+            Delta: `+310 B`,
+            '%': `39.0% → 69.3%`,
+            Size: `390 B → 700 B`,
+            Instances: `2`,
+            Constructor: `Uint8Array`,
+          },
+        ],
+      })
+      expect(categoryRankingTables(md, `Self size`, `Improvements`)).toEqual({
+        Object: [
+          {
+            Change: `-50.0%`,
+            Delta: `-300 B`,
+            '%': `60.0% → 29.7%`,
+            Size: `600 B → 300 B`,
+            Instances: `3`,
+            Constructor: `Widget`,
+          },
+        ],
+      })
+    })
+
+    test(`covers a category by the side it weighs more on`, () => {
+      // The typed array's share falls from 39.0% to under 1%, so only its base
+      // side clears the threshold.
+      const md = diffMixedSnapshots([600, 390, 10], [1000, 1, 10])
+
+      expect(
+        Object.keys(categoryRankingTables(md, `Self size`, `Improvements`)),
+      ).toEqual([`Array`])
+    })
+
+    test(`splits a ranking whose constructors all fall in one category`, () => {
+      const md = diffMixedSnapshots([1000, 0, 0], [500, 0, 0])
+
+      expect(categoryRankingTables(md, `Self size`, `Improvements`)).toEqual({
+        Object: [
+          {
+            Change: `-50.0%`,
+            Delta: `-500 B`,
+            '%': `100.0%`,
+            Size: `1000 B → 500 B`,
+            Instances: `3`,
+            Constructor: `Widget`,
+          },
+        ],
+      })
+    })
+
+    test(`splits the strings ranking by the representation of each string`, () => {
+      const base = makeAggregatedHeapSnapshot({
+        strings: [
+          makeAggregatedHeapSnapshotString({ value: `flat`, selfSize: 100 }),
+          makeAggregatedHeapSnapshotString({
+            value: `joined`,
+            selfSize: 100,
+            category: `concatenated string`,
+          }),
+        ],
+      })
+      const current = makeAggregatedHeapSnapshot({
+        strings: [
+          makeAggregatedHeapSnapshotString({ value: `flat`, selfSize: 300 }),
+          makeAggregatedHeapSnapshotString({
+            value: `joined`,
+            selfSize: 200,
+            category: `concatenated string`,
+          }),
+        ],
+      })
+
+      const md = mdastToMarkdown(
+        formatHeapSnapshotDiff(
+          diffAggregatedHeapSnapshots(base, current, defaultOptions),
+          defaultOptions,
+        ),
+      )
+
+      expect(
+        categoryRankingTables(md, `Largest strings`, `Regressions`),
+      ).toEqual({
+        String: [
+          {
+            Change: `+200.0%`,
+            Delta: `+200 B`,
+            '%': `50.0% → 60.0%`,
+            Size: `100 B → 300 B`,
+            Value: `flat`,
+            Path: `(GC root)`,
+          },
+        ],
+        'Concatenated string': [
+          {
+            Change: `+100.0%`,
+            Delta: `+100 B`,
+            '%': `50.0% → 40.0%`,
+            Size: `100 B → 200 B`,
+            Value: `joined`,
+            Path: `(GC root)`,
+          },
+        ],
+      })
+    })
   })
 })

--- a/src/modalities/heap-snapshot/format.ts
+++ b/src/modalities/heap-snapshot/format.ts
@@ -18,12 +18,20 @@ import {
 import { formatSourceLocation } from '../../location.ts'
 import type { FileReference, SourceLocation } from '../../location.ts'
 import type { FormattingProfileToMdOptions } from '../../options.ts'
+import {
+  formatRankingTables,
+  rankEntities,
+  subsectionCategories,
+  subsectionDiffCategories,
+} from '../category.ts'
 import type { Diff } from '../diff.ts'
 import {
+  formatDiffRankingSections,
   resolveEntryFilter,
   selectDiffEntities,
   showDiffEntity,
 } from '../format.ts'
+import type { DiffCategoryRanking } from '../format.ts'
 import { formatDiffTable, formatTable } from '../table.ts'
 import type { Table } from '../table.ts'
 import type {
@@ -31,6 +39,7 @@ import type {
   AggregatedHeapSnapshotConstructor,
   AggregatedHeapSnapshotFunction,
   AggregatedHeapSnapshotNode,
+  AggregatedHeapSnapshotString,
 } from './aggregate.ts'
 import type {
   AggregatedHeapSnapshotDiff,
@@ -47,6 +56,7 @@ import {
   stringColumns,
 } from './table.ts'
 import type { FunctionRow, NodeRow } from './table.ts'
+import type { HeapSnapshotNodeCategory } from './type.ts'
 
 export const formatHeapSnapshot = (
   snapshot: AggregatedHeapSnapshot,
@@ -125,24 +135,37 @@ const formatLargestConstructors = ({
   snapshot: AggregatedHeapSnapshot
   hasLocation: boolean
   options: FormattingProfileToMdOptions
-}): RootContent[] =>
-  formatSectionGroup(
+}): RootContent[] => {
+  // Resolved once for both rankings: a category qualifies for a subsection by
+  // its share of the shown constructors' summed self size, which the ranking it
+  // appears under doesn't change.
+  const categories = subsectionCategories({
+    entries: snapshot.constructors.filter(options.showEntry),
+    selfValueOf: constructor => constructor.selfSize,
+    categoryOf: constructor => constructor.category,
+    minCategoryShare: options.minCategoryShare,
+  })
+
+  return formatSectionGroup(
     [heading(2, `Largest constructors`)],
     [
       ...formatLargestSizeConstructors({
         snapshot,
         hasLocation,
+        categories,
         options,
         size: SELF_SIZE,
       }),
       ...formatLargestSizeConstructors({
         snapshot,
         hasLocation,
+        categories,
         options,
         size: RETAINED_SIZE,
       }),
     ],
   )
+}
 
 /**
  * The size accessor, heading, and phrasing for one constructor size (self or
@@ -190,46 +213,55 @@ const RETAINED_SIZE: ConstructorSize = {
 const formatLargestSizeConstructors = ({
   snapshot,
   hasLocation,
+  categories,
   options,
   size: { sizeOf, formatHeader, description },
 }: {
   snapshot: AggregatedHeapSnapshot
   hasLocation: boolean
+  categories: HeapSnapshotNodeCategory[]
   options: FormattingProfileToMdOptions
   size: ConstructorSize
 }): RootContent[] => {
   const { totalSize, constructors } = snapshot
 
-  const largestConstructors = selectTopN(
-    constructors.filter(options.showEntry),
-    options.topN,
-    sizeOf,
-  )
-  if (largestConstructors.length === 0) {
+  const ranking = rankEntities({
+    entities: constructors.filter(options.showEntry),
+    categories,
+    valueOf: sizeOf,
+    topN: options.topN,
+  })
+  if (ranking.rankedEntities.length === 0) {
     return []
   }
 
-  const largestInstanceSections = largestConstructors.flatMap(constructor =>
-    formatLargestConstructorInstances({
-      constructor,
-      snapshot,
-      sizeOf,
-      hasLocation,
-      options,
-    }),
+  const largestInstanceSections = ranking.displayedEntities.flatMap(
+    constructor =>
+      formatLargestConstructorInstances({
+        constructor,
+        snapshot,
+        sizeOf,
+        hasLocation,
+        options,
+      }),
   )
 
   return [
     ...formatHeader({ isEmptyDiff: false }),
-    formatTable(
-      constructorColumns(hasLocation, options),
-      largestConstructors.map(constructor => ({
-        entity: constructor,
-        size: sizeOf(constructor),
-        total: totalSize,
-        instanceCount: constructor.instances.length,
-      })),
-    ),
+    ...formatRankingTables({
+      ranking,
+      formatEntityTable: entities =>
+        formatTable(
+          constructorColumns(hasLocation, options),
+          entities.map(constructor => ({
+            entity: constructor,
+            size: sizeOf(constructor),
+            total: totalSize,
+            instanceCount: constructor.instances.length,
+          })),
+        ),
+      headingLevel: 4,
+    }),
     ...formatSectionGroup(
       [
         heading(4, `Instances`),
@@ -449,27 +481,42 @@ const formatLargestStrings = ({
   snapshot: AggregatedHeapSnapshot
   options: FormattingProfileToMdOptions
 }): RootContent[] => {
-  const largestStrings = selectTopN(
-    strings,
-    options.topN,
-    string => string.selfSize,
-  )
-  if (largestStrings.length === 0) {
+  const selfSizeOf = (string: AggregatedHeapSnapshotString) => string.selfSize
+  const ranking = rankEntities({
+    entities: strings,
+    categories: subsectionCategories({
+      entries: strings,
+      selfValueOf: selfSizeOf,
+      categoryOf: string => string.category,
+      minCategoryShare: options.minCategoryShare,
+    }),
+    valueOf: selfSizeOf,
+    topN: options.topN,
+  })
+  if (ranking.rankedEntities.length === 0) {
     return []
   }
 
-  const hasValues = largestStrings.some(string => string.name !== undefined)
+  // Resolved across every displayed string, so all the tables share a column.
+  const hasValues = ranking.displayedEntities.some(
+    string => string.name !== undefined,
+  )
   return [
     ...formatLargestStringsHeading({ isEmptyDiff: false }),
-    formatTable(
-      stringColumns(hasValues),
-      largestStrings.map(string => ({
-        name: string.name,
-        size: string.selfSize,
-        total: totalSize,
-        path: retainerPathOf(string.id, options),
-      })),
-    ),
+    ...formatRankingTables({
+      ranking,
+      formatEntityTable: entities =>
+        formatTable(
+          stringColumns(hasValues),
+          entities.map(string => ({
+            name: string.name,
+            size: string.selfSize,
+            total: totalSize,
+            path: retainerPathOf(string.id, options),
+          })),
+        ),
+      headingLevel: 3,
+    }),
   ]
 }
 
@@ -562,44 +609,63 @@ const formatDiffConstructors = ({
   diff: AggregatedHeapSnapshotDiff
   hasLocation: boolean
   options: FormattingProfileToMdOptions
-}): RootContent[] =>
-  formatSectionGroup(
+}): RootContent[] => {
+  // Resolved once for both rankings, like a single snapshot's, and over the
+  // same constructors each side of the diff shows.
+  const categories = subsectionDiffCategories({
+    entries: diff.constructors.filter(entity =>
+      showDiffEntity(entity, options),
+    ),
+    baseSelfValueOf: entity => entity.base?.selfSize ?? 0,
+    currentSelfValueOf: entity => entity.current?.selfSize ?? 0,
+    categoryOf: entity => entity.category ?? `object`,
+    minCategoryShare: options.minCategoryShare,
+  })
+
+  return formatSectionGroup(
     [heading(2, `Largest constructors`)],
     [
       ...formatDiffSizeConstructors({
         diff,
         hasLocation,
+        categories,
         options,
         size: SELF_SIZE,
       }),
       ...formatDiffSizeConstructors({
         diff,
         hasLocation,
+        categories,
         options,
         size: RETAINED_SIZE,
       }),
     ],
   )
+}
 
 const formatDiffSizeConstructors = ({
   diff,
   hasLocation,
+  categories,
   options,
   size: { sizeOf, formatHeader, description },
 }: {
   diff: AggregatedHeapSnapshotDiff
   hasLocation: boolean
+  categories: HeapSnapshotNodeCategory[]
   options: FormattingProfileToMdOptions
   size: ConstructorSize
 }): RootContent[] => {
-  const { regressions, improvements, hasActive } = selectDiffEntities(
-    diff.constructors.map(entity => ({
-      entity,
-      baseValue: entity.base ? sizeOf(entity.base) : 0,
-      currentValue: entity.current ? sizeOf(entity.current) : 0,
-    })),
-    options,
-  )
+  const { regressions, improvements, hasActive, categoryRankings } =
+    selectDiffEntities(
+      diff.constructors.map(entity => ({
+        entity,
+        baseValue: entity.base ? sizeOf(entity.base) : 0,
+        currentValue: entity.current ? sizeOf(entity.current) : 0,
+      })),
+      options,
+      { categories, categoryOf: entity => entity.category ?? `object` },
+    )
 
   const sideRowOf = (total: number, entity?: DiffedHeapSnapshotEntity) =>
     entity && {
@@ -620,8 +686,10 @@ const formatDiffSizeConstructors = ({
     description,
     columns: constructorColumns(hasLocation, options),
     hasActive,
-    regressions: regressions.map(({ entity }) => rowOf(entity)),
-    improvements: improvements.map(({ entity }) => rowOf(entity)),
+    regressions,
+    improvements,
+    categoryRankings,
+    rowOf: ({ entity }) => rowOf(entity),
   })
 }
 
@@ -655,8 +723,9 @@ const formatDiffFunctions = ({
     description: `retained size`,
     columns: functionColumns(hasLocation, options),
     hasActive,
-    regressions: regressions.map(({ entity }) => rowOf(entity)),
-    improvements: improvements.map(({ entity }) => rowOf(entity)),
+    regressions,
+    improvements,
+    rowOf: ({ entity }) => rowOf(entity),
   })
 }
 
@@ -683,14 +752,28 @@ const formatDiffStrings = ({
   diff: AggregatedHeapSnapshotDiff
   options: FormattingProfileToMdOptions
 }): RootContent[] => {
-  const { regressions, improvements, hasActive } = selectDiffEntities(
-    diff.strings.map(entity => ({
-      entity,
-      baseValue: entity.base ? entity.base.selfSize : 0,
-      currentValue: entity.current ? entity.current.selfSize : 0,
-    })),
-    options,
-  )
+  // A string is categorized by its representation in the heap, which the
+  // snapshot always records.
+  const categoryOf = (entity: AggregatedHeapSnapshotEntityDiff) =>
+    entity.category ?? `string`
+  const categories = subsectionDiffCategories({
+    entries: diff.strings.filter(entity => showDiffEntity(entity, options)),
+    baseSelfValueOf: entity => entity.base?.selfSize ?? 0,
+    currentSelfValueOf: entity => entity.current?.selfSize ?? 0,
+    categoryOf,
+    minCategoryShare: options.minCategoryShare,
+  })
+
+  const { regressions, improvements, hasActive, categoryRankings } =
+    selectDiffEntities(
+      diff.strings.map(entity => ({
+        entity,
+        baseValue: entity.base ? entity.base.selfSize : 0,
+        currentValue: entity.current ? entity.current.selfSize : 0,
+      })),
+      options,
+      { categories, categoryOf },
+    )
 
   const rowOf = ({ base, current }: AggregatedHeapSnapshotEntityDiff) => ({
     base: base && nodeRowOf(base, diff.base, options),
@@ -705,8 +788,10 @@ const formatDiffStrings = ({
     // Diffed strings are matched by value, so they always have a value.
     columns: stringColumns(true),
     hasActive,
-    regressions: regressions.map(({ entity }) => rowOf(entity)),
-    improvements: improvements.map(({ entity }) => rowOf(entity)),
+    regressions,
+    improvements,
+    categoryRankings,
+    rowOf: ({ entity }) => rowOf(entity),
   })
 }
 
@@ -726,7 +811,7 @@ const nodeRowOf = (
  * Assembles the regressions and improvements subsections for one diffed entity
  * table from its row records, with rows under the given table {@link columns}.
  */
-const formatDiffEntitySections = <Row>({
+const formatDiffEntitySections = <Entity, Row>({
   formatHeader,
   headingLevel,
   plural,
@@ -735,6 +820,8 @@ const formatDiffEntitySections = <Row>({
   hasActive,
   regressions,
   improvements,
+  categoryRankings = [],
+  rowOf,
 }: {
   formatHeader: (options: { isEmptyDiff: boolean }) => RootContent[]
   headingLevel: number
@@ -742,26 +829,33 @@ const formatDiffEntitySections = <Row>({
   description: string
   columns: Table<Row>
   hasActive: boolean
-  regressions: Diff<Row>[]
-  improvements: Diff<Row>[]
+  regressions: Entity[]
+  improvements: Entity[]
+  categoryRankings?: DiffCategoryRanking<Entity>[]
+  rowOf: (entity: Entity) => Diff<Row>
 }): RootContent[] => {
-  const sections: RootContent[] = []
-
-  if (regressions.length > 0) {
-    sections.push(
-      heading(headingLevel, `Regressions`),
-      paragraph(`${plural} with the largest increase in ${description}.`),
-      formatDiffTable(columns, regressions),
-    )
-  }
-
-  if (improvements.length > 0) {
-    sections.push(
-      heading(headingLevel, `Improvements`),
-      paragraph(`${plural} with the largest decrease in ${description}.`),
-      formatDiffTable(columns, improvements),
-    )
-  }
+  const sections = [
+    ...formatDiffRankingSections({
+      headingLevel,
+      subtitle: `Regressions`,
+      sentence: `${plural} with the largest increase in ${description}.`,
+      columns,
+      entities: regressions,
+      categoryRankings,
+      entitiesOf: ranking => ranking.regressions,
+      rowOf,
+    }),
+    ...formatDiffRankingSections({
+      headingLevel,
+      subtitle: `Improvements`,
+      sentence: `${plural} with the largest decrease in ${description}.`,
+      columns,
+      entities: improvements,
+      categoryRankings,
+      entitiesOf: ranking => ranking.improvements,
+      rowOf,
+    }),
+  ]
 
   // With active entities but no change, keep the section and let the header note
   // it didn't differ. With nothing active (the section a non-diff snapshot

--- a/src/modalities/heap-snapshot/testing.ts
+++ b/src/modalities/heap-snapshot/testing.ts
@@ -13,7 +13,7 @@ import type {
   AggregatedHeapSnapshot,
   AggregatedHeapSnapshotConstructor,
   AggregatedHeapSnapshotFunction,
-  AggregatedHeapSnapshotNode,
+  AggregatedHeapSnapshotString,
   NodeCategoryStats,
 } from './aggregate.ts'
 import { computeStartOffsets } from './graph.ts'
@@ -94,7 +94,7 @@ export const makeAggregatedHeapSnapshot = ({
   nodeCategoryToStats?: Map<HeapSnapshotNodeCategory, NodeCategoryStats>
   constructors?: AggregatedHeapSnapshotConstructor[]
   functions?: AggregatedHeapSnapshotFunction[]
-  strings?: AggregatedHeapSnapshotNode[]
+  strings?: AggregatedHeapSnapshotString[]
 } = {}): AggregatedHeapSnapshot => ({
   type: `heap-snapshot`,
   context,
@@ -127,17 +127,20 @@ export const makeAggregatedHeapSnapshotConstructor = ({
   selfSize,
   retainedSize,
   instanceCount,
+  category = `object`,
 }: {
   name: string
   location?: SourceLocation
   selfSize: number
   retainedSize: number
   instanceCount: number
+  category?: HeapSnapshotNodeCategory
 }): AggregatedHeapSnapshotConstructor => ({
   type: `node`,
   id: 0,
   name,
   location,
+  category,
   selfSize,
   retainedSize,
   instances: Array.from({ length: instanceCount }, (_, index) => ({
@@ -175,13 +178,16 @@ export const makeAggregatedHeapSnapshotFunction = ({
 export const makeAggregatedHeapSnapshotString = ({
   value,
   selfSize,
+  category = `string`,
 }: {
   value?: string
   selfSize: number
-}): AggregatedHeapSnapshotNode => ({
+  category?: HeapSnapshotNodeCategory
+}): AggregatedHeapSnapshotString => ({
   type: `node`,
   id: 0,
   name: value,
+  category,
   selfSize,
   retainedSize: selfSize,
 })


### PR DESCRIPTION
Extends the per-category breakdown to heap snapshots, whose categories are what a node holds rather than where code came from.

A constructor and a closure now carry a category, since a ranking of them has to partition by something the entity holds. A node contributes to its entity, and the category holding the most of the entity's self size wins: most entities agree, though a DOM wrapper class exists as both a host-allocated node and a plain object, so the sizes of the categories that lost are tracked once a second one appears.

The constructor rankings split usefully. Node splits into `object` 78.6%, `array` 11.4%, `native` 5.7%, and `built-in` 4.2%; Bun's JavaScriptCore snapshot into `code` 55.9%, `internal` 26.5%, and four more. Julia's constructors are all objects, so its rankings stay unsplit, as do the closure rankings of every snapshot, since a closure holds a closure.