### PR TITLE
feat(options): pass the format and origin to showEntry

### DIFF
--- a/src/modalities/call-graph/format.ts
+++ b/src/modalities/call-graph/format.ts
@@ -11,7 +11,10 @@ import {
   heading,
   paragraph,
 } from '../../helpers/markdown.ts'
-import type { FormattingProfileToMdOptions } from '../../options.ts'
+import type {
+  FormattingProfileToMdOptions,
+  ProfileToMdContext,
+} from '../../options.ts'
 import {
   formatRankingTables,
   rankEntities,
@@ -78,7 +81,9 @@ export const formatCallGraph = (
 
         const { sectionOptions, notes } = resolveEntryFilter({
           options,
-          showsAnyEntry: graph.functions.some(func => options.showEntry(func)),
+          showsAnyEntry: graph.functions.some(func =>
+            options.showEntry(func, graph.context),
+          ),
           disabledNote: ENTRY_FILTER_DISABLED_NOTE,
         })
         return [
@@ -156,7 +161,9 @@ const formatHottestFunctions = ({
   // Resolved once for both rankings, since a category's share comes from the
   // shown functions' self values whether the ranking is by self or total value.
   const categories = subsectionCategories({
-    entries: graph.functions.filter(func => options.showEntry(func)),
+    entries: graph.functions.filter(func =>
+      options.showEntry(func, graph.context),
+    ),
     selfValueOf: func => func.selfValues[measure.index]!,
     categoryOf: func => func.category,
     minCategoryShare: options.minCategoryShare,
@@ -200,7 +207,7 @@ const formatHottestSelfFunctions = ({
   const valueOf = (func: AggregatedCallGraphFunction) => func.selfValues[index]!
   const ranking = rankEntities({
     entities: graph.functions.filter(
-      func => options.showEntry(func) && valueOf(func) > 0,
+      func => options.showEntry(func, graph.context) && valueOf(func) > 0,
     ),
     categories,
     valueOf,
@@ -321,7 +328,7 @@ const formatHottestTotalFunctions = ({
     func.totalValues[index]!
   const ranking = rankEntities({
     entities: graph.functions.filter(
-      func => options.showEntry(func) && valueOf(func) > 0,
+      func => options.showEntry(func, graph.context) && valueOf(func) > 0,
     ),
     categories,
     valueOf,
@@ -339,6 +346,7 @@ const formatHottestTotalFunctions = ({
       func,
       entity: `Caller`,
       hasCallCounts,
+      context: graph.context,
       options,
       headingLevel: headingLevel + 2,
     }),
@@ -349,6 +357,7 @@ const formatHottestTotalFunctions = ({
       func,
       entity: `Callee`,
       hasCallCounts,
+      context: graph.context,
       options,
       headingLevel: headingLevel + 2,
     }),
@@ -401,6 +410,7 @@ const formatHottestArcs = ({
   func,
   entity,
   hasCallCounts,
+  context,
   options,
   headingLevel,
 }: {
@@ -408,6 +418,7 @@ const formatHottestArcs = ({
   func: AggregatedCallGraphFunction
   entity: `Caller` | `Callee`
   hasCallCounts: boolean
+  context: ProfileToMdContext
   options: FormattingProfileToMdOptions
   headingLevel: number
 }): RootContent[] => {
@@ -426,7 +437,9 @@ const formatHottestArcs = ({
         }))
 
   const hottestArcs = selectTopN(
-    arcs.filter(({ func, value }) => options.showEntry(func) && value > 0),
+    arcs.filter(
+      ({ func, value }) => options.showEntry(func, context) && value > 0,
+    ),
     Math.ceil(options.topN / 4),
     ({ value }) => value,
   )
@@ -468,7 +481,7 @@ export const formatCallGraphDiff = (
         const { sectionOptions, notes } = resolveEntryFilter({
           options,
           showsAnyEntry: diff.functions.some(func =>
-            showDiffEntity(func, options),
+            showDiffEntity(func, diff, options),
           ),
           disabledNote: ENTRY_FILTER_DISABLED_NOTE,
         })
@@ -556,7 +569,7 @@ const formatDiffFunctions = ({
 }): RootContent[] => {
   // Resolved once for both rankings, over the functions the diff shows.
   const categories = subsectionDiffCategories({
-    entries: diff.functions.filter(func => showDiffEntity(func, options)),
+    entries: diff.functions.filter(func => showDiffEntity(func, diff, options)),
     baseSelfValueOf: func => func.base?.selfValues[measure.baseIndex] ?? 0,
     currentSelfValueOf: func =>
       func.current?.selfValues[measure.currentIndex] ?? 0,
@@ -619,6 +632,7 @@ const formatDiffDirectionFunctions = ({
         baseValue: valueOf(func.base, baseIndex),
         currentValue: valueOf(func.current, currentIndex),
       })),
+      diff,
       options,
       { categories, categoryOf: func => func.category },
     )

--- a/src/modalities/call-stack-profile/format.ts
+++ b/src/modalities/call-stack-profile/format.ts
@@ -18,7 +18,10 @@ import {
   phrasing,
   text,
 } from '../../helpers/markdown.ts'
-import type { FormattingProfileToMdOptions } from '../../options.ts'
+import type {
+  FormattingProfileToMdOptions,
+  ProfileToMdContext,
+} from '../../options.ts'
 import {
   formatRankingTables,
   rankEntities,
@@ -131,14 +134,15 @@ const memoizeShowEntry = (
   const shownById = new Array<boolean | undefined>(profile.functions.length)
   let showsAnyEntry = false
   for (const func of profile.functions) {
-    if ((shownById[func.id] = showEntry(func))) {
+    if ((shownById[func.id] = showEntry(func, profile.context))) {
       showsAnyEntry = true
     }
   }
   return {
     memoizedOptions: {
       ...options,
-      showEntry: entry => shownById[entry.id] ?? showEntry(entry),
+      showEntry: (entry, context) =>
+        shownById[entry.id] ?? showEntry(entry, context),
     },
     showsAnyEntry,
   }
@@ -167,7 +171,7 @@ export const formatCallStackProfileDiff = (
         const { sectionOptions, notes } = resolveEntryFilter({
           options,
           showsAnyEntry: diff.functions.some(func =>
-            showDiffEntity(func, options),
+            showDiffEntity(func, diff, options),
           ),
           disabledNote: ENTRY_FILTER_DISABLED_NOTE,
         })
@@ -290,7 +294,9 @@ const formatHottestFunctions = ({
   // share of the shown functions' self value, which the ranking it appears
   // under doesn't change.
   const categories = subsectionCategories({
-    entries: profile.functions.filter(func => options.showEntry(func)),
+    entries: profile.functions.filter(func =>
+      options.showEntry(func, profile.context),
+    ),
     selfValueOf: func => selfValueOf(measure, func),
     categoryOf: func => func.category,
     minCategoryShare: options.minCategoryShare,
@@ -335,7 +341,7 @@ const formatHottestSelfFunctions = ({
   const countOf = (func: AggregatedCallStackProfileFunction) => func.selfCount
   const ranking = rankEntities({
     entities: profile.functions.filter(
-      func => options.showEntry(func) && valueOf(func) > 0,
+      func => options.showEntry(func, profile.context) && valueOf(func) > 0,
     ),
     categories,
     valueOf,
@@ -361,6 +367,7 @@ const formatHottestSelfFunctions = ({
     formatHottestCallers({
       measure,
       func,
+      context: profile.context,
       options,
       headingLevel: headingLevel + 2,
     }),
@@ -459,11 +466,13 @@ const formatHottestLines = ({
 const formatHottestCallers = ({
   measure,
   func,
+  context,
   options,
   headingLevel,
 }: {
   measure: Measure
   func: AggregatedCallStackProfileFunction
+  context: ProfileToMdContext
   options: FormattingProfileToMdOptions
   headingLevel: number
 }): RootContent[] => {
@@ -471,7 +480,8 @@ const formatHottestCallers = ({
   const hottestCallers = selectTopN(
     [...func.callerIdToMetrics.values()].filter(
       entry =>
-        options.showEntry(entry.caller) && selfValueOf(measure, entry) > 0,
+        options.showEntry(entry.caller, context) &&
+        selfValueOf(measure, entry) > 0,
     ),
     Math.ceil(options.topN / 4),
     entry => selfValueOf(measure, entry),
@@ -512,7 +522,7 @@ const formatHottestTotalFunctions = ({
   const countOf = (func: AggregatedCallStackProfileFunction) => func.totalCount
   const ranking = rankEntities({
     entities: profile.functions.filter(
-      func => options.showEntry(func) && valueOf(func) > 0,
+      func => options.showEntry(func, profile.context) && valueOf(func) > 0,
     ),
     categories,
     valueOf,
@@ -527,6 +537,7 @@ const formatHottestTotalFunctions = ({
     formatHottestCallees({
       measure,
       func,
+      context: profile.context,
       options,
       headingLevel: headingLevel + 2,
     }),
@@ -558,11 +569,13 @@ const formatHottestTotalFunctions = ({
 const formatHottestCallees = ({
   measure,
   func,
+  context,
   options,
   headingLevel,
 }: {
   measure: Measure
   func: AggregatedCallStackProfileFunction
+  context: ProfileToMdContext
   options: FormattingProfileToMdOptions
   headingLevel: number
 }): RootContent[] => {
@@ -570,7 +583,8 @@ const formatHottestCallees = ({
   const hottestCallees = selectTopN(
     [...func.calleeIdToMetrics.values()].filter(
       entry =>
-        options.showEntry(entry.callee) && totalValueOf(measure, entry) > 0,
+        options.showEntry(entry.callee, context) &&
+        totalValueOf(measure, entry) > 0,
     ),
     Math.ceil(options.topN / 4),
     entry => totalValueOf(measure, entry),
@@ -605,7 +619,7 @@ const formatHottestCallStacks = ({
   headingLevel: number
 }): RootContent[] => {
   const hottestCallStacks = selectTopN(
-    mergeShownCallStacks(profile.callStacks, options).filter(
+    mergeShownCallStacks(profile, options).filter(
       callStack => selfValueOf(measure, callStack) > 0,
     ),
     options.topN,
@@ -705,13 +719,13 @@ type ShownCallStack = {
  * frames are dropped: a single-frame "stack" has no call structure.
  */
 const mergeShownCallStacks = (
-  callStacks: AggregatedCallStackProfileCallStack[],
+  { callStacks, context }: AggregatedCallStackProfile,
   options: FormattingProfileToMdOptions,
 ): ShownCallStack[] => {
   const interner = newShownCallStackInterner()
   const { showEntry } = options
   for (const callStack of callStacks) {
-    const frames = shownFramesOf(callStack.frames, showEntry)
+    const frames = shownFramesOf(callStack.frames, context, showEntry)
     if (frames === null) {
       continue
     }
@@ -763,13 +777,14 @@ const newShownCallStackInterner = (): HashInterner<
  */
 const shownFramesOf = (
   frames: AggregatedCallStackProfileFunction[],
+  context: ProfileToMdContext,
   showEntry: FormattingProfileToMdOptions[`showEntry`],
 ): ShownFrame[] | null => {
   const shownFrames: ShownFrame[] = []
   let shownCount = 0
   let hidAnyFrame = false
   for (const frame of frames) {
-    if (!showEntry(frame)) {
+    if (!showEntry(frame, context)) {
       hidAnyFrame = true
       continue
     }
@@ -940,7 +955,7 @@ const formatDiffFunctions = ({
   // Resolved once for both rankings, like the ones a single profile gets, and
   // over the same functions each side of the diff shows.
   const categories = subsectionDiffCategories({
-    entries: diff.functions.filter(func => showDiffEntity(func, options)),
+    entries: diff.functions.filter(func => showDiffEntity(func, diff, options)),
     baseSelfValueOf: func =>
       func.base === undefined ? 0 : selfValueOf(measure.base, func.base),
     currentSelfValueOf: func =>
@@ -1029,6 +1044,7 @@ const formatDiffDirectionFunctions = ({
         baseValue: diffValue(baseMeasure, func.base),
         currentValue: diffValue(currentMeasure, func.current),
       })),
+      diff,
       options,
       { categories, categoryOf: func => func.category },
     )

--- a/src/modalities/format.ts
+++ b/src/modalities/format.ts
@@ -15,6 +15,7 @@ import type {
   AggregatedProfileEntry,
   FormattingProfileToMdOptions,
   FunctionCategory,
+  ProfileToMdContext,
 } from '../options.ts'
 import type { Diff } from './diff.ts'
 import type { HeapSnapshotNodeCategory } from './heap-snapshot/type.ts'
@@ -363,15 +364,22 @@ export const resolveEntryFilter = ({
         notes: [paragraph(disabledNote)],
       }
 
+/** The two sides of a diff, each stating the context it was aggregated under. */
+export type DiffSides = {
+  base: { context: ProfileToMdContext }
+  current: { context: ProfileToMdContext }
+}
+
 /** Returns whether either side of the diffed entity should be shown. */
 export const showDiffEntity = <
   Entry extends DeepReadonly<AggregatedProfileEntry>,
 >(
   { base, current }: Diff<Entry>,
+  sides: DiffSides,
   options: FormattingProfileToMdOptions,
 ): boolean =>
-  (base !== undefined && options.showEntry(base)) ||
-  (current !== undefined && options.showEntry(current))
+  (base !== undefined && options.showEntry(base, sides.base.context)) ||
+  (current !== undefined && options.showEntry(current, sides.current.context))
 
 /** A diffed entity paired with its base and current values for one measure. */
 export type ActiveDiffEntity<Entity> = {
@@ -393,6 +401,7 @@ export const selectDiffEntities = <
   Entity extends Diff<DeepReadonly<AggregatedProfileEntry>>,
 >(
   candidates: ActiveDiffEntity<Entity>[],
+  sides: DiffSides,
   options: FormattingProfileToMdOptions,
   categories?: {
     categories: Category[]
@@ -406,7 +415,8 @@ export const selectDiffEntities = <
 } => {
   const active = candidates.filter(
     ({ entity, baseValue, currentValue }) =>
-      (baseValue > 0 || currentValue > 0) && showDiffEntity(entity, options),
+      (baseValue > 0 || currentValue > 0) &&
+      showDiffEntity(entity, sides, options),
   )
   const increased = active.filter(
     ({ baseValue, currentValue }) => currentValue > baseValue,

--- a/src/modalities/heap-snapshot/format.ts
+++ b/src/modalities/heap-snapshot/format.ts
@@ -17,7 +17,10 @@ import {
 } from '../../helpers/markdown.ts'
 import { formatSourceLocation } from '../../location.ts'
 import type { FileReference, SourceLocation } from '../../location.ts'
-import type { FormattingProfileToMdOptions } from '../../options.ts'
+import type {
+  FormattingProfileToMdOptions,
+  ProfileToMdContext,
+} from '../../options.ts'
 import {
   formatRankingTables,
   rankEntities,
@@ -69,9 +72,14 @@ export const formatHeapSnapshot = (
   const { sectionOptions, notes } = resolveEntryFilter({
     options,
     showsAnyEntry:
-      snapshot.constructors.some(options.showEntry) ||
+      snapshot.constructors.some(constructor =>
+        options.showEntry(constructor, snapshot.context),
+      ) ||
       snapshot.functions.some(fn =>
-        options.showEntry({ ...fn, id: fn.largestInstanceId }),
+        options.showEntry(
+          { ...fn, id: fn.largestInstanceId },
+          snapshot.context,
+        ),
       ),
     disabledNote: ENTRY_FILTER_DISABLED_NOTE,
   })
@@ -143,7 +151,9 @@ const formatLargestConstructors = ({
   // its share of the shown constructors' summed self size, which the ranking it
   // appears under doesn't change.
   const categories = subsectionCategories({
-    entries: snapshot.constructors.filter(options.showEntry),
+    entries: snapshot.constructors.filter(constructor =>
+      options.showEntry(constructor, snapshot.context),
+    ),
     selfValueOf: constructor => constructor.selfSize,
     categoryOf: constructor => constructor.category,
     minCategoryShare: options.minCategoryShare,
@@ -226,10 +236,12 @@ const formatLargestSizeConstructors = ({
   options: FormattingProfileToMdOptions
   size: ConstructorSize
 }): RootContent[] => {
-  const { totalSize, constructors } = snapshot
+  const { totalSize, constructors, context } = snapshot
 
   const ranking = rankEntities({
-    entities: constructors.filter(options.showEntry),
+    entities: constructors.filter(constructor =>
+      options.showEntry(constructor, context),
+    ),
     categories,
     valueOf: sizeOf,
     topN: options.topN,
@@ -371,11 +383,11 @@ const formatLargestFunctions = ({
   hasLocation: boolean
   options: FormattingProfileToMdOptions
 }): RootContent[] => {
-  const { totalSize, functions, retainerPathOf } = snapshot
+  const { totalSize, functions, retainerPathOf, context } = snapshot
 
   const largestFunctions = selectTopN(
     functions.filter(fn =>
-      options.showEntry({ ...fn, id: fn.largestInstanceId }),
+      options.showEntry({ ...fn, id: fn.largestInstanceId }, context),
     ),
     options.topN,
     fn => fn.retainedSize,
@@ -419,7 +431,7 @@ const formatLargestFunctions = ({
 
 const formatFunctionRetainedObjects = ({
   fn,
-  snapshot: { retainedNodesOf, retainerPathOf },
+  snapshot: { retainedNodesOf, retainerPathOf, context },
   hasLocation,
   options,
 }: {
@@ -429,7 +441,7 @@ const formatFunctionRetainedObjects = ({
   options: FormattingProfileToMdOptions
 }): RootContent[] => {
   const retainedNodes = selectTopN(
-    collectShownRetainedNodes(fn, retainedNodesOf, options),
+    collectShownRetainedNodes(fn, retainedNodesOf, context, options),
     Math.ceil(options.topN / 4),
     node => node.selfSize,
   )
@@ -458,6 +470,7 @@ const formatFunctionRetainedObjects = ({
 const collectShownRetainedNodes = (
   fn: AggregatedHeapSnapshotFunction,
   retainedNodesOf: AggregatedHeapSnapshot[`retainedNodesOf`],
+  context: ProfileToMdContext,
   options: FormattingProfileToMdOptions,
 ): AggregatedHeapSnapshotNode[] => {
   const instanceIdToSeen = new DynamicTypedArray(new Uint8Array(256))
@@ -469,7 +482,7 @@ const collectShownRetainedNodes = (
         continue
       }
       seen[node.id] = 1
-      if (options.showEntry(node)) {
+      if (options.showEntry(node, context)) {
         retainedNodes.push(node)
       }
     }
@@ -531,8 +544,8 @@ export const formatHeapSnapshotDiff = (
   const { sectionOptions, notes } = resolveEntryFilter({
     options,
     showsAnyEntry:
-      diff.constructors.some(entity => showDiffEntity(entity, options)) ||
-      diff.functions.some(entity => showDiffEntity(entity, options)),
+      diff.constructors.some(entity => showDiffEntity(entity, diff, options)) ||
+      diff.functions.some(entity => showDiffEntity(entity, diff, options)),
     disabledNote: ENTRY_FILTER_DISABLED_NOTE,
   })
   return [
@@ -617,7 +630,7 @@ const formatDiffConstructors = ({
   // same constructors each side of the diff shows.
   const categories = subsectionDiffCategories({
     entries: diff.constructors.filter(entity =>
-      showDiffEntity(entity, options),
+      showDiffEntity(entity, diff, options),
     ),
     baseSelfValueOf: entity => entity.base?.selfSize ?? 0,
     currentSelfValueOf: entity => entity.current?.selfSize ?? 0,
@@ -666,6 +679,7 @@ const formatDiffSizeConstructors = ({
         baseValue: entity.base ? sizeOf(entity.base) : 0,
         currentValue: entity.current ? sizeOf(entity.current) : 0,
       })),
+      diff,
       options,
       { categories, categoryOf: entity => entity.category ?? `object` },
     )
@@ -711,6 +725,7 @@ const formatDiffFunctions = ({
       baseValue: entity.base ? entity.base.retainedSize : 0,
       currentValue: entity.current ? entity.current.retainedSize : 0,
     })),
+    diff,
     options,
   )
 
@@ -760,7 +775,9 @@ const formatDiffStrings = ({
   const categoryOf = (entity: AggregatedHeapSnapshotEntityDiff) =>
     entity.category ?? `string`
   const categories = subsectionDiffCategories({
-    entries: diff.strings.filter(entity => showDiffEntity(entity, options)),
+    entries: diff.strings.filter(entity =>
+      showDiffEntity(entity, diff, options),
+    ),
     baseSelfValueOf: entity => entity.base?.selfSize ?? 0,
     currentSelfValueOf: entity => entity.current?.selfSize ?? 0,
     categoryOf,
@@ -774,6 +791,7 @@ const formatDiffStrings = ({
         baseValue: entity.base ? entity.base.selfSize : 0,
         currentValue: entity.current ? entity.current.selfSize : 0,
       })),
+      diff,
       options,
       { categories, categoryOf },
     )

--- a/src/options.ts
+++ b/src/options.ts
@@ -261,7 +261,10 @@ export type ProfileToMdOptions = {
    *
    * Defaults to {@link defaultShowEntry}.
    */
-  showEntry?: (entry: DeepReadonly<AggregatedProfileEntry>) => boolean
+  showEntry?: (
+    entry: DeepReadonly<AggregatedProfileEntry>,
+    context: ProfileToMdContext,
+  ) => boolean
 }
 
 /** {@link ProfileToMdOptions} with defaults applied. */
@@ -275,7 +278,10 @@ export type NormalizedProfileToMdOptions = {
     entries: readonly ProfileEntry[],
     context: ProfileToMdContext,
   ) => readonly FunctionCategory[]
-  showEntry: (entry: DeepReadonly<AggregatedProfileEntry>) => boolean
+  showEntry: (
+    entry: DeepReadonly<AggregatedProfileEntry>,
+    context: ProfileToMdContext,
+  ) => boolean
 }
 
 /**


### PR DESCRIPTION
A custom showEntry had to decide from the entry alone, though whether a name or location means the entry is worth showing depends on who wrote the input. matchEntry and categorizeFunctions already receive the context, so showEntry now takes it as a second parameter too. A diff resolves it per side, since the base and current may come from different origins.

Closes #377