### PR TITLE
feat(heap-snapshot): categorize and filter every aggregated node

### DIFF
--- a/src/formats/jsc-heap-snapshot/parse.ts
+++ b/src/formats/jsc-heap-snapshot/parse.ts
@@ -4,6 +4,7 @@ import type {
   HeapSnapshotNode,
   HeapSnapshotNodeCategory,
   NodeAdjacencyGraph,
+  UnresolvedHeapSnapshotNodeCategory,
 } from '../../modalities/heap-snapshot/index.ts'
 
 /**
@@ -50,12 +51,13 @@ export type JSCHeapSnapshot = {
 export const parseJSCHeapSnapshot = (
   snapshot: JSCHeapSnapshot,
 ): HeapSnapshot[] => {
-  const { nodes, edges, edgeTypes } = snapshot
+  const { nodes, edges, edgeTypes, nodeClassNames } = snapshot
   const nodeCount = nodes.length / NODE_FIELD_COUNT
   const rawEdgeCount = edges.length / EDGE_FIELD_COUNT
 
   const indexEdgeType = edgeTypes.indexOf(`Index`)
   const internalEdgeType = edgeTypes.indexOf(`Internal`)
+  const stringClassNameIndex = nodeClassNames.indexOf(`string`)
 
   const idToOrdinal = computeIdToOrdinal(nodes, nodeCount)
   const nodeAdjacencyGraph = computeNodeAdjacencyGraph(
@@ -84,8 +86,26 @@ export const parseJSCHeapSnapshot = (
         ),
       formatNodeLabel: nodeOrdinal => formatNodeLabel(nodeOrdinal, snapshot),
       isInternalNode: nodeOrdinal => isInternalNode(nodeOrdinal, snapshot),
+      unresolvedCategoryOf: nodeOrdinal =>
+        unresolvedCategoryOf(nodeOrdinal, nodes, stringClassNameIndex),
     },
   ]
+}
+
+/**
+ * Classifies a node by its flags, except for a string, whose class name the
+ * snapshot records instead of a flag.
+ */
+const unresolvedCategoryOf = (
+  nodeOrdinal: number,
+  nodes: number[],
+  stringClassNameIndex: number,
+): UnresolvedHeapSnapshotNodeCategory => {
+  const nodeIndex = nodeOrdinal * NODE_FIELD_COUNT
+  const classNameIndex = nodes[nodeIndex + NODE_CLASS_OFFSET]!
+  return classNameIndex === stringClassNameIndex
+    ? { category: `string` }
+    : { category: categorizeNode(nodes[nodeIndex + NODE_FLAGS_OFFSET]!) }
 }
 
 const isInternalNode = (

--- a/src/formats/v8/heap-snapshot/index.test.ts
+++ b/src/formats/v8/heap-snapshot/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 import {
   functionTables,
   largestStringsTables,
+  retainedObjectsTables,
   selfSizeInstancesTables,
   selfSizeTables,
 } from '../../../modalities/heap-snapshot/testing.ts'
@@ -20,6 +21,7 @@ import {
   makeV8Snapshot,
   NODE_TYPE_CLOSURE,
   NODE_TYPE_CODE,
+  NODE_TYPE_NATIVE,
   NODE_TYPE_OBJECT,
   NODE_TYPE_STRING,
   NODE_TYPE_SYNTHETIC,
@@ -199,6 +201,117 @@ const makeObjectSnapshot = (firstName: string, secondName: string) =>
       ...makeV8Edge({ type: EDGE_TYPE_HIDDEN, nameOrIndex: 0, toNode: 12 }),
     ],
     strings: [``, firstName, secondName],
+  })
+
+// A synthetic root retaining a closure, which exclusively retains a string, so
+// the string appears under the function's retained objects.
+const makeRetainingClosureSnapshot = () =>
+  makeV8Snapshot({
+    nodeCount: 3,
+    edgeCount: 2,
+    nodes: [
+      ...makeV8Node({
+        type: NODE_TYPE_SYNTHETIC,
+        name: 0,
+        id: 1,
+        selfSize: 0,
+        edgeCount: 1,
+      }),
+      ...makeV8Node({
+        type: NODE_TYPE_CLOSURE,
+        name: 1,
+        id: 3,
+        selfSize: 64,
+        edgeCount: 1,
+      }),
+      ...makeV8Node({
+        type: NODE_TYPE_STRING,
+        name: 2,
+        id: 5,
+        selfSize: 128,
+        edgeCount: 0,
+      }),
+    ],
+    edges: [
+      ...makeV8Edge({ type: EDGE_TYPE_HIDDEN, nameOrIndex: 0, toNode: 6 }),
+      ...makeV8Edge({ type: EDGE_TYPE_PROPERTY, nameOrIndex: 3, toNode: 12 }),
+    ],
+    strings: [``, `myFn`, `payload`, `data`],
+  })
+
+// A synthetic root retaining two `Widget` nodes the engine classifies
+// differently, as it does a host-allocated DOM wrapper class. The constructor
+// takes the category holding the most of its self size, and each instance keeps
+// its own.
+const makeMixedCategoryConstructorSnapshot = () =>
+  makeV8Snapshot({
+    nodeCount: 3,
+    edgeCount: 2,
+    nodes: [
+      ...makeV8Node({
+        type: NODE_TYPE_SYNTHETIC,
+        name: 0,
+        id: 1,
+        selfSize: 0,
+        edgeCount: 2,
+      }),
+      ...makeV8Node({
+        type: NODE_TYPE_OBJECT,
+        name: 1,
+        id: 3,
+        selfSize: 200,
+        edgeCount: 0,
+      }),
+      ...makeV8Node({
+        type: NODE_TYPE_NATIVE,
+        name: 1,
+        id: 5,
+        selfSize: 50,
+        edgeCount: 0,
+      }),
+    ],
+    edges: [
+      ...makeV8Edge({ type: EDGE_TYPE_HIDDEN, nameOrIndex: 0, toNode: 6 }),
+      ...makeV8Edge({ type: EDGE_TYPE_HIDDEN, nameOrIndex: 0, toNode: 12 }),
+    ],
+    strings: [``, `Widget`],
+  })
+
+// A synthetic root retaining an object node and a string node holding the
+// given value. The object keeps the entry filter from hiding every node,
+// because a filter that hides every node is disabled.
+const makeStringSnapshot = (value: string) =>
+  makeV8Snapshot({
+    nodeCount: 3,
+    edgeCount: 2,
+    nodes: [
+      ...makeV8Node({
+        type: NODE_TYPE_SYNTHETIC,
+        name: 0,
+        id: 1,
+        selfSize: 0,
+        edgeCount: 2,
+      }),
+      ...makeV8Node({
+        type: NODE_TYPE_OBJECT,
+        name: 1,
+        id: 3,
+        selfSize: 200,
+        edgeCount: 0,
+      }),
+      ...makeV8Node({
+        type: NODE_TYPE_STRING,
+        name: 2,
+        id: 5,
+        selfSize: 120,
+        edgeCount: 0,
+      }),
+    ],
+    edges: [
+      ...makeV8Edge({ type: EDGE_TYPE_HIDDEN, nameOrIndex: 0, toNode: 6 }),
+      ...makeV8Edge({ type: EDGE_TYPE_HIDDEN, nameOrIndex: 0, toNode: 12 }),
+    ],
+    strings: [``, `MyClass`, value],
   })
 
 describe(`convert`, () => {
@@ -608,5 +721,136 @@ describe(`convert`, () => {
 
     expect(md).toContain(`## Largest strings`)
     expect(md).toContain(`hello`)
+  })
+
+  test(`a category filter hides functions`, () => {
+    const md = convertJsonToMd(
+      v8HeapSnapshotConverter,
+      makeClosureSnapshot(),
+      normalizeProfileToMdOptions({
+        baseURL: `/project`,
+        showEntry: entry => entry.category !== `function`,
+      }),
+    )
+
+    expect(md).not.toContain(`## Largest functions`)
+    expect(selfSizeTables(md)).toEqual([
+      [
+        {
+          '%': `47.4%`,
+          Size: `200 B`,
+          Instances: `1`,
+          Constructor: `MyClass`,
+          Location: `<unknown>`,
+        },
+      ],
+    ])
+  })
+
+  test(`a category filter hides a function's retained objects`, () => {
+    const shown = convertJsonToMd(
+      v8HeapSnapshotConverter,
+      makeRetainingClosureSnapshot(),
+      normalizeProfileToMdOptions(),
+    )
+
+    expect(retainedObjectsTables(shown, `myFn`)).toEqual([
+      [{ '%': `66.7%`, Self: `128 B`, Name: `payload`, Path: `.data myFn` }],
+    ])
+
+    const hidden = convertJsonToMd(
+      v8HeapSnapshotConverter,
+      makeRetainingClosureSnapshot(),
+      normalizeProfileToMdOptions({
+        showEntry: entry => entry.category !== `string`,
+      }),
+    )
+
+    expect(functionTables(hidden)).toEqual([
+      [
+        {
+          '%': `100.0%`,
+          Retained: `192 B`,
+          Instances: `1`,
+          Paths: `1`,
+          Name: `myFn`,
+          'Example path': `(GC root)`,
+        },
+      ],
+    ])
+    expect(retainedObjectsTables(hidden, `myFn`)).toEqual([])
+  })
+
+  test(`a category filter hides strings`, () => {
+    const md = convertJsonToMd(
+      v8HeapSnapshotConverter,
+      makeClosureSnapshot(),
+      normalizeProfileToMdOptions({
+        baseURL: `/project`,
+        showEntry: entry => entry.category !== `string`,
+      }),
+    )
+
+    expect(md).not.toContain(`## Largest strings`)
+    expect(selfSizeTables(md)).toEqual([
+      [
+        {
+          '%': `47.4%`,
+          Size: `200 B`,
+          Instances: `1`,
+          Constructor: `MyClass`,
+          Location: `<unknown>`,
+        },
+      ],
+    ])
+  })
+
+  test(`a category filter hides a constructor's instances`, () => {
+    const shown = convertJsonToMd(
+      v8HeapSnapshotConverter,
+      makeMixedCategoryConstructorSnapshot(),
+      normalizeProfileToMdOptions(),
+    )
+
+    expect(selfSizeInstancesTables(shown, `Widget`)).toEqual([
+      [{ '%': `100.0%`, Size: `250 B`, Instances: `2`, Path: `(GC root)` }],
+    ])
+
+    const hidden = convertJsonToMd(
+      v8HeapSnapshotConverter,
+      makeMixedCategoryConstructorSnapshot(),
+      normalizeProfileToMdOptions({
+        showEntry: entry => entry.category !== `native`,
+      }),
+    )
+
+    expect(selfSizeInstancesTables(hidden, `Widget`)).toEqual([
+      [{ '%': `80.0%`, Size: `200 B`, Instances: `1`, Path: `(GC root)` }],
+    ])
+  })
+  test(`a constructor's instances take the category the origin names for its class`, () => {
+    const md = convertJsonToMd(
+      v8HeapSnapshotConverter,
+      makeObjectSnapshot(`Array`, `Array`),
+      normalizeProfileToMdOptions({
+        showEntry: entry => entry.category === `array`,
+      }),
+    )
+
+    expect(selfSizeInstancesTables(md, `Array`)).toEqual([
+      [{ '%': `100.0%`, Size: `300 B`, Instances: `2`, Path: `(GC root)` }],
+    ])
+  })
+
+  test(`a string holding a synthetic entry's name is shown`, () => {
+    const md = convertJsonToMd(
+      v8HeapSnapshotConverter,
+      makeStringSnapshot(`(module)`),
+      normalizeProfileToMdOptions(),
+    )
+
+    expect(largestStringsTables(md)).toEqual([
+      [{ '%': `37.5%`, Size: `120 B`, Value: `(module)`, Path: `(GC root)` }],
+    ])
   })
 })

--- a/src/formats/v8/heap-snapshot/parse.ts
+++ b/src/formats/v8/heap-snapshot/parse.ts
@@ -10,6 +10,7 @@ import type {
   HeapSnapshotNode,
   HeapSnapshotNodeCategory,
   NodeAdjacencyGraph,
+  UnresolvedHeapSnapshotNodeCategory,
 } from '../../../modalities/heap-snapshot/index.ts'
 import type { FormattingProfileToMdOptions } from '../../../options.ts'
 import { FormatParseError } from '../../error.ts'
@@ -133,8 +134,38 @@ export const parseV8HeapSnapshot = (
         formatNodeLabel(nodeOrdinal, snapshot, fieldLayout, options),
       isInternalNode: nodeOrdinal =>
         isInternalNode(nodeOrdinal, snapshot, fieldLayout),
+      unresolvedCategoryOf: nodeOrdinal =>
+        unresolvedCategoryOf(nodeOrdinal, snapshot, fieldLayout),
     },
   ]
+}
+
+/**
+ * Classifies a node by the type it declares, looked up in the layout resolved
+ * from `meta.node_types`.
+ */
+const unresolvedCategoryOf = (
+  nodeOrdinal: number,
+  {
+    nodes,
+    snapshot: {
+      meta: {
+        node_types: [nodeTypes],
+      },
+    },
+  }: V8HeapSnapshot,
+  fieldLayout: FieldLayout,
+): UnresolvedHeapSnapshotNodeCategory => {
+  const nodeType =
+    nodes[
+      nodeOrdinal * fieldLayout.nodeFieldCount + fieldLayout.nodeTypeOffset
+    ]!
+  const category = fieldLayout.nodeTypeToCategory[nodeType]
+  // Keep a declared type name that isn't V8's own for an origin to map (see
+  // `HeapSnapshotNode.declaredType`).
+  return category === undefined
+    ? { category, declaredType: nodeTypes[nodeType]! }
+    : { category }
 }
 
 const isInternalNode = (
@@ -156,22 +187,17 @@ function* v8SnapshotNodes(
   nodeOrdinalToLocation: SourceLocation[],
 ): Iterable<HeapSnapshotNode> {
   const {
-    snapshot: {
-      node_count: nodeCount,
-      meta: {
-        node_types: [nodeTypes],
-      },
-    },
+    snapshot: { node_count: nodeCount },
     nodes,
   } = snapshot
   for (let nodeOrdinal = 0; nodeOrdinal < nodeCount; nodeOrdinal++) {
     const nodeIndex = nodeOrdinal * fieldLayout.nodeFieldCount
     const nodeType = nodes[nodeIndex + fieldLayout.nodeTypeOffset]!
-    const category = fieldLayout.nodeTypeToCategory[nodeType]
-    // A declared type name that isn't V8's own is kept for an origin to map
-    // (see `HeapSnapshotNode.declaredType`).
-    const declaredType =
-      category === undefined ? nodeTypes[nodeType]! : undefined
+    const { category, declaredType } = unresolvedCategoryOf(
+      nodeOrdinal,
+      snapshot,
+      fieldLayout,
+    )
 
     switch (nodeType) {
       case fieldLayout.nodeTypeObject:

--- a/src/formats/v8/heap-snapshot/testing.ts
+++ b/src/formats/v8/heap-snapshot/testing.ts
@@ -4,6 +4,7 @@ export const NODE_TYPE_STRING = 2
 export const NODE_TYPE_OBJECT = 3
 export const NODE_TYPE_CODE = 4
 export const NODE_TYPE_CLOSURE = 5
+export const NODE_TYPE_NATIVE = 8
 export const NODE_TYPE_SYNTHETIC = 9
 
 export const EDGE_TYPE_PROPERTY = 2

--- a/src/modalities/heap-snapshot/aggregate.ts
+++ b/src/modalities/heap-snapshot/aggregate.ts
@@ -6,9 +6,14 @@ import type {
   ProfileEntry,
   ProfileToMdContext,
 } from '../../options.ts'
-import type { OriginDetector } from '../../origins/index.ts'
+import { categorizeHeapSnapshotConstructorForOrigin } from '../../origins/index.ts'
+import type { Origin, OriginDetector } from '../../origins/index.ts'
 import type { InputAggregator } from '../aggregator.ts'
-import { EntityCategorizer, NodeCategoryStatsAggregator } from './categorize.ts'
+import {
+  EntityCategorizer,
+  newNodeCategoryResolver,
+  NodeCategoryStatsAggregator,
+} from './categorize.ts'
 import { computeImmediateDominatorGraph } from './graph.ts'
 import type { ImmediateDominatorGraph, NodeAdjacencyGraph } from './graph.ts'
 import {
@@ -19,6 +24,7 @@ import type {
   HeapSnapshot,
   HeapSnapshotNode,
   HeapSnapshotNodeCategory,
+  UnresolvedHeapSnapshotNodeCategory,
 } from './type.ts'
 
 /**
@@ -45,6 +51,10 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
   ) => string
 
   readonly #isInternalNode: (nodeOrdinal: number) => boolean
+
+  readonly #unresolvedCategoryOf: (
+    nodeOrdinal: number,
+  ) => UnresolvedHeapSnapshotNodeCategory
 
   #totalSize = 0
   readonly #nodeCategoryStats = new NodeCategoryStatsAggregator()
@@ -76,6 +86,7 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
       formatEdgeLabel,
       formatNodeLabel,
       isInternalNode,
+      unresolvedCategoryOf,
     } = snapshot
     this.#nodeCount = nodeCount
     this.#edgeCount = edgeCount
@@ -84,6 +95,7 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
     this.#formatEdgeLabel = formatEdgeLabel
     this.#formatNodeLabel = formatNodeLabel
     this.#isInternalNode = isInternalNode
+    this.#unresolvedCategoryOf = unresolvedCategoryOf
 
     this.#immediateDominatorGraph = computeImmediateDominatorGraph(
       nodeCount,
@@ -150,7 +162,7 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
         name,
         nameLocation,
         location,
-        // Assigned in `aggregate`, where the origin is known.
+        // `aggregate` assigns this once the origin is known.
         category: `object`,
         selfSize: 0,
         retainedSize: 0,
@@ -169,6 +181,8 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
       type: `node`,
       id: nodeOrdinal,
       name,
+      // `aggregate` assigns this once the origin is known.
+      category: `object`,
       selfSize,
       retainedSize,
       location: constructor.location,
@@ -193,6 +207,8 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
         id: nodeOrdinal,
         name,
         location,
+        // `aggregate` assigns this once the origin is known.
+        category: `function`,
         selfSize: 0,
         retainedSize: 0,
         largestInstanceId: nodeOrdinal,
@@ -219,7 +235,7 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
       type: `node`,
       id: nodeOrdinal,
       name: node.name,
-      // Assigned in `aggregate`, where the origin is known.
+      // `aggregate` assigns this once the origin is known.
       category: `string`,
       selfSize,
       retainedSize: selfSize,
@@ -251,6 +267,9 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
       origin,
     )
 
+    const categoryOf = this.#newNodeCategorizer(origin)
+    this.#categorizeNodes(categoryOf)
+
     return {
       type: `heap-snapshot`,
       context,
@@ -278,7 +297,52 @@ export class HeapSnapshotAggregator implements InputAggregator<AggregatedHeapSna
           this.#selfSizeOf,
           ordinal => this.#formatNodeLabel(ordinal, options),
           this.#isInternalNode,
+          categoryOf,
         ),
+    }
+  }
+
+  /**
+   * Categorizes a node under {@link origin}: the category the origin assigns to
+   * the class its constructor defines, falling back to the node's own category.
+   *
+   * This resolves a constructor's class name once per constructor rather than
+   * once per node, since a class can have thousands of instances.
+   */
+  #newNodeCategorizer(
+    origin: Origin,
+  ): (nodeOrdinal: number) => HeapSnapshotNodeCategory {
+    const resolveCategory = newNodeCategoryResolver(origin)
+    const constructorIndexToNamedCategory = this.#constructors.map(({ name }) =>
+      categorizeHeapSnapshotConstructorForOrigin(name, origin),
+    )
+    return nodeOrdinal => {
+      const constructorIndex = this.#nodeOrdinalToConstructorIndex[nodeOrdinal]!
+      const namedCategory =
+        constructorIndex === -1
+          ? undefined
+          : constructorIndexToNamedCategory[constructorIndex]
+      return (
+        namedCategory ??
+        resolveCategory(this.#unresolvedCategoryOf(nodeOrdinal))
+      )
+    }
+  }
+
+  /**
+   * Categorizes the nodes no entity took a dominant category for: a function,
+   * from the instance its rows show, and each of a constructor's instances.
+   */
+  #categorizeNodes(
+    categoryOf: (nodeOrdinal: number) => HeapSnapshotNodeCategory,
+  ): void {
+    for (const fn of this.#functions) {
+      fn.category = categoryOf(fn.largestInstanceId)
+    }
+    for (const constructor of this.#constructors) {
+      for (const instance of constructor.instances) {
+        instance.category = categoryOf(instance.id)
+      }
     }
   }
 }
@@ -365,6 +429,7 @@ const computeRetainedNodes = (
   selfSizeOf: (nodeOrdinal: number) => number,
   formatNodeLabel: (nodeOrdinal: number) => string,
   isInternalNode: (nodeOrdinal: number) => boolean,
+  categoryOf: (nodeOrdinal: number) => HeapSnapshotNodeCategory,
 ): AggregatedHeapSnapshotNode[] => {
   const retainedNodes: AggregatedHeapSnapshotNode[] = []
 
@@ -383,6 +448,7 @@ const computeRetainedNodes = (
         type: `node`,
         id: current,
         name: formatNodeLabel(current),
+        category: categoryOf(current),
         selfSize: selfSizeOf(current),
         retainedSize: nodeOrdinalToRetainedSize[current]!,
       })
@@ -431,12 +497,8 @@ export type AggregatedHeapSnapshotNode = {
   /** Bytes allocated directly for this node. */
   selfSize: number
 
-  /**
-   * What this node holds, set on the entities a ranking breaks down by
-   * category: constructors and strings. An instance of a constructor has none,
-   * since its constructor's category stands for it.
-   */
-  category?: HeapSnapshotNodeCategory
+  /** What this node holds. */
+  category: HeapSnapshotNodeCategory
 
   /**
    * Bytes allocated for this node, as well as all nodes that would be freed if
@@ -453,8 +515,9 @@ export type AggregatedHeapSnapshotConstructor = AggregatedHeapSnapshotNode & {
   name: string
 
   /**
-   * What this constructor's instances hold, taken from the category holding the
-   * most of their self size.
+   * What this constructor's instances hold: the category the origin assigns to
+   * its class, falling back to the category holding the most of their self
+   * size.
    */
   category: HeapSnapshotNodeCategory
 
@@ -470,6 +533,12 @@ export type AggregatedHeapSnapshotString = AggregatedHeapSnapshotNode & {
 export type AggregatedHeapSnapshotFunction = AggregatedHeapSnapshotNode & {
   /** A human readable label for this function. */
   name: string
+
+  /**
+   * What this function holds, taken from the instance
+   * {@link largestInstanceId} identifies, which is the instance its rows show.
+   */
+  category: HeapSnapshotNodeCategory
 
   /** Node ordinal of the instance with the largest individual retained size. */
   largestInstanceId: number

--- a/src/modalities/heap-snapshot/categorize.ts
+++ b/src/modalities/heap-snapshot/categorize.ts
@@ -15,7 +15,47 @@ import {
 import type { Origin } from '../../origins/index.ts'
 import type { NodeCategoryStats } from './aggregate.ts'
 import { HEAP_SNAPSHOT_NODE_CATEGORIES } from './type.ts'
-import type { HeapSnapshotNode, HeapSnapshotNodeCategory } from './type.ts'
+import type {
+  HeapSnapshotNode,
+  HeapSnapshotNodeCategory,
+  UnresolvedHeapSnapshotNodeCategory,
+} from './type.ts'
+
+/**
+ * Resolves a node's unresolved category to its category under {@link origin}.
+ *
+ * Memoized by declared type name, since a snapshot declaring its own type names
+ * can hold thousands of them.
+ */
+export const newNodeCategoryResolver = (
+  origin: Origin,
+): ((
+  unresolvedCategory: UnresolvedHeapSnapshotNodeCategory,
+) => HeapSnapshotNodeCategory) => {
+  const declaredTypeToCategory = new Map<string, HeapSnapshotNodeCategory>()
+  return ({ category, declaredType }) => {
+    if (category !== undefined || declaredType === undefined) {
+      return category ?? `unknown`
+    }
+
+    let resolved = declaredTypeToCategory.get(declaredType)
+    if (resolved === undefined) {
+      resolved = declaredTypeCategory(declaredType, origin)
+      declaredTypeToCategory.set(declaredType, resolved)
+    }
+    return resolved
+  }
+}
+
+/**
+ * The category {@link origin} assigns to a type name a format declared,
+ * falling back to `object` for one the origin doesn't categorize.
+ */
+const declaredTypeCategory = (
+  declaredType: string,
+  origin: Origin,
+): HeapSnapshotNodeCategory =>
+  categorizeHeapSnapshotDeclaredTypeForOrigin(declaredType, origin) ?? `object`
 
 /**
  * Aggregates each node's self size and count into its category's stats.
@@ -49,7 +89,7 @@ export class NodeCategoryStatsAggregator {
   /**
    * Resolves each node's category: the origin categorizes a constructor by the
    * class name its language defines, falling back to the category the format
-   * derived from the engine's own node classification.
+   * derived from the engine's own node type.
    */
   public aggregate(
     origin: Origin,
@@ -67,9 +107,7 @@ export class NodeCategoryStatsAggregator {
     this.#byDeclaredType.aggregateInto(
       nodeCategoryToStats,
       origin,
-      declaredType =>
-        categorizeHeapSnapshotDeclaredTypeForOrigin(declaredType, origin) ??
-        `object`,
+      declaredType => declaredTypeCategory(declaredType, origin),
     )
 
     return nodeCategoryToStats
@@ -277,11 +315,10 @@ class CategoryKeys {
         return HEAP_SNAPSHOT_NODE_CATEGORIES[key - 1]!
       }
       const index = -key - 1
-      return (declaredTypeCategories[index] ??=
-        categorizeHeapSnapshotDeclaredTypeForOrigin(
-          this.#declaredTypes[index]!,
-          origin,
-        ) ?? `object`)
+      return (declaredTypeCategories[index] ??= declaredTypeCategory(
+        this.#declaredTypes[index]!,
+        origin,
+      ))
     }
   }
 }

--- a/src/modalities/heap-snapshot/diff.ts
+++ b/src/modalities/heap-snapshot/diff.ts
@@ -43,8 +43,8 @@ export type AggregatedHeapSnapshotEntityDiff = {
   /** A human readable label for this entity. */
   name: string
 
-  /** What this entity holds, set on the entities a ranking breaks down. */
-  category?: HeapSnapshotNodeCategory
+  /** What this entity holds. */
+  category: HeapSnapshotNodeCategory
 
   /** The file reference the {@link name} parses as, when it is URL-shaped. */
   nameLocation?: FileReference
@@ -191,6 +191,7 @@ const mergeFunctions = (
         id: func.largestInstanceId,
         name: func.name,
         location: func.location,
+        category: func.category,
         selfSize: func.selfSize,
         retainedSize: func.retainedSize,
         instanceCount: func.instanceIds.length,

--- a/src/modalities/heap-snapshot/format.ts
+++ b/src/modalities/heap-snapshot/format.ts
@@ -80,6 +80,9 @@ export const formatHeapSnapshot = (
           { ...fn, id: fn.largestInstanceId },
           snapshot.context,
         ),
+      ) ||
+      snapshot.strings.some(string =>
+        options.showEntry(string, snapshot.context),
       ),
     disabledNote: ENTRY_FILTER_DISABLED_NOTE,
   })
@@ -291,7 +294,7 @@ const formatLargestSizeConstructors = ({
 
 const formatLargestConstructorInstances = ({
   constructor,
-  snapshot: { retainerPathOf },
+  snapshot: { retainerPathOf, context },
   sizeOf,
   hasLocation,
   options,
@@ -303,7 +306,9 @@ const formatLargestConstructorInstances = ({
   options: FormattingProfileToMdOptions
 }): RootContent[] => {
   const largestInstanceGroups = selectLargestInstancesByRetainerPath({
-    instances: constructor.instances,
+    instances: constructor.instances.filter(instance =>
+      options.showEntry(instance, context),
+    ),
     sizeOf,
     retainerPathOf: nodeOrdinal => retainerPathOf(nodeOrdinal, options),
     topN: Math.ceil(options.topN / 4),
@@ -491,17 +496,20 @@ const collectShownRetainedNodes = (
 }
 
 const formatLargestStrings = ({
-  snapshot: { totalSize, strings, retainerPathOf },
+  snapshot: { totalSize, strings, retainerPathOf, context },
   options,
 }: {
   snapshot: AggregatedHeapSnapshot
   options: FormattingProfileToMdOptions
 }): RootContent[] => {
+  const shownStrings = strings.filter(string =>
+    options.showEntry(string, context),
+  )
   const selfSizeOf = (string: AggregatedHeapSnapshotString) => string.selfSize
   const ranking = rankEntities({
-    entities: strings,
+    entities: shownStrings,
     categories: subsectionCategories({
-      entries: strings,
+      entries: shownStrings,
       selfValueOf: selfSizeOf,
       categoryOf: string => string.category,
       minCategoryShare: options.minCategoryShare,
@@ -545,7 +553,8 @@ export const formatHeapSnapshotDiff = (
     options,
     showsAnyEntry:
       diff.constructors.some(entity => showDiffEntity(entity, diff, options)) ||
-      diff.functions.some(entity => showDiffEntity(entity, diff, options)),
+      diff.functions.some(entity => showDiffEntity(entity, diff, options)) ||
+      diff.strings.some(entity => showDiffEntity(entity, diff, options)),
     disabledNote: ENTRY_FILTER_DISABLED_NOTE,
   })
   return [
@@ -634,7 +643,7 @@ const formatDiffConstructors = ({
     ),
     baseSelfValueOf: entity => entity.base?.selfSize ?? 0,
     currentSelfValueOf: entity => entity.current?.selfSize ?? 0,
-    categoryOf: entity => entity.category ?? `object`,
+    categoryOf: entity => entity.category,
     minCategoryShare: options.minCategoryShare,
   })
 
@@ -681,7 +690,7 @@ const formatDiffSizeConstructors = ({
       })),
       diff,
       options,
-      { categories, categoryOf: entity => entity.category ?? `object` },
+      { categories, categoryOf: entity => entity.category },
     )
 
   const sideRowOf = (total: number, entity?: DiffedHeapSnapshotEntity) =>
@@ -770,10 +779,8 @@ const formatDiffStrings = ({
   diff: AggregatedHeapSnapshotDiff
   options: FormattingProfileToMdOptions
 }): RootContent[] => {
-  // A string is categorized by its representation in the heap, which the
-  // snapshot always records.
   const categoryOf = (entity: AggregatedHeapSnapshotEntityDiff) =>
-    entity.category ?? `string`
+    entity.category
   const categories = subsectionDiffCategories({
     entries: diff.strings.filter(entity =>
       showDiffEntity(entity, diff, options),

--- a/src/modalities/heap-snapshot/testing.ts
+++ b/src/modalities/heap-snapshot/testing.ts
@@ -147,6 +147,7 @@ export const makeAggregatedHeapSnapshotConstructor = ({
     type: `node`,
     id: index,
     name,
+    category,
     selfSize: 0,
     retainedSize: 0,
   })),
@@ -158,17 +159,20 @@ export const makeAggregatedHeapSnapshotFunction = ({
   selfSize,
   retainedSize,
   instanceCount = 1,
+  category = `function`,
 }: {
   name: string
   location?: SourceLocation
   selfSize: number
   retainedSize: number
   instanceCount?: number
+  category?: HeapSnapshotNodeCategory
 }): AggregatedHeapSnapshotFunction => ({
   type: `node`,
   id: 0,
   name,
   location,
+  category,
   selfSize,
   retainedSize,
   largestInstanceId: 0,
@@ -224,6 +228,15 @@ export const retainedSizeInstancesTables = (
 
 export const functionTables = (md: string): Table[] =>
   allTablesAfterHeading(parseMd(md), `Largest functions`)
+
+export const retainedObjectsTables = (md: string, name: string): Table[] => {
+  const functionsUnder = nodesUnderHeading(parseMd(md), `Largest functions`)
+  const retainedUnder = nodesUnderHeading(
+    { type: `root`, children: functionsUnder } as Root,
+    `Retained`,
+  )
+  return allTablesAfterHeadingContaining(retainedUnder, name)
+}
 
 export const largestStringsTables = (md: string): Table[] =>
   allTablesAfterHeading(parseMd(md), `Largest strings`)

--- a/src/modalities/heap-snapshot/type.ts
+++ b/src/modalities/heap-snapshot/type.ts
@@ -4,7 +4,7 @@ import type { NodeAdjacencyGraph } from './graph.ts'
 
 /**
  * A heap snapshot parsed into the uniform structure containing the node
- * adjacency graph and each node's classification.
+ * adjacency graph and each node's unresolved category.
  *
  * A format that yields several snapshots returns one of these per snapshot.
  */
@@ -50,6 +50,15 @@ export type HeapSnapshot = {
 
   /** Whether the node is a bookkeeping node that never points to user code. */
   isInternalNode: (nodeOrdinal: number) => boolean
+
+  /**
+   * The node's category before the origin resolves it, computed from the node
+   * ordinal so formatting can categorize a node again after {@link nodes} is
+   * consumed.
+   */
+  unresolvedCategoryOf: (
+    nodeOrdinal: number,
+  ) => UnresolvedHeapSnapshotNodeCategory
 }
 
 /**
@@ -89,10 +98,8 @@ export const HEAP_SNAPSHOT_NODE_CATEGORIES = [
 ] as const
 
 /**
- * A heap snapshot node's classification.
- *
- * Every node contributes to its category's stats. A node with a `type` also
- * aggregates into that type's entities.
+ * What a heap snapshot node holds, as the format categorized it, before the
+ * origin resolves it.
  *
  * {@link category} is undefined when the format declared a type name this
  * modality's categories don't name, in which case {@link declaredType} holds
@@ -100,38 +107,47 @@ export const HEAP_SNAPSHOT_NODE_CATEGORIES = [
  * `meta.node_types`, so every node of its snapshots has a {@link declaredType}
  * instead of a category.
  */
-export type HeapSnapshotNode = {
+export type UnresolvedHeapSnapshotNodeCategory = {
   category: HeapSnapshotNodeCategory | undefined
   declaredType?: string
-} & (
-  | { type?: undefined }
-  | {
-      type: `constructor`
+}
 
-      /** A human readable label for this constructor. */
-      name: string
+/**
+ * A heap snapshot node.
+ *
+ * Every node contributes to its category's stats. A node with a `type` also
+ * aggregates into that type's entities.
+ */
+export type HeapSnapshotNode = UnresolvedHeapSnapshotNodeCategory &
+  (
+    | { type?: undefined }
+    | {
+        type: `constructor`
 
-      /** The exact location where the node was defined. */
-      location?: SourceLocation
+        /** A human readable label for this constructor. */
+        name: string
 
-      /**
-       * The file reference the {@link name} parses as, when it is URL-shaped.
-       */
-      nameLocation?: FileReference
-    }
-  | {
-      type: `function`
+        /** The exact location where the node was defined. */
+        location?: SourceLocation
 
-      /** A human readable label for this function. */
-      name: string
+        /**
+         * The file reference the {@link name} parses as, when it is URL-shaped.
+         */
+        nameLocation?: FileReference
+      }
+    | {
+        type: `function`
 
-      /** The exact location where the function was defined. */
-      location?: SourceLocation
-    }
-  | {
-      type: `string`
+        /** A human readable label for this function. */
+        name: string
 
-      /** The (truncated) string value, if known. */
-      name?: string
-    }
-)
+        /** The exact location where the function was defined. */
+        location?: SourceLocation
+      }
+    | {
+        type: `string`
+
+        /** The (truncated) string value, if known. */
+        name?: string
+      }
+  )

--- a/src/options.ts
+++ b/src/options.ts
@@ -10,6 +10,7 @@ import type { SourceLocation } from './location.ts'
 import type { AggregatedCallGraphFunction } from './modalities/call-graph/aggregate.ts'
 import type { AggregatedCallStackProfileFunction } from './modalities/call-stack-profile/aggregate.ts'
 import type { AggregatedHeapSnapshotNode } from './modalities/heap-snapshot/aggregate.ts'
+import type { HeapSnapshotNodeCategory } from './modalities/heap-snapshot/type.ts'
 import {
   categorizeEntryForOrigin,
   matchEntryForOrigin,
@@ -487,8 +488,20 @@ export const defaultShowEntry = (
  *
  * The profiler invents these entries; they correspond to nothing that exists
  * in code or at runtime (e.g. a synthetic `(root)` node for heap snapshots).
+ *
+ * A heap snapshot node holding text takes the text as its name, so a string
+ * whose value equals a synthetic name is not a synthetic entry.
  */
 export const isSyntheticEntry = ({
   name,
+  category,
 }: DeepReadonly<AggregatedProfileEntry>): boolean =>
-  name === `(root)` || name === `<root>` || name === `(module)`
+  !TEXT_CATEGORIES.has(category) &&
+  (name === `(root)` || name === `<root>` || name === `(module)`)
+
+/** The categories of a heap snapshot node named by the text it holds. */
+const TEXT_CATEGORIES = new Set<FunctionCategory | HeapSnapshotNodeCategory>([
+  `string`,
+  `concatenated string`,
+  `sliced string`,
+])


### PR DESCRIPTION
A function, a constructor's instances, and a retained node carried no category, so a caller filtering by category could not reach them.

The nodes an entity aggregates are consumed once, so a retained node, built at formatting time from its ordinal alone, was left uncategorized. Parsers now expose `classificationOf`, a sibling of `isInternalNode` that recomputes a node's classification from its ordinal, and the aggregator resolves it through the origin once the origin is known.

A snapshot's strings and a constructor's instances now pass through `showEntry`, which only the diff formatter applied to its strings.

`AggregatedHeapSnapshotNode.category` and
`AggregatedHeapSnapshotEntityDiff.category` are now required.