### PR TITLE
refactor(heap-snapshot): derive the predecessor lists in one place

### DIFF
--- a/src/formats/v8/heap-snapshot/parse.ts
+++ b/src/formats/v8/heap-snapshot/parse.ts
@@ -4,7 +4,7 @@ import {
   sourceReferenceToSourceLocation,
 } from '../../../location.ts'
 import type { FileReference, SourceLocation } from '../../../location.ts'
-import { computeStartOffsets } from '../../../modalities/heap-snapshot/index.ts'
+import { nodeAdjacencyGraphFromSuccessors } from '../../../modalities/heap-snapshot/index.ts'
 import type {
   HeapSnapshot,
   HeapSnapshotNode,
@@ -232,13 +232,12 @@ const computeNodeAdjacencyGraph = (
   // Decode the plain JSON `nodes` and `edges` arrays once, recording each
   // retaining (non-weak) edge's successor and edge index in discovery order.
   // Discovery order groups edges by their node, so these arrays are the
-  // successor CSR lists. The second pass scatters the predecessor side,
-  // reading these arrays back sequentially instead of re-decoding.
+  // successor CSR lists. The predecessor side is scattered from them without
+  // re-decoding.
   const totalEdgeCount = edges.length / edgeFieldCount
   let offsetToSuccessorOrdinal = new Int32Array(totalEdgeCount)
   let offsetToSuccessorEdgeIndex = new Int32Array(totalEdgeCount)
   const ordinalToSuccessorCount = new Int32Array(nodeCount)
-  const ordinalToPredecessorCount = new Int32Array(nodeCount)
   let retainingEdgeCount = 0
   let nodeEdgesStartIndex = 0
   for (let nodeOrdinal = 0; nodeOrdinal < nodeCount; nodeOrdinal++) {
@@ -254,7 +253,6 @@ const computeNodeAdjacencyGraph = (
       const successorOrdinal =
         edges[edgeIndex + edgeToNodeOffset]! / nodeFieldCount
       ordinalToSuccessorCount[nodeOrdinal]!++
-      ordinalToPredecessorCount[successorOrdinal]!++
       offsetToSuccessorOrdinal[retainingEdgeCount] = successorOrdinal
       offsetToSuccessorEdgeIndex[retainingEdgeCount] = edgeIndex
       retainingEdgeCount++
@@ -274,42 +272,11 @@ const computeNodeAdjacencyGraph = (
     )
   }
 
-  const ordinalToSuccessorStartOffset = computeStartOffsets(
+  return nodeAdjacencyGraphFromSuccessors(
     ordinalToSuccessorCount,
-  )
-  const ordinalToPredecessorStartOffset = computeStartOffsets(
-    ordinalToPredecessorCount,
-  )
-
-  // Scatter the predecessor CSR lists, reusing the predecessor count array as
-  // write cursors rather than allocating a new one.
-  const offsetToPredecessorOrdinal = new Int32Array(retainingEdgeCount)
-  const offsetToPredecessorEdgeIndex = new Int32Array(retainingEdgeCount)
-  const ordinalToPredecessorCursor = ordinalToPredecessorCount
-  ordinalToPredecessorCursor.fill(0)
-  let successorOffset = 0
-  for (let nodeOrdinal = 0; nodeOrdinal < nodeCount; nodeOrdinal++) {
-    const successorEndOffset = ordinalToSuccessorStartOffset[nodeOrdinal + 1]!
-    for (; successorOffset < successorEndOffset; successorOffset++) {
-      const successorOrdinal = offsetToSuccessorOrdinal[successorOffset]!
-      const predecessorOffset =
-        ordinalToPredecessorStartOffset[successorOrdinal]! +
-        ordinalToPredecessorCursor[successorOrdinal]!
-      offsetToPredecessorOrdinal[predecessorOffset] = nodeOrdinal
-      offsetToPredecessorEdgeIndex[predecessorOffset] =
-        offsetToSuccessorEdgeIndex[successorOffset]!
-      ordinalToPredecessorCursor[successorOrdinal]!++
-    }
-  }
-
-  return {
-    ordinalToSuccessorStartOffset,
     offsetToSuccessorOrdinal,
     offsetToSuccessorEdgeIndex,
-    ordinalToPredecessorStartOffset,
-    offsetToPredecessorOrdinal,
-    offsetToPredecessorEdgeIndex,
-  }
+  )
 }
 
 const computeNodeOrdinalToLocation = (

--- a/src/modalities/heap-snapshot/graph.ts
+++ b/src/modalities/heap-snapshot/graph.ts
@@ -70,6 +70,62 @@ export const computeStartOffsets = (ordinalToCount: Int32Array): Int32Array => {
 }
 
 /**
+ * Builds a {@link NodeAdjacencyGraph} from successor lists already grouped by
+ * the node holding each edge, scattering the predecessor side from them.
+ *
+ * The successor lists are kept as they are, so the graph reports the caller's
+ * edge order.
+ */
+export const nodeAdjacencyGraphFromSuccessors = (
+  ordinalToSuccessorCount: Int32Array,
+  offsetToSuccessorOrdinal: Int32Array,
+  offsetToSuccessorEdgeIndex: Int32Array,
+): NodeAdjacencyGraph => {
+  const nodeCount = ordinalToSuccessorCount.length
+  const ordinalToSuccessorStartOffset = computeStartOffsets(
+    ordinalToSuccessorCount,
+  )
+
+  const ordinalToPredecessorCount = new Int32Array(nodeCount)
+  for (const successorOrdinal of offsetToSuccessorOrdinal) {
+    ordinalToPredecessorCount[successorOrdinal]!++
+  }
+  const ordinalToPredecessorStartOffset = computeStartOffsets(
+    ordinalToPredecessorCount,
+  )
+
+  // Reuse the predecessor count array as write cursors rather than allocating
+  // a new one.
+  const edgeCount = offsetToSuccessorOrdinal.length
+  const offsetToPredecessorOrdinal = new Int32Array(edgeCount)
+  const offsetToPredecessorEdgeIndex = new Int32Array(edgeCount)
+  const ordinalToPredecessorCursor = ordinalToPredecessorCount
+  ordinalToPredecessorCursor.fill(0)
+  let successorOffset = 0
+  for (let nodeOrdinal = 0; nodeOrdinal < nodeCount; nodeOrdinal++) {
+    const successorEndOffset = ordinalToSuccessorStartOffset[nodeOrdinal + 1]!
+    for (; successorOffset < successorEndOffset; successorOffset++) {
+      const successorOrdinal = offsetToSuccessorOrdinal[successorOffset]!
+      const predecessorOffset =
+        ordinalToPredecessorStartOffset[successorOrdinal]! +
+        ordinalToPredecessorCursor[successorOrdinal]!++
+      offsetToPredecessorOrdinal[predecessorOffset] = nodeOrdinal
+      offsetToPredecessorEdgeIndex[predecessorOffset] =
+        offsetToSuccessorEdgeIndex[successorOffset]!
+    }
+  }
+
+  return {
+    ordinalToSuccessorStartOffset,
+    offsetToSuccessorOrdinal,
+    offsetToSuccessorEdgeIndex,
+    ordinalToPredecessorStartOffset,
+    offsetToPredecessorOrdinal,
+    offsetToPredecessorEdgeIndex,
+  }
+}
+
+/**
  * The immediate dominator graph for a heap snapshot in CSR format.
  *
  * There's a 1:N relationship between immediate dominator and immediate


### PR DESCRIPTION
The V8 parser scattered the predecessor CSR lists itself, so every parser that builds successor lists first would repeat that. `nodeAdjacencyGraphFromSuccessors` now scatters them, and reports the caller's successor order unchanged.