### PR TITLE
feat(cli): accept auto for --format and --origin

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -127,6 +127,13 @@ const regexCategory = (): ValueParser<`sync`, RegexCategory> => ({
   format: ([regex, category]) => `${regex.source}=${category}`,
 })
 
+/** The `--format` and `--origin` value meaning the format or origin is detected. */
+const AUTO = `auto`
+
+const specified = <Value extends string>(
+  value: Value | typeof AUTO | undefined,
+): Value | undefined => (value === AUTO ? undefined : value)
+
 const parser = object({
   help: optional(
     or(
@@ -136,15 +143,31 @@ const parser = object({
       flag(`-h`, `--help`, { hidden: `help` }),
     ),
   ),
-  format: optional(
-    option(`-f`, `--format`, choice(formats, { metavar: `FORMAT` }), {
-      description: message`Input profile format (default: auto)`,
-    }),
+  format: map(
+    optional(
+      option(
+        `-f`,
+        `--format`,
+        choice([AUTO, ...formats], { metavar: `FORMAT` }),
+        {
+          description: message`Input profile format (default: auto)`,
+        },
+      ),
+    ),
+    specified,
   ),
-  origin: optional(
-    option(`-r`, `--origin`, choice(origins, { metavar: `ORIGIN` }), {
-      description: message`Input profile origin (default: auto)`,
-    }),
+  origin: map(
+    optional(
+      option(
+        `-r`,
+        `--origin`,
+        choice([AUTO, ...origins], { metavar: `ORIGIN` }),
+        {
+          description: message`Input profile origin (default: auto)`,
+        },
+      ),
+    ),
+    specified,
   ),
   output: withDefault(
     option(`-o`, `--output`, path({ metavar: `FILE` }), {

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -94,6 +94,19 @@ if (format === undefined) {
     expect(stdout).toMatch(/^# /u)
   })
 
+  test.concurrent(
+    `--format auto and --origin auto detect the format and origin`,
+    async () => {
+      const { status, stdout } = await runCli(
+        [`--format`, `auto`, `--origin`, `auto`],
+        cpuProfileContent,
+      )
+
+      expect(status).toBe(0)
+      expect(stdout).toMatch(expectedCpuProfileMarkdown)
+    },
+  )
+
   test.concurrent.each([`-`, `/dev/stdin`, `/dev/fd/0`])(
     `reads a piped profile from %s`,
     async path => {


### PR DESCRIPTION
Both flags document their default as auto, but the choice rejected that value, so a script passing the documented default failed. Each flag now accepts auto and maps it back to detection.