### PR TITLE
fix: decode invalid UTF-8 as replacement characters

### DIFF
--- a/src/formats/collapsed/index.test.ts
+++ b/src/formats/collapsed/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest'
+import { concatUint8Arrays } from '../../helpers/bytes.ts'
 import { chunk, streamOf } from '../../helpers/testing.ts'
 import {
   selfSamplesTables,
@@ -18,6 +19,16 @@ import { collapsedConverter } from './index.ts'
 import { parseCollapsed } from './parse.ts'
 import { makeCollapsed } from './testing.ts'
 
+const encodeUtf8 = (text: string): Uint8Array => new TextEncoder().encode(text)
+
+// `py-spy` reads the profiled process's memory while it keeps running, so a
+// `--nonblocking` sample can contain invalid bytes.
+const invalidByteCollapsed = concatUint8Arrays([
+  encodeUtf8(`main (app.py:10);wo`),
+  new Uint8Array([0xff]),
+  encodeUtf8(`rk (app.py:20) 6\nmain (app.py:10) 4\n`),
+])
+
 describe(`matches`, () => {
   test(`accepts a valid collapsed buffer`, () => {
     expect(collapsedConverter.matches(makeCollapsed([`main;work 1`]))).toBe(
@@ -25,8 +36,8 @@ describe(`matches`, () => {
     )
   })
 
-  test(`parse rejects non-UTF-8 bytes`, () => {
-    expect(() => parseCollapsed(new Uint8Array([0xff, 0xfe, 0x00]))).toThrow()
+  test(`accepts a buffer whose frame name contains an invalid UTF-8 byte`, () => {
+    expect(collapsedConverter.matches(invalidByteCollapsed)).toBe(true)
   })
 
   test(`parse rejects lines lacking a trailing count`, () => {
@@ -182,6 +193,26 @@ describe(`convert`, () => {
       [
         { '%': `60.0%`, Samples: `6`, Location: `app.py:20` },
         { '%': `40.0%`, Samples: `4`, Location: `app.py:22` },
+      ],
+    ])
+  })
+
+  test(`an invalid UTF-8 byte in a frame name becomes a replacement character`, () => {
+    const md = convertBytesToMd(
+      collapsedConverter,
+      invalidByteCollapsed,
+      normalizeProfileToMdOptions({ baseURL: `/`, showEntry: () => true }),
+    )
+
+    expect(selfSamplesTables(md)).toEqual([
+      [
+        {
+          '%': `60.0%`,
+          Samples: `6`,
+          Function: `wo\uFFFDrk`,
+          Location: `app.py`,
+        },
+        { '%': `40.0%`, Samples: `4`, Function: `main`, Location: `app.py` },
       ],
     ])
   })

--- a/src/helpers/bytes.test.ts
+++ b/src/helpers/bytes.test.ts
@@ -68,13 +68,17 @@ describe(`decodeUtf8Lines`, () => {
     expect(lines(`a→b\n→`, 2)).toEqual([`a→b`, `→`])
   })
 
-  test(`throws on invalid UTF-8`, () => {
-    expect(() => [...decodeUtf8Lines(new Uint8Array([0xff]))]).toThrow()
+  test(`replaces invalid UTF-8, keeping the surrounding text`, () => {
+    expect([...decodeUtf8Lines(new Uint8Array([0x61, 0xff, 0x62]))]).toEqual([
+      `a\uFFFDb`,
+    ])
   })
 
-  test(`throws on a truncated trailing sequence`, () => {
+  test(`replaces a truncated trailing sequence`, () => {
     // The first two bytes of `→` with the third missing.
-    expect(() => [...decodeUtf8Lines(new Uint8Array([0xe2, 0x86]))]).toThrow()
+    expect([...decodeUtf8Lines(new Uint8Array([0xe2, 0x86]))]).toEqual([
+      `\uFFFD`,
+    ])
   })
 })
 
@@ -113,13 +117,15 @@ describe(`decodeUtf8LinesAsync`, () => {
     expect(await asyncTextLines(`a→b\n→`, 2)).toEqual([`a→b`, `→`])
   })
 
-  test(`throws on invalid UTF-8`, async () => {
-    await expect(asyncLines([new Uint8Array([0xff])])).rejects.toThrow()
+  test(`replaces invalid UTF-8, keeping the surrounding text`, async () => {
+    expect(await asyncLines([new Uint8Array([0x61, 0xff, 0x62])])).toEqual([
+      `a\uFFFDb`,
+    ])
   })
 
-  test(`throws on a truncated trailing sequence`, async () => {
+  test(`replaces a truncated trailing sequence`, async () => {
     // The first two bytes of `→` with the third missing.
-    await expect(asyncLines([new Uint8Array([0xe2, 0x86])])).rejects.toThrow()
+    expect(await asyncLines([new Uint8Array([0xe2, 0x86])])).toEqual([`\uFFFD`])
   })
 })
 

--- a/src/helpers/bytes.ts
+++ b/src/helpers/bytes.ts
@@ -45,8 +45,8 @@ export const concatUint8Arrays = (arrays: Iterable<Uint8Array>): Uint8Array => {
  * Decoding is synchronous and correct across multi-byte sequences split at a
  * chunk boundary.
  *
- * Throws on invalid UTF-8, including a truncated trailing sequence, so a caller
- * can treat a failure as "these bytes aren't this text format".
+ * Replaces an invalid sequence, including a truncated trailing one, with
+ * U+FFFD.
  *
  * Yields the same lines as `decoder.decode(bytes).split('\n')` would (with `\r`
  * stripped), i.e. a trailing empty line when the input ends with a newline.
@@ -73,8 +73,8 @@ export function* decodeUtf8Lines(
  * whole input. Decoding is correct across multi-byte sequences split at a chunk
  * boundary.
  *
- * Throws on invalid UTF-8, including a truncated trailing sequence, so a caller
- * can treat a failure as "these bytes aren't this text format".
+ * Replaces an invalid sequence, including a truncated trailing one, with
+ * U+FFFD.
  *
  * Yields a trailing empty line when the input ends with a newline.
  */
@@ -128,7 +128,7 @@ const NUL_SCAN_LENGTH = 4096
 class Utf8LineDecoder {
   // A streaming decoder must be exclusive to this instance, since it buffers
   // bytes across chunks; sharing one would corrupt interleaved iterations.
-  readonly #decoder = new TextDecoder(`utf-8`, { fatal: true })
+  readonly #decoder = new TextDecoder(`utf-8`)
   #pending = ``
 
   public *push(bytes: Uint8Array): Iterable<string> {
@@ -143,11 +143,6 @@ class Utf8LineDecoder {
     }
   }
 
-  /**
-   * Flush buffered bytes.
-   *
-   * @throws if a trailing sequence is truncated.
-   */
   public *flush(): Iterable<string> {
     this.#pending += this.#decoder.decode()
     yield stripCarriageReturn(this.#pending)


### PR DESCRIPTION
py-spy reads the profiled process's memory while it keeps running, so a `--nonblocking` sample can contain bytes that are not valid UTF-8. The decoder threw on them, so one mangled frame name failed the whole profile, and auto-detection reported the input as undetectable.

The decoder now substitutes U+FFFD for an invalid sequence, so the rest of the profile parses and the mangled name is visible in the output.