### PR TITLE
fix(jfr): rank live objects by count when an older JDK records no size

### DIFF
--- a/docs/formats/jfr.md
+++ b/docs/formats/jfr.md
@@ -8,8 +8,8 @@ binary profiling format, written by the JDK's built-in
 A recording splits into self-contained chunks of LEB128 varint-encoded events.
 One recording can mix event kinds, so it converts to one profile per kind:
 CPU/wall sampling measured by sample count, heap and native memory allocation
-sampling measured by allocated bytes, and lock contention measured by blocked
-time.
+sampling measured by allocated bytes, live-object sampling measured by retained
+bytes, and lock contention measured by blocked time.
 
 It supports a single metric per profile and multiple profiles per file.
 

--- a/src/formats/jfr/index.test.ts
+++ b/src/formats/jfr/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 import { concatUint8Arrays } from '../../helpers/bytes.ts'
 import { chunk, streamOf } from '../../helpers/testing.ts'
 import {
+  selfObjectsTables,
   selfSamplesTables,
   selfTimeTables,
 } from '../../modalities/call-stack-profile/testing.ts'
@@ -292,6 +293,54 @@ describe(`convert`, () => {
           Size: `3 KiB`,
           Objects: `2`,
           Function: `allocate`,
+          Location: `com.example.A`,
+        },
+      ],
+    ])
+  })
+
+  test(`live-object samples without a size rank by object count`, () => {
+    // `jdk.OldObjectSample` gained `objectSize` in JDK 21. An older recording
+    // records which objects were live but not their sizes, so its profile has
+    // no size column instead of a byte per object.
+    const bytes = makeJfr({
+      methods: [
+        { name: `allocate`, className: `com.example.A` },
+        { name: `run`, className: `com.example.A` },
+      ],
+      stackTraces: [
+        {
+          frames: [
+            { method: 0, line: 7 },
+            { method: 1, line: 3 },
+          ],
+        },
+        { frames: [{ method: 1, line: 3 }] },
+      ],
+      events: [
+        { type: `live`, stack: 0 },
+        { type: `live`, stack: 0 },
+        { type: `live`, stack: 1 },
+      ],
+      unweightedEventTypes: [`live`],
+    })
+
+    const md = convertBytesToMd(jfrConverter, bytes, options)
+
+    expect(profileTitles(md)).toEqual([`Object profile`])
+    expect(summaryLines(md)).toEqual([`Recorded 3 objects.`])
+    expect(selfObjectsTables(md)).toEqual([
+      [
+        {
+          '%': `66.7%`,
+          Objects: `2`,
+          Function: `allocate`,
+          Location: `com.example.A`,
+        },
+        {
+          '%': `33.3%`,
+          Objects: `1`,
+          Function: `run`,
           Location: `com.example.A`,
         },
       ],

--- a/src/formats/jfr/parse.ts
+++ b/src/formats/jfr/parse.ts
@@ -108,6 +108,14 @@ type Jfr = {
    * when the sampled stacks are pure Java frames.
    */
   isAsyncProfiler: boolean
+
+  /**
+   * The weighted kinds whose events lack their weight field in some chunk, so
+   * their profiles rank by count alone. Older JDKs write such layouts:
+   * `jdk.OldObjectSample` gained `objectSize` in JDK 21, so a JDK 17 recording
+   * records which objects were live but not how large they were.
+   */
+  unweightedKinds: Set<JfrSampleKind>
 }
 
 /**
@@ -217,6 +225,7 @@ const jfrToProfiles = ({
   stackTraces,
   events,
   isAsyncProfiler,
+  unweightedKinds,
 }: Jfr): CallStackProfile[] => {
   // Methods are a dense table whose index is the method id, shared across every
   // kind's profile as its distinct frames.
@@ -228,11 +237,12 @@ const jfrToProfiles = ({
   // profile per kind that's present (all sharing `frames`), like multi-metric
   // pprof.
   const profiles: CallStackProfile[] = []
-  for (const { kind, metric, countMetric } of KINDS) {
+  for (const { kind, metric: kindMetric, countMetric } of KINDS) {
     const kindEvents = byKind.get(kind)
     if (!kindEvents) {
       continue
     }
+    const metric = unweightedKinds.has(kind) ? undefined : kindMetric
     profiles.push({
       type: `call-stack-profile`,
       ...(isAsyncProfiler && { originHint: `async-profiler` }),
@@ -498,6 +508,7 @@ class JfrParser {
   readonly #tlabEvents: JfrSampleEvent[] = []
 
   #hasSampledAlloc = false
+  readonly #unweightedKinds = new Set<JfrSampleKind>()
 
   /**
    * Parses one self-contained chunk, accumulating its methods, stacks, and
@@ -529,6 +540,7 @@ class JfrParser {
       stackTraces: this.#stackInterner.items,
       events: this.#finalizeEvents(),
       isAsyncProfiler: this.#isAsyncProfiler,
+      unweightedKinds: this.#unweightedKinds,
     }
   }
 
@@ -790,13 +802,26 @@ class JfrParser {
 
   // Events
 
-  /** Maps this chunk's type IDs to their supported event kinds, skipping absent event types. */
+  /**
+   * Maps this chunk's type IDs to their supported event kinds, skipping absent
+   * event types. An event type declared without its kind's weight field, as an
+   * older JDK writes it, marks the kind unweighted so its profile ranks by
+   * count instead of by a weight no event recorded.
+   */
   #eventKinds(): Map<number, EventKind> {
     const eventKinds = new Map<number, EventKind>()
     for (const [name, eventKind] of EVENT_KINDS_BY_NAME) {
       const id = this.#typeIdsByName.get(name)
-      if (id !== undefined) {
-        eventKinds.set(id, eventKind)
+      if (id === undefined) {
+        continue
+      }
+      eventKinds.set(id, eventKind)
+      const { kind, weightField } = eventKind
+      if (
+        weightField !== undefined &&
+        !this.#types.get(id)!.fields.some(field => field.name === weightField)
+      ) {
+        this.#unweightedKinds.add(kind)
       }
     }
     return eventKinds

--- a/src/formats/jfr/testing.ts
+++ b/src/formats/jfr/testing.ts
@@ -57,6 +57,13 @@ export type JfrTestEvent = {
   samples?: number
 }
 
+/**
+ * The event types whose declaration and bodies can omit the weight field, as
+ * an older JDK writes them: `jdk.OldObjectSample` lacks `objectSize` before
+ * JDK 21.
+ */
+export type JfrUnweightedEventType = `live`
+
 // Metadata class IDs. Avoid 0 and 1, which are reserved for the metadata and
 // constant pool events in the chunk body.
 const LONG = 2
@@ -108,10 +115,14 @@ export const makeJfr = ({
   stackTraces,
   events,
   malformations: { emptyUnknownPools = [], unreadableEventTypes = [] } = {},
+  unweightedEventTypes = [],
 }: {
   methods: JfrTestMethod[]
   stackTraces: JfrTestStack[]
   events: JfrTestEvent[]
+
+  /** Event types declared and written without their weight field. */
+  unweightedEventTypes?: JfrUnweightedEventType[]
 
   /** Optional structural defects for parser-robustness tests. */
   malformations?: JfrMalformations
@@ -235,7 +246,9 @@ export const makeJfr = ({
         break
       case `live`:
         body.varint(stack + 1)
-        body.varint(weight ?? 0)
+        if (!unweightedEventTypes.includes(`live`)) {
+          body.varint(weight ?? 0)
+        }
         eventWriters.push(sizedEvent(OLD_OBJECT_SAMPLE, body))
         break
       case `liveobject`:
@@ -256,7 +269,7 @@ export const makeJfr = ({
     }
   }
 
-  const metadata = makeMetadata(unreadableEventTypes)
+  const metadata = makeMetadata(unreadableEventTypes, unweightedEventTypes)
   const constantPool = sizedEvent(CONSTANT_POOL_EVENT, pool)
 
   const bodyParts = [
@@ -290,7 +303,10 @@ const CONSTANT_POOL_EVENT = 1
 const METADATA_EVENT = 0
 
 /** Builds the metadata event declaring every type the parser reads. */
-const makeMetadata = (unreadableEventTypes: string[]): ByteWriter => {
+const makeMetadata = (
+  unreadableEventTypes: string[],
+  unweightedEventTypes: JfrUnweightedEventType[],
+): ByteWriter => {
   const strings = new StringTable()
 
   type Attr = [string, string]
@@ -385,7 +401,9 @@ const makeMetadata = (unreadableEventTypes: string[]): ByteWriter => {
     ]),
     type(OLD_OBJECT_SAMPLE, `jdk.OldObjectSample`, [
       field(`stackTrace`, STACK_TRACE, { constantPool: true }),
-      field(`objectSize`, LONG),
+      ...(unweightedEventTypes.includes(`live`)
+        ? []
+        : [field(`objectSize`, LONG)]),
     ]),
     type(LIVE_OBJECT, `profiler.LiveObject`, [
       field(`stackTrace`, STACK_TRACE, { constantPool: true }),

--- a/src/modalities/call-stack-profile/testing.ts
+++ b/src/modalities/call-stack-profile/testing.ts
@@ -94,6 +94,9 @@ export const selfSleepsTables = (md: string): Table[] =>
 export const totalSleepsTables = (md: string): Table[] =>
   allTablesAfterHeading(parseMd(md), `Total sleeps`)
 
+export const selfObjectsTables = (md: string): Table[] =>
+  allTablesAfterHeading(parseMd(md), `Self objects`)
+
 /**
  * The `Self size` tables under {@link section}, the heading separating the size
  * metrics an input records several of, whether as one profile's measures or as


### PR DESCRIPTION
jdk.OldObjectSample gained objectSize in JDK 21, so a JDK 17 recording records which objects were live but not how large they were. The parser assigned the profile a retained size metric regardless, so every event contributed a zero the ranking sorted by.

An event type declared without its kind's weight field now marks that kind unweighted, and its profile states no metric and ranks by object count alone.