### PR TITLE
fix(cli): exit without an error when the reader closes the pipe

### DIFF
--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -125,6 +125,46 @@ if (format === undefined) {
     await rm(dir, { recursive: true })
   })
 
+  test.concurrent(
+    `exits without an error when the reader closes the pipe early`,
+    async () => {
+      // The Markdown exceeds the pipe buffer, so the CLI's write is still in
+      // flight when `head` reads its line and exits.
+      const reader = spawn(`head`, [`-n`, `1`], {
+        stdio: [`pipe`, `pipe`, `inherit`],
+      })
+      const child = spawn(process.execPath, [cliPath, cpuProfilePath], {
+        stdio: [`ignore`, reader.stdin, `pipe`],
+        env: { ...process.env, NODE_COMPILE_CACHE: compileCachePath },
+      })
+      // Closing the parent's handle before the CLI exits would close the
+      // inherited descriptor too, so `head` reaches EOF only once the CLI
+      // exits.
+      child.on(`close`, () => reader.stdin.end())
+
+      const stderr: Buffer[] = []
+      child.stderr.on(`data`, (chunk: Buffer) => stderr.push(chunk))
+      const readerStdout: Buffer[] = []
+      reader.stdout.on(`data`, (chunk: Buffer) => readerStdout.push(chunk))
+      const [status] = await Promise.all([
+        new Promise<number | null>((resolve, reject) => {
+          child.on(`error`, reject)
+          child.on(`close`, resolve)
+        }),
+        new Promise((resolve, reject) => {
+          reader.on(`error`, reject)
+          reader.on(`close`, resolve)
+        }),
+      ])
+
+      expect(Buffer.concat(stderr).toString(`utf8`)).toBe(``)
+      expect(status).toBe(0)
+      expect(Buffer.concat(readerStdout).toString(`utf8`)).toBe(
+        `# CPU profile\n`,
+      )
+    },
+  )
+
   test.concurrent.each([`--output`, `-o`])(
     `writes output to a file with %s`,
     async flag => {

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -28,9 +28,19 @@ const openOutput = async (outputPath: string): Promise<Output> => {
     return {
       write: text =>
         new Promise((resolve, reject) => {
-          process.stdout.write(text, error =>
-            error ? reject(error) : resolve(),
-          )
+          // A reader such as `head` can close the pipe before the write
+          // finishes, failing the write with `EPIPE` and emitting an `error`
+          // event that would otherwise go unhandled. A closed pipe is a normal
+          // exit.
+          const finish = (error?: NodeJS.ErrnoException | null) => {
+            if (!error || error.code === `EPIPE`) {
+              resolve()
+            } else {
+              reject(error)
+            }
+          }
+          process.stdout.on(`error`, finish)
+          process.stdout.write(text, finish)
         }),
     }
   }


### PR DESCRIPTION
Piping stdout into a reader such as `head` fails the write with `EPIPE` once the reader exits, and the stream's `error` event went unhandled, so a run that a reader cut short printed a stack trace and exited nonzero. An `EPIPE` now resolves the write like a completed one.