### PR TITLE
refactor(testing): share a byte buffer across the binary format writers

### DIFF
--- a/src/formats/jfr/testing.ts
+++ b/src/formats/jfr/testing.ts
@@ -6,6 +6,8 @@
  * aggregator without depending on the binary input.
  */
 
+import { ByteBuffer } from '../../helpers/testing.ts'
+
 /** A method to place in the constant pools, referenced by index. */
 export type JfrTestMethod = {
   name: string
@@ -500,38 +502,30 @@ class StringTable {
   }
 }
 
+/** Writes a recording's varint-encoded events. */
 class ByteWriter {
-  readonly #bytes: number[] = []
+  readonly #buffer = new ByteBuffer()
 
   public byte(value: number): void {
-    this.#bytes.push(value & 0xff)
+    this.#buffer.byte(value)
   }
 
   public varint(value: number): void {
-    let remaining = value
-    while (remaining >= 0x80) {
-      this.#bytes.push((remaining & 0x7f) | 0x80)
-      remaining = Math.floor(remaining / 128)
-    }
-    this.#bytes.push(remaining & 0x7f)
+    this.#buffer.leb128(value)
   }
 
   public string(value: string): void {
     const utf8 = new TextEncoder().encode(value)
     this.byte(3) // UTF-8 encoding
     this.varint(utf8.length)
-    for (const byte of utf8) {
-      this.#bytes.push(byte)
-    }
+    this.append(utf8)
   }
 
   public append(bytes: Uint8Array): void {
-    for (const byte of bytes) {
-      this.#bytes.push(byte)
-    }
+    this.#buffer.bytes(bytes)
   }
 
   public toBytes(): Uint8Array {
-    return Uint8Array.from(this.#bytes)
+    return this.#buffer.toBytes()
   }
 }

--- a/src/formats/memray/testing.ts
+++ b/src/formats/memray/testing.ts
@@ -6,6 +6,8 @@
  * on the committed inputs.
  */
 
+import { ByteBuffer } from '../../helpers/testing.ts'
+
 /** The allocators a test allocation names, by their capture file values. */
 const MEMRAY_PYMALLOC_FREE = 1
 export const MEMRAY_FREE = 5
@@ -405,11 +407,12 @@ const writeUncachedAddress = (
   state.lastDataPointer = address / 8
 }
 
+/** Writes a capture's little-endian records. */
 class ByteWriter {
-  readonly #bytes: number[] = []
+  readonly #buffer = new ByteBuffer()
 
   public byte(value: number): void {
-    this.#bytes.push(value & 0xff)
+    this.#buffer.byte(value)
   }
 
   public uint32(value: number): void {
@@ -424,12 +427,7 @@ class ByteWriter {
   }
 
   public varint(value: number): void {
-    let remaining = value
-    while (remaining >= 0x80) {
-      this.byte((remaining % 128) | 0x80)
-      remaining = Math.floor(remaining / 128)
-    }
-    this.byte(remaining)
+    this.#buffer.leb128(value)
   }
 
   public signedVarint(value: number): void {
@@ -443,12 +441,10 @@ class ByteWriter {
   }
 
   public bytes(bytes: Uint8Array): void {
-    for (const byte of bytes) {
-      this.#bytes.push(byte)
-    }
+    this.#buffer.bytes(bytes)
   }
 
   public toBytes(): Uint8Array {
-    return Uint8Array.from(this.#bytes)
+    return this.#buffer.toBytes()
   }
 }

--- a/src/helpers/testing.ts
+++ b/src/helpers/testing.ts
@@ -8,6 +8,7 @@ import type {
 import { fromMarkdown } from 'mdast-util-from-markdown'
 import { gfmFromMarkdown } from 'mdast-util-gfm'
 import { gfm } from 'micromark-extension-gfm'
+import { DynamicTypedArray } from './array.ts'
 import { nodeText } from './markdown.ts'
 
 /** Wraps {@link chunks} in a `ReadableStream`. */
@@ -28,6 +29,44 @@ export const chunk = (bytes: Uint8Array, chunkSize: number): Uint8Array[] => {
     chunks.push(bytes.subarray(offset, offset + chunkSize))
   }
   return chunks
+}
+
+/**
+ * A growable buffer of bytes written for a test.
+ *
+ * It encodes the parts binary formats share: single bytes, byte runs, and
+ * unsigned LEB128. A format's writer wraps it and adds the integer widths,
+ * endianness, and record framing its own encoding uses.
+ */
+export class ByteBuffer {
+  readonly #bytes = new DynamicTypedArray(new Uint8Array(1024))
+  #length = 0
+
+  public byte(value: number): void {
+    this.#bytes.ensureCapacity(this.#length + 1)[this.#length++] = value & 0xff
+  }
+
+  public bytes(bytes: Uint8Array): void {
+    this.#bytes
+      .ensureCapacity(this.#length + bytes.length)
+      .set(bytes, this.#length)
+    this.#length += bytes.length
+  }
+
+  /** Writes an unsigned LEB128 integer, seven bits per byte, low group first. */
+  public leb128(value: number): void {
+    let remaining = value
+    while (remaining >= 0x80) {
+      this.byte((remaining % 128) | 0x80)
+      remaining = Math.floor(remaining / 128)
+    }
+    this.byte(remaining)
+  }
+
+  /** The bytes written so far, copied so later writes don't change them. */
+  public toBytes(): Uint8Array {
+    return this.#bytes.array.slice(0, this.#length)
+  }
 }
 
 type Row = Record<string, string>


### PR DESCRIPTION
The JFR and memray test writers each grew a byte-appending buffer of their own. Both now compose over a `ByteBuffer` holding what the two share: single bytes, byte runs, and unsigned LEB128.