### PR TITLE
feat(options): add a logger and log the pipeline's decisions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,29 @@ pnpm generate-inputs go ruby   # Limit to named workload scripts
 - Derive a format or origin name from the registry (e.g. `FormatMeta.title`),
   never a string literal
 
+### Logging
+
+- The library logs only through `ProfileToMdOptions.logger`, filtered to
+  `logLevel`, never through `console` or another global channel. The CLI passes
+  a logger writing to stderr, so stdout stays the Markdown
+- Throw an error, never log one. `error` is the CLI's level for reporting the
+  thrown error, and the library never logs at it
+- `warn` when the run succeeded but something the caller supplied had no effect,
+  or an option would change the outcome (e.g. a source map that matched no
+  generated file). The test: the caller changes an option or an input after
+  reading it. Assert every `warn` line through `collectLogs()` in
+  `src/testing.ts`, and assert no `warn` in the successful case
+- `info` for one line per decision the pipeline made on the caller's behalf
+  (e.g. the detected format). At most a few lines per input
+- `debug` for the reasoning behind an info line, and for detail keyed by a
+  distinct file, format, or record type, such as each format that rejected the
+  input and why. Count per key in a `Map` and log once at the end. NEVER log per
+  entry, observation, frame, or node
+- Call a level's method only if it is defined (`logger.debug?.(...)`), and build
+  an expensive message or per-key detail only inside `if (logger.debug)`. Write
+  the message like an error message: `<what happened>: <detail>`, values last
+  after `got: `, naming what the caller controls
+
 ### Performance
 
 - Prioritize runtime performance so large profiles process quickly

--- a/docs/api.md
+++ b/docs/api.md
@@ -102,6 +102,14 @@ const options = {
   // Make paths relative to a custom base URL or directory, or pass `auto` to
   // infer the profiled files' common ancestor directory.
   baseURL: `/path/to/project`,
+  // Receive the conversion's diagnostics: at `warn`, an option or input that
+  // had no effect; at `info`, each decision made on your behalf; and at
+  // `debug`, the reasoning behind them. Only defined methods are called, so
+  // `console` qualifies.
+  //
+  // Set `logLevel`, which defaults to `none`, to receive any message.
+  logger: console,
+  logLevel: `info`,
   matchEntry: (entry, context) => {
     if (entry.location?.url?.pathname.includes(`/bundle.`)) {
       // Match bundled entries when diffing by name only, ignoring

--- a/src/formats/aggregate.ts
+++ b/src/formats/aggregate.ts
@@ -1,13 +1,16 @@
+import type { DeepReadonly } from '../helpers/types.ts'
+import { sourceReferenceId } from '../location.ts'
 import { CallGraphAggregator } from '../modalities/call-graph/index.ts'
 import { CallStackProfileAggregator } from '../modalities/call-stack-profile/index.ts'
 import { HeapSnapshotAggregator } from '../modalities/heap-snapshot/aggregate.ts'
 import type {
   AggregationProfileToMdOptions,
+  ProfileEntry,
   ProfileToMdContext,
   UnresolvedProfileToMdContext,
 } from '../options.ts'
-import { OriginDetector } from '../origins/index.ts'
-import type { Origin } from '../origins/index.ts'
+import { OriginDetector, originTitle } from '../origins/index.ts'
+import type { Origin, OriginEvidence } from '../origins/index.ts'
 import type { AggregatedInput, ParsedInput } from './converter.ts'
 import type { Format } from './registry.ts'
 
@@ -41,9 +44,48 @@ export const aggregateParsedInputs = (
     format: context.format,
     origin: detector.resolve(),
   }
+  logOrigin(detector, resolvedContext, options)
   return aggregators.map(aggregator =>
     aggregator.aggregate(options, resolvedContext),
   )
+}
+
+const logOrigin = (
+  detector: OriginDetector,
+  { origin }: ProfileToMdContext,
+  { logger }: AggregationProfileToMdOptions,
+): void => {
+  const { info, debug } = logger
+  if (!info && !debug) {
+    return
+  }
+
+  const { evidence, candidates } = detector
+  if (evidence.type !== `specified` && candidates.length > 1) {
+    debug?.(`origin candidates, in priority order: ${candidates.join(`, `)}`)
+  }
+  info?.(`origin: ${originTitle(origin)} (${describeOriginEvidence(evidence)})`)
+}
+
+const describeOriginEvidence = (evidence: OriginEvidence): string => {
+  switch (evidence.type) {
+    case `specified`:
+      return `specified`
+    case `marker`:
+      return `detected from the entry ${describeEntry(evidence.entry)}`
+    case `hint`:
+      return `detected from the format's metadata`
+    case `fallback`:
+      return `the fallback: no entry marked another origin`
+  }
+}
+
+const describeEntry = ({
+  name,
+  location,
+}: DeepReadonly<ProfileEntry>): string => {
+  const described = name ?? `<anonymous>`
+  return location ? `${described} (${sourceReferenceId(location)})` : described
 }
 
 /**

--- a/src/formats/detect.ts
+++ b/src/formats/detect.ts
@@ -1,4 +1,5 @@
 import { reasonOf } from '../error.ts'
+import type { AggregationProfileToMdOptions } from '../options.ts'
 import type {
   BinaryFormatConverter,
   Detect,
@@ -26,9 +27,10 @@ export type FormatRejection = { converter: FormatConverter; error: unknown }
 export const detectJsonFormat = (
   json: unknown,
   rejections: FormatRejection[],
+  options: AggregationProfileToMdOptions,
 ): DetectedInput | undefined => {
   for (const [format, converter] of jsonFormatConverters) {
-    const parsed = detectWithConverter(converter, json, rejections)
+    const parsed = detectWithConverter(converter, json, rejections, options)
     if (parsed) {
       return { format, parsed }
     }
@@ -39,9 +41,10 @@ export const detectJsonFormat = (
 export const detectBinaryFormat = (
   bytes: Uint8Array,
   rejections: FormatRejection[],
+  options: AggregationProfileToMdOptions,
 ): DetectedInput | undefined => {
   for (const [format, converter] of binaryFormatConverters) {
-    const parsed = detectWithConverter(converter, bytes, rejections)
+    const parsed = detectWithConverter(converter, bytes, rejections, options)
     if (parsed) {
       return { format, parsed }
     }
@@ -75,18 +78,25 @@ const detectWithConverter = <Input>(
   converter: FormatConverter & Detect<Input> & Parse<Input>,
   input: Input,
   rejections: FormatRejection[],
+  { logger }: AggregationProfileToMdOptions,
 ): ParsedInput[] | undefined => {
   try {
     if (!converter.matches(input)) {
       return undefined
     }
-  } catch {
+  } catch (error: unknown) {
+    logger.debug?.(
+      `${converter.title}: detection threw, so the format was skipped: ${reasonOf(error)}`,
+    )
     return undefined
   }
 
   try {
     return classifyLazyParseFailures(converter, converter.parse(input))
   } catch (error: unknown) {
+    logger.debug?.(
+      `${converter.title}: recognized the input but rejected it: ${reasonOf(error)}`,
+    )
     rejections.push({ converter, error })
     return undefined
   }

--- a/src/formats/format.ts
+++ b/src/formats/format.ts
@@ -127,14 +127,30 @@ const makeFormattingProfileToMdOptions = (
   inputs: AggregatedInput[],
 ): FormattingProfileToMdOptions => {
   const { baseURL } = options
-  return baseURL === `auto`
-    ? {
-        ...options,
-        baseURL: commonAncestorDirectoryURL(
-          collectInferableURLs(inputs, { ...options, baseURL: undefined }),
-        ),
-      }
-    : { ...options, baseURL }
+  if (baseURL !== `auto`) {
+    return { ...options, baseURL }
+  }
+
+  const urls = collectInferableURLs(inputs, { ...options, baseURL: undefined })
+  const inferredBaseURL = commonAncestorDirectoryURL(urls)
+  logInferredBaseURL(inferredBaseURL, urls, options)
+  return { ...options, baseURL: inferredBaseURL }
+}
+
+const logInferredBaseURL = (
+  inferredBaseURL: URL | undefined,
+  urls: readonly URL[],
+  { logger }: NormalizedProfileToMdOptions,
+): void => {
+  if (inferredBaseURL) {
+    logger.info?.(
+      `base URL: inferred ${inferredBaseURL.href} from ${urls.length} locations`,
+    )
+  } else {
+    logger.warn?.(
+      `base URL "auto" inferred no directory, so paths stay absolute: no function categorized as ours has an absolute location`,
+    )
+  }
 }
 
 /**

--- a/src/formats/index.test.ts
+++ b/src/formats/index.test.ts
@@ -11,7 +11,12 @@ import {
 } from '../modalities/call-stack-profile/testing.ts'
 import { SAMPLES } from '../modalities/metrics.ts'
 import { normalizeProfileToMdOptions } from '../options.ts'
-import { categoryTables, profileTitles, rankingTables } from '../testing.ts'
+import {
+  categoryTables,
+  collectLogs,
+  profileTitles,
+  rankingTables,
+} from '../testing.ts'
 import type { JsonFormatConverter } from './converter.ts'
 import { FormatDetectError, mayBeParserBug } from './error.ts'
 import {
@@ -990,6 +995,122 @@ describe(`origin detection`, () => {
         },
       ],
     ])
+  })
+})
+
+describe(`logging`, () => {
+  test(`logs the detected format and the fallback origin`, () => {
+    const { lines, options } = collectLogs()
+
+    profileToMd(baseCpuProfile, { baseURL: null, ...options })
+
+    expect(lines).toStrictEqual([
+      `info: format: V8 CPU profile (detected)`,
+      `debug: origin candidates, in priority order: deno, bun, node, chrome`,
+      `info: origin: Chrome (the fallback: no entry marked another origin)`,
+    ])
+  })
+
+  test(`logs the specified format and origin`, () => {
+    const { lines, options } = collectLogs()
+
+    profileToMd(
+      { data: baseCpuProfile, format: `v8-cpu-profile`, origin: `deno` },
+      { baseURL: null, ...options },
+    )
+
+    expect(lines).toStrictEqual([
+      `info: format: V8 CPU profile (specified)`,
+      `info: origin: Deno (specified)`,
+    ])
+  })
+
+  test(`logs the entry an origin was detected from`, () => {
+    const { lines, options } = collectLogs(`info`)
+    const cpuProfile = JSON.stringify({
+      nodes: [
+        makeV8CpuProfileRoot([2]),
+        {
+          id: 2,
+          hitCount: 1,
+          callFrame: makeV8CallFrame(`post`, `node:inspector`),
+        },
+      ],
+      samples: [2],
+      timeDeltas: [20],
+    })
+
+    profileToMd(cpuProfile, { baseURL: null, ...options })
+
+    expect(lines).toStrictEqual([
+      `info: format: V8 CPU profile (detected)`,
+      `info: origin: Node.js (detected from the entry post (node:inspector))`,
+    ])
+  })
+
+  test(`logs each format that recognized the input but rejected it`, () => {
+    const { lines, options } = collectLogs()
+
+    expect(() => profileToMd(`a;b 1\nc;d x\n`, options)).toThrow(
+      /invalid sample count/u,
+    )
+    expect(lines).toStrictEqual([
+      `debug: Collapsed stacks: recognized the input but rejected it: invalid sample count`,
+    ])
+  })
+
+  test(`logs input that opens like JSON but fails to parse`, () => {
+    const { lines, options } = collectLogs()
+
+    expect(() => profileToMd(`{"nodes": [`, options)).toThrow(
+      /could not detect/u,
+    )
+    expect(lines).toStrictEqual([
+      expect.stringMatching(
+        /^debug: input opens like a JSON document but failed to parse as JSON: /u,
+      ),
+    ])
+  })
+
+  test(`logs the inferred base URL`, () => {
+    const { lines, options } = collectLogs(`info`)
+
+    profileToMd(baseCpuProfile, { baseURL: `auto`, ...options })
+
+    expect(lines).toContain(
+      `info: base URL: inferred file:///project/src/ from 2 locations`,
+    )
+  })
+
+  test(`warns when no base URL is inferable`, () => {
+    const { lines, options } = collectLogs(`warn`)
+
+    profileToMd(emptyProfile, { baseURL: `auto`, ...options })
+
+    expect(lines).toStrictEqual([
+      `warn: base URL "auto" inferred no directory, so paths stay absolute: no function categorized as ours has an absolute location`,
+    ])
+  })
+
+  test(`logs nothing at the default level`, () => {
+    const { lines, options } = collectLogs()
+
+    profileToMd(baseCpuProfile, {
+      baseURL: `auto`,
+      logger: options.logger,
+    })
+
+    expect(lines).toStrictEqual([])
+  })
+
+  test(`throws on an unknown log level`, () => {
+    expect(() =>
+      profileToMd(baseCpuProfile, {
+        logLevel: `loud` as `debug`,
+      }),
+    ).toThrow(
+      `logLevel must be one of none, error, warn, info, debug, got: loud`,
+    )
   })
 })
 

--- a/src/formats/index.ts
+++ b/src/formats/index.ts
@@ -1,3 +1,4 @@
+import { reasonOf } from '../error.ts'
 import { concatUint8Arrays, streamToUint8Array } from '../helpers/bytes.ts'
 import {
   maybeJson,
@@ -34,6 +35,7 @@ import {
   rethrowInputReadFailure,
 } from './parse.ts'
 import { formatConverters } from './registry.ts'
+import type { Format } from './registry.ts'
 
 export { formatConverters, formats } from './registry.ts'
 export type { Format } from './registry.ts'
@@ -121,6 +123,7 @@ export const aggregateInput = (
   const { data, format, origin } = normalizeProfileInput(input)
 
   if (format) {
+    logFormat(format, `specified`, options)
     const parsed = parseAsFormat(formatConverters[format], data)
     return aggregateParsedInputs(parsed, options, makeContext(format, origin))
   }
@@ -144,13 +147,17 @@ export const aggregateInput = (
     }
   }
 
+  logJsonError(jsonError, options)
   const rejections: FormatRejection[] = []
   const detected =
-    (json === undefined ? undefined : detectJsonFormat(json, rejections)) ??
-    detectBinaryFormat(dataToBytes(buffered), rejections)
+    (json === undefined
+      ? undefined
+      : detectJsonFormat(json, rejections, options)) ??
+    detectBinaryFormat(dataToBytes(buffered), rejections, options)
   if (!detected) {
     throw toUndetectedFormatError(rejections, jsonError)
   }
+  logFormat(detected.format, `detected`, options)
   return aggregateParsedInputs(
     detected.parsed,
     options,
@@ -165,6 +172,7 @@ const aggregateInputAsync = async (
   const { data, format, origin } = normalizeProfileInput(input)
 
   if (format) {
+    logFormat(format, `specified`, options)
     const parsed = await parseAsFormatAsync(formatConverters[format], data)
     return aggregateParsedInputs(parsed, options, makeContext(format, origin))
   }
@@ -200,19 +208,43 @@ const aggregateInputAsync = async (
     }
   }
 
+  logJsonError(jsonError, options)
   const rejections: FormatRejection[] = []
   const detected =
-    (json === undefined ? undefined : detectJsonFormat(json, rejections)) ??
+    (json === undefined
+      ? undefined
+      : detectJsonFormat(json, rejections, options)) ??
     detectBinaryFormat(
       buffered instanceof Blob ? await buffered.bytes() : buffered,
       rejections,
+      options,
     )
   if (!detected) {
     throw toUndetectedFormatError(rejections, jsonError)
   }
+  logFormat(detected.format, `detected`, options)
   return aggregateParsedInputs(
     detected.parsed,
     options,
     makeContext(detected.format, origin),
   )
+}
+
+const logFormat = (
+  format: Format,
+  evidence: `specified` | `detected`,
+  { logger }: AggregationProfileToMdOptions,
+): void => {
+  logger.info?.(`format: ${formatConverters[format].title} (${evidence})`)
+}
+
+const logJsonError = (
+  jsonError: unknown,
+  { logger }: AggregationProfileToMdOptions,
+): void => {
+  if (jsonError !== undefined) {
+    logger.debug?.(
+      `input opens like a JSON document but failed to parse as JSON: ${reasonOf(jsonError)}`,
+    )
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,3 +31,4 @@ export type {
 } from './location.ts'
 export type { Origin } from './origins/index.ts'
 export type { SourceMap } from './source-map.ts'
+export type { Logger, LogLevel } from './logger.ts'

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'vitest'
+import { LOG_LEVELS, normalizeLogger } from './logger.ts'
+import type { LogLevel } from './logger.ts'
+
+const LEVEL_METHODS = LOG_LEVELS.filter(level => level !== `none`)
+
+test.each(LOG_LEVELS)(
+  `normalizeLogger keeps the methods at or before %s`,
+  logLevel => {
+    const logger = Object.fromEntries(
+      LEVEL_METHODS.map(level => [level, () => {}]),
+    )
+
+    const normalized = normalizeLogger(logger, logLevel)
+
+    expect(Object.keys(normalized)).toStrictEqual(
+      LEVEL_METHODS.filter(
+        level => LOG_LEVELS.indexOf(level) <= LOG_LEVELS.indexOf(logLevel),
+      ),
+    )
+  },
+)
+
+test(`normalizeLogger omits the methods the logger lacks`, () => {
+  const normalized = normalizeLogger({ warn: () => {} }, `debug`)
+
+  expect(Object.keys(normalized)).toStrictEqual([`warn`])
+})
+
+test(`normalizeLogger returns no methods without a logger`, () => {
+  expect(normalizeLogger(undefined, `debug`)).toStrictEqual({})
+})
+
+test(`normalizeLogger calls the logger's methods with the message`, () => {
+  const messages: string[] = []
+  const normalized = normalizeLogger(
+    { info: message => messages.push(`info: ${message}`) },
+    `info` satisfies LogLevel,
+  )
+
+  normalized.info!(`hello`)
+
+  expect(messages).toStrictEqual([`info: hello`])
+})

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,47 @@
+/**
+ * The verbosity of a conversion's diagnostics, from `none` (the default) to
+ * `debug`. A level enables its own messages and every level before it.
+ */
+export type LogLevel = (typeof LOG_LEVELS)[number]
+
+/** Every {@link LogLevel}, least to most verbose. */
+export const LOG_LEVELS = [`none`, `error`, `warn`, `info`, `debug`] as const
+
+/**
+ * Receives a conversion's diagnostics, one message per call.
+ *
+ * Only defined methods are called, so `console` qualifies as a logger, and so
+ * does `{ warn: console.warn }`.
+ */
+export type Logger = Partial<
+  Record<Exclude<LogLevel, `none`>, (message: string) => void>
+>
+
+/**
+ * A {@link Logger} filtered to a {@link LogLevel}: a method is defined only if
+ * the logger defines it and the level enables it. Test for the method before
+ * building an expensive message.
+ */
+export type NormalizedLogger = Logger
+
+export const normalizeLogger = (
+  logger: Logger | undefined,
+  logLevel: LogLevel,
+): NormalizedLogger => {
+  if (!logger) {
+    return {}
+  }
+
+  const threshold = LOG_LEVELS.indexOf(logLevel)
+  const normalized: NormalizedLogger = {}
+  for (const level of LOG_LEVELS) {
+    if (level === `none`) {
+      continue
+    }
+    const log = logger[level]
+    if (log && LOG_LEVELS.indexOf(level) <= threshold) {
+      normalized[level] = message => log.call(logger, message)
+    }
+  }
+  return normalized
+}

--- a/src/options.ts
+++ b/src/options.ts
@@ -7,6 +7,8 @@ import {
   sourceReferenceKind,
 } from './location.ts'
 import type { SourceLocation } from './location.ts'
+import { LOG_LEVELS, normalizeLogger } from './logger.ts'
+import type { Logger, LogLevel, NormalizedLogger } from './logger.ts'
 import type { AggregatedCallGraphFunction } from './modalities/call-graph/aggregate.ts'
 import type { AggregatedCallStackProfileFunction } from './modalities/call-stack-profile/aggregate.ts'
 import type { AggregatedHeapSnapshotNode } from './modalities/heap-snapshot/aggregate.ts'
@@ -227,6 +229,25 @@ export type ProfileToMdOptions = {
   sourceMaps?: SourceMap[] | Record<string, SourceMap>
 
   /**
+   * Receives the conversion's diagnostics: at `warn`, an option or input that
+   * had no effect (e.g. a source map matching no location); at `info`, each
+   * decision made on the caller's behalf (the detected format and origin, how
+   * many locations source maps mapped, the inferred base URL); at `debug`, the
+   * reasoning behind those decisions.
+   *
+   * Only defined methods are called, so `console` qualifies. Only the levels
+   * {@link logLevel} enables are logged.
+   */
+  logger?: Logger
+
+  /**
+   * The most verbose level {@link logger} receives.
+   *
+   * Defaults to `none`.
+   */
+  logLevel?: LogLevel
+
+  /**
    * Returns a normalized name and location to match this entry by across
    * diffed profiles, or `undefined` to match by the entry's own name and
    * location.
@@ -290,6 +311,7 @@ export type NormalizedProfileToMdOptions = {
   minCategoryShare: number
   baseURL: URL | `auto` | undefined
   sourceMaps: NormalizedSourceMaps
+  logger: NormalizedLogger
   entryMatchKeys: (
     entry: ProfileEntry,
     context: ProfileToMdContext,
@@ -331,6 +353,8 @@ export const normalizeProfileToMdOptions = ({
   minCategoryShare = 0.01,
   baseURL,
   sourceMaps = [],
+  logger,
+  logLevel = `none`,
   matchEntry = defaultMatchEntry,
   categorizeFunctions = defaultCategorizeFunctions,
   showEntry = defaultShowEntry,
@@ -339,6 +363,7 @@ export const normalizeProfileToMdOptions = ({
   minCategoryShare: normalizeMinCategoryShare(minCategoryShare),
   baseURL: normalizeBaseURL(baseURL),
   sourceMaps: normalizeSourceMaps(sourceMaps),
+  logger: normalizeLogger(logger, normalizeLogLevel(logLevel)),
   entryMatchKeys: cacheEntryFunction((entry, context) =>
     entryMatchKeys(entry, context, matchEntry),
   ),
@@ -362,6 +387,15 @@ const normalizeTopN = (topN: number): number => {
     )
   }
   return topN
+}
+
+const normalizeLogLevel = (logLevel: LogLevel): LogLevel => {
+  if (!LOG_LEVELS.includes(logLevel)) {
+    throw new ProfilerMdError(
+      `logLevel must be one of ${LOG_LEVELS.join(`, `)}, got: ${String(logLevel)}`,
+    )
+  }
+  return logLevel
 }
 
 const normalizeMinCategoryShare = (minCategoryShare: number): number => {

--- a/src/origins/index.ts
+++ b/src/origins/index.ts
@@ -118,6 +118,7 @@ export class OriginDetector {
    */
   #bestMatchIndex = Infinity
   #decided: Origin | undefined
+  #evidence: OriginEvidence = { type: `fallback` }
 
   public constructor({ format, origin }: UnresolvedProfileToMdContext) {
     this.#fallback = originToSpec.get(formatConverters[format].fallbackOrigin)!
@@ -125,6 +126,7 @@ export class OriginDetector {
       // A forced origin skips detection; added entries are ignored.
       this.#candidates = []
       this.#decided = origin
+      this.#evidence = { type: `specified` }
       return
     }
 
@@ -166,6 +168,7 @@ export class OriginDetector {
         continue
       }
       this.#bestMatchIndex = index
+      this.#evidence = { type: `marker`, entry }
       // The highest-priority candidate matched; nothing can outrank it.
       if (index === 0) {
         this.#decided = this.#candidates[0]!.id
@@ -199,6 +202,7 @@ export class OriginDetector {
       return
     }
     this.#bestMatchIndex = index
+    this.#evidence = { type: `hint` }
     if (index === 0) {
       this.#decided = this.#candidates[0]!.id
     }
@@ -225,7 +229,24 @@ export class OriginDetector {
         : this.#candidates[this.#bestMatchIndex]!
     ).id
   }
+
+  /** The evidence {@link resolve} selects the origin by. */
+  public get evidence(): OriginEvidence {
+    return this.#evidence
+  }
+
+  /** The IDs of the origins that can emit the format, in priority order. */
+  public get candidates(): Origin[] {
+    return this.#candidates.map(candidate => candidate.id)
+  }
 }
+
+/** The evidence an {@link OriginDetector} resolves its origin by. */
+export type OriginEvidence =
+  | { type: `specified` }
+  | { type: `marker`; entry: DeepReadonly<ProfileEntry> }
+  | { type: `hint` }
+  | { type: `fallback` }
 
 /** One of the concrete origin specs, with its literal {@link Origin} ID. */
 type SpecificOriginSpec = (typeof originSpecs)[number]

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -9,6 +9,7 @@ import {
   rowsFromTable,
 } from './helpers/testing.ts'
 import type { Table } from './helpers/testing.ts'
+import type { LogLevel } from './logger.ts'
 import { normalizeProfileToMdOptions } from './options.ts'
 import type {
   FormattingProfileToMdOptions,
@@ -30,6 +31,34 @@ export const resolveProfileToMdOptions = (
     )
   }
   return { ...rest, baseURL }
+}
+
+/**
+ * A logger that records every message as `<level>: <message>`, with the
+ * options that enable it.
+ */
+export const collectLogs = (
+  logLevel: LogLevel = `debug`,
+): {
+  lines: string[]
+  options: Pick<ProfileToMdOptions, `logger` | `logLevel`>
+} => {
+  const lines: string[] = []
+  const log = (level: string) => (message: string) => {
+    lines.push(`${level}: ${message}`)
+  }
+  return {
+    lines,
+    options: {
+      logger: {
+        error: log(`error`),
+        warn: log(`warn`),
+        info: log(`info`),
+        debug: log(`debug`),
+      },
+      logLevel,
+    },
+  }
 }
 
 export const profileTitles = (md: string): string[] =>


### PR DESCRIPTION
The library reports the format it detected, the origin it resolved and the evidence behind it, and the base URL it inferred, through the caller's logger filtered to logLevel.

First step in #92 