### PR TITLE
fix(heap-snapshot): merge diffed constructors sharing a match key

### DIFF
--- a/src/modalities/call-graph/diff.ts
+++ b/src/modalities/call-graph/diff.ts
@@ -71,12 +71,12 @@ export const diffAggregatedCallGraphs = (
     throw new ProfilerMdError(`cannot diff profiles with no metrics in common`)
   }
 
-  const { entryMatchKey } = options
+  const { entryMatchKeys } = options
   const functions = matchDiffedEntries(
     base.functions,
     current.functions,
-    func => entryMatchKey(func, base.context),
-    func => entryMatchKey(func, current.context),
+    func => entryMatchKeys(func, base.context).nameAndLocation,
+    func => entryMatchKeys(func, current.context).nameAndLocation,
   ).map(({ base: baseFunc, current: currentFunc }) => {
     const { name, location, category } = (currentFunc ?? baseFunc)!
     return { name, location, category, base: baseFunc, current: currentFunc }

--- a/src/modalities/call-stack-profile/diff.ts
+++ b/src/modalities/call-stack-profile/diff.ts
@@ -130,12 +130,12 @@ export const diffAggregatedCallStackProfiles = (
     throw new ProfilerMdError(`cannot diff profiles with no metrics in common`)
   }
 
-  const { entryMatchKey } = options
+  const { entryMatchKeys } = options
   const functions = matchDiffedEntries(
     base.functions,
     current.functions,
-    func => entryMatchKey(func, base.context),
-    func => entryMatchKey(func, current.context),
+    func => entryMatchKeys(func, base.context).nameAndLocation,
+    func => entryMatchKeys(func, current.context).nameAndLocation,
   ).map(({ base: baseFunc, current: currentFunc }) => {
     const { name, location, category } = (currentFunc ?? baseFunc)!
     return { name, location, category, base: baseFunc, current: currentFunc }

--- a/src/modalities/heap-snapshot/diff.test.ts
+++ b/src/modalities/heap-snapshot/diff.test.ts
@@ -124,6 +124,60 @@ describe(`diffAggregatedHeapSnapshots`, () => {
     expect(rankingTables(md, `Self size`, `Improvements`)).toEqual([])
   })
 
+  test(`merges and matches constructors whose names differ by a per-run address`, () => {
+    // The runtime includes a per-run address in the name. Match normalization
+    // strips it so the same class matches across snapshots.
+    const options = resolveProfileToMdOptions({
+      baseURL: `/project`,
+      matchEntry: ({ name }) => ({
+        name: (name ?? ``).replace(/@0x[0-9a-f]+$/u, ``),
+      }),
+    })
+    const base = makeAggregatedHeapSnapshot({
+      constructors: [
+        makeAggregatedHeapSnapshotConstructor({
+          name: `MyClass@0x1003a68`,
+          selfSize: 100,
+          retainedSize: 100,
+          instanceCount: 1,
+        }),
+        makeAggregatedHeapSnapshotConstructor({
+          name: `MyClass@0x117f9d8`,
+          selfSize: 100,
+          retainedSize: 100,
+          instanceCount: 1,
+        }),
+      ],
+    })
+    const current = makeAggregatedHeapSnapshot({
+      constructors: [
+        makeAggregatedHeapSnapshotConstructor({
+          name: `MyClass@0x10d95b8`,
+          selfSize: 300,
+          retainedSize: 300,
+          instanceCount: 3,
+        }),
+      ],
+    })
+
+    const diff = diffAggregatedHeapSnapshots(base, current, options)
+    const md = mdastToMarkdown(formatHeapSnapshotDiff(diff, options))
+
+    expect(rankingTables(md, `Self size`, `Regressions`)).toEqual([
+      [
+        {
+          Change: `+50.0%`,
+          Delta: `+100 B`,
+          '%': `100.0%`,
+          Size: `200 B → 300 B`,
+          Instances: `2 → 3`,
+          Constructor: `MyClass`,
+        },
+      ],
+    ])
+    expect(rankingTables(md, `Self size`, `Improvements`)).toEqual([])
+  })
+
   test(`matches functions by name and file despite differing line and column`, () => {
     const base = makeAggregatedHeapSnapshot({
       functions: [

--- a/src/modalities/heap-snapshot/diff.ts
+++ b/src/modalities/heap-snapshot/diff.ts
@@ -96,15 +96,11 @@ export const diffAggregatedHeapSnapshots = (
     current.nodeCategoryToStats,
   ),
   constructors: entityDiffsFromMatches(
+    // Each side's constructors are keyed under that side's own context, since
+    // match normalization is origin-aware.
     matchDiffedMaps(
-      base.constructors.map(constructor => [
-        constructor.name,
-        diffedConstructor(constructor),
-      ]),
-      current.constructors.map(constructor => [
-        constructor.name,
-        diffedConstructor(constructor),
-      ]),
+      mergeConstructors(base.constructors, base.context, options),
+      mergeConstructors(current.constructors, current.context, options),
     ),
   ),
   functions: entityDiffsFromMatches(
@@ -120,27 +116,56 @@ export const diffAggregatedHeapSnapshots = (
   ),
 })
 
-const diffedConstructor = ({
-  id,
-  name,
-  nameLocation,
-  location,
-  category,
-  selfSize,
-  retainedSize,
-  instances,
-}: AggregatedHeapSnapshotConstructor): DiffedHeapSnapshotEntity => ({
-  type: `node`,
-  id,
-  name,
-  nameLocation,
-  location,
-  category,
-  selfSize,
-  retainedSize,
-  instanceCount: instances.length,
-  instanceIds: [],
-})
+/**
+ * Merges constructors sharing the same normalized name so the same class
+ * matches across snapshots even when the runtime includes a per-run address in
+ * its name. The JVM includes one in the names of the hidden classes it
+ * generates for lambdas.
+ *
+ * A constructor's location records where one instance was allocated instead of
+ * identifying the class, so the merge keys by name alone.
+ *
+ * A merged constructor takes the normalized name its members share, because
+ * each member's own name contains the per-run part they differ in. Merged
+ * members can be categorized differently, so it takes the category of its
+ * largest member.
+ */
+const mergeConstructors = (
+  constructors: AggregatedHeapSnapshotConstructor[],
+  context: ProfileToMdContext,
+  options: FormattingProfileToMdOptions,
+): Map<string, DiffedHeapSnapshotEntity> => {
+  const keyToConstructor = new Map<string, DiffedHeapSnapshotEntity>()
+  const keyToCategorySelfSize = new Map<string, number>()
+  for (const constructor of constructors) {
+    const key = options.entryMatchKeys(constructor, context).name
+    const merged = keyToConstructor.get(key)
+    if (merged) {
+      merged.selfSize += constructor.selfSize
+      merged.retainedSize += constructor.retainedSize
+      merged.instanceCount += constructor.instances.length
+      if (constructor.selfSize > keyToCategorySelfSize.get(key)!) {
+        merged.category = constructor.category
+        keyToCategorySelfSize.set(key, constructor.selfSize)
+      }
+    } else {
+      keyToCategorySelfSize.set(key, constructor.selfSize)
+      keyToConstructor.set(key, {
+        type: `node`,
+        id: constructor.id,
+        name: key,
+        nameLocation: constructor.nameLocation,
+        location: constructor.location,
+        category: constructor.category,
+        selfSize: constructor.selfSize,
+        retainedSize: constructor.retainedSize,
+        instanceCount: constructor.instances.length,
+        instanceIds: [],
+      })
+    }
+  }
+  return keyToConstructor
+}
 
 /**
  * Merges functions sharing the same match key so the same function matches
@@ -152,24 +177,24 @@ const mergeFunctions = (
   options: FormattingProfileToMdOptions,
 ): Map<string, DiffedHeapSnapshotEntity> => {
   const keyToFunction = new Map<string, DiffedHeapSnapshotEntity>()
-  for (const fn of functions) {
-    const key = options.entryMatchKey(fn, context)
+  for (const func of functions) {
+    const key = options.entryMatchKeys(func, context).nameAndLocation
     const merged = keyToFunction.get(key)
     if (merged) {
-      merged.selfSize += fn.selfSize
-      merged.retainedSize += fn.retainedSize
-      merged.instanceCount += fn.instanceIds.length
-      merged.instanceIds.push(...fn.instanceIds)
+      merged.selfSize += func.selfSize
+      merged.retainedSize += func.retainedSize
+      merged.instanceCount += func.instanceIds.length
+      merged.instanceIds.push(...func.instanceIds)
     } else {
       keyToFunction.set(key, {
         type: `node`,
-        id: fn.largestInstanceId,
-        name: fn.name,
-        location: fn.location,
-        selfSize: fn.selfSize,
-        retainedSize: fn.retainedSize,
-        instanceCount: fn.instanceIds.length,
-        instanceIds: [...fn.instanceIds],
+        id: func.largestInstanceId,
+        name: func.name,
+        location: func.location,
+        selfSize: func.selfSize,
+        retainedSize: func.retainedSize,
+        instanceCount: func.instanceIds.length,
+        instanceIds: [...func.instanceIds],
       })
     }
   }

--- a/src/options.ts
+++ b/src/options.ts
@@ -122,6 +122,21 @@ export type EntryMatch = {
   location?: string
 }
 
+/**
+ * The keys an entry is paired by across a diff's two sides, derived from its
+ * {@link EntryMatch}.
+ */
+export type EntryMatchKeys = {
+  /**
+   * The key pairing entries by normalized name alone, for entities whose
+   * location varies between profiles of the same program.
+   */
+  name: string
+
+  /** The key pairing entries by normalized name and location. */
+  nameAndLocation: string
+}
+
 /** An aggregated entry in a formatted profile. */
 export type AggregatedProfileEntry =
   | AggregatedCallStackProfileFunction
@@ -273,7 +288,10 @@ export type NormalizedProfileToMdOptions = {
   minCategoryShare: number
   baseURL: URL | `auto` | undefined
   sourceMaps: NormalizedSourceMaps
-  entryMatchKey: (entry: ProfileEntry, context: ProfileToMdContext) => string
+  entryMatchKeys: (
+    entry: ProfileEntry,
+    context: ProfileToMdContext,
+  ) => EntryMatchKeys
   categorizeFunctions: (
     entries: readonly ProfileEntry[],
     context: ProfileToMdContext,
@@ -319,8 +337,8 @@ export const normalizeProfileToMdOptions = ({
   minCategoryShare: normalizeMinCategoryShare(minCategoryShare),
   baseURL: normalizeBaseURL(baseURL),
   sourceMaps: normalizeSourceMaps(sourceMaps),
-  entryMatchKey: cacheEntryFunction((entry, context) =>
-    entryMatchKey(entry, context, matchEntry),
+  entryMatchKeys: cacheEntryFunction((entry, context) =>
+    entryMatchKeys(entry, context, matchEntry),
   ),
   categorizeFunctions: (entries, context) => {
     const categories = categorizeFunctions(entries, context)
@@ -389,25 +407,25 @@ const ensureTrailingSlash = (url: URL): URL => {
   return url
 }
 
-/** Returns an entry's full diff match key. */
-const entryMatchKey = (
+/** Returns an entry's diff match keys. */
+const entryMatchKeys = (
   entry: ProfileEntry,
   context: ProfileToMdContext,
   matchEntry: Exclude<ProfileToMdOptions[`matchEntry`], undefined>,
-): string => {
+): EntryMatchKeys => {
   const match = matchEntry(entry, context)
   const name = match?.name ?? entry.name ?? ``
   const location =
     match?.location ??
     (entry.location ? sourceReferenceId(entry.location) : undefined)
   if (location === undefined) {
-    return name
+    return { name, nameAndLocation: name }
   }
 
   // `EntryMatch.location` is a bare string, so the kind comes from the entry's
   // own location, which a match normalizes rather than replaces.
   const kind = entry.location ? sourceReferenceKind(entry.location) : ``
-  return `${name}\0${kind}\0${location}`
+  return { name, nameAndLocation: `${name}\0${kind}\0${location}` }
 }
 
 const cacheEntryFunction = <Entry extends object, Context, Value>(


### PR DESCRIPTION
Constructors were keyed by their raw names, so a runtime that includes a per-run address in a class's name reported one entity per run rather than one class across runs. Each side's constructors now merge under the match key their own context produces, as functions already do.