### PR TITLE
refactor(cli): take the TTY stream in makeAnsis instead of an output path

### DIFF
--- a/src/cli/ansis.ts
+++ b/src/cli/ansis.ts
@@ -1,12 +1,12 @@
 import { Ansis } from 'ansis'
-import { isTTYOutput } from './output.ts'
 
 export type MakeAnsisOptions = {
-  outputPath: string
+  /** Whether the stream the styled text is written to is a TTY. */
+  isTTY: boolean
 }
 
-export const makeAnsis = ({ outputPath }: MakeAnsisOptions): Ansis => {
-  if (isTTYOutput(outputPath)) {
+export const makeAnsis = ({ isTTY }: MakeAnsisOptions): Ansis => {
+  if (isTTY) {
     return new Ansis()
   }
 

--- a/src/cli/highlight.ts
+++ b/src/cli/highlight.ts
@@ -7,6 +7,7 @@ import {
   nodeText,
 } from '../helpers/markdown.ts'
 import { makeAnsis } from './ansis.ts'
+import { isTTYOutput } from './output.ts'
 import kindlingTheme from './theme-kindling.ts'
 
 export type HighlightMarkdownOptions = {
@@ -15,9 +16,9 @@ export type HighlightMarkdownOptions = {
 
 export const highlightMarkdown = async (
   markdown: string,
-  options: HighlightMarkdownOptions,
+  { outputPath }: HighlightMarkdownOptions,
 ): Promise<string> => {
-  const ansis = makeAnsis(options)
+  const ansis = makeAnsis({ isTTY: isTTYOutput(outputPath) })
   if (!ansis.isSupported()) {
     return markdown
   }


### PR DESCRIPTION
The caller decides which stream's TTY-ness selects the styles.