### PR TITLE
fix(cli): report file access failures as CLI errors

### DIFF
--- a/src/cli/error.ts
+++ b/src/cli/error.ts
@@ -27,3 +27,6 @@ export const reportError = (error: unknown): never => {
   process.stderr.write(`error: ${String(error)}\n`)
   process.exit(1)
 }
+
+export const reasonOf = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1,6 +1,6 @@
 import { execFile, spawn } from 'node:child_process'
 import { createWriteStream } from 'node:fs'
-import { mkdtemp, open, readFile, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdtemp, open, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
@@ -195,6 +195,55 @@ if (format === undefined) {
       await rm(tempPath, { recursive: true })
     },
   )
+
+  test.concurrent.each([
+    {
+      scenario: `a path in a nonexistent directory`,
+      path: (dir: string) => join(dir, `nonexistent`, `out.md`),
+      expectedReason: `no such directory`,
+    },
+    {
+      scenario: `a directory`,
+      path: (dir: string) => dir,
+      expectedReason: `is a directory`,
+    },
+  ])(`errors on --output to $scenario`, async ({ path, expectedReason }) => {
+    const dir = await mkdtemp(join(tmpdir(), `profiler-md-`))
+    const outputPath = path(dir)
+
+    const { status, stdout, stderr } = await runCli([
+      cpuProfilePath,
+      `--output`,
+      outputPath,
+    ])
+
+    expect(status).toBe(1)
+    expect(stdout).toBe(``)
+    expect(stderr).toBe(
+      `error: cannot write ${outputPath}: ${expectedReason}\n`,
+    )
+
+    await rm(dir, { recursive: true })
+  })
+
+  // Root reads a file regardless of its mode.
+  test
+    .skipIf(process.getuid?.() === 0)
+    .concurrent(`errors on an unreadable file`, async () => {
+      const dir = await mkdtemp(join(tmpdir(), `profiler-md-`))
+      const unreadablePath = join(dir, `unreadable.cpuprofile`)
+      await writeFile(unreadablePath, cpuProfileContent)
+      await chmod(unreadablePath, 0o000)
+
+      const { status, stderr } = await runCli([unreadablePath])
+
+      expect(status).toBe(1)
+      expect(stderr).toBe(
+        `error: cannot read ${unreadablePath}: permission denied\n`,
+      )
+
+      await rm(dir, { recursive: true, force: true })
+    })
 
   test.concurrent(`--top-n limits the number of entries shown`, async () => {
     const [{ stdout: top1 }, { stdout: top5 }] = await Promise.all([
@@ -543,6 +592,28 @@ if (format === undefined) {
 
       expect(status).toBe(0)
       expect(stdout).toMatch(/^# .* diff\n/u)
+    },
+  )
+
+  test.concurrent(
+    `errors on a --source-maps file that is not a source map`,
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), `profiler-md-`))
+      const sourceMapPath = join(dir, `garbage.map`)
+      await writeFile(sourceMapPath, `garbage\n`)
+
+      const { status, stderr } = await runCli([
+        cpuProfilePath,
+        `--source-maps`,
+        sourceMapPath,
+      ])
+
+      expect(status).toBe(1)
+      expect(stderr).toMatch(
+        new RegExp(`^error: cannot parse source map ${sourceMapPath}: `, `u`),
+      )
+
+      await rm(dir, { recursive: true })
     },
   )
 

--- a/src/cli/input.ts
+++ b/src/cli/input.ts
@@ -1,10 +1,10 @@
 import { createReadStream, openAsBlob } from 'node:fs'
-import { stat } from 'node:fs/promises'
+import { access, constants, stat } from 'node:fs/promises'
 import type { Transform } from 'node:stream'
 import { blob } from 'node:stream/consumers'
 import { pipeline } from 'node:stream/promises'
 import { createBrotliDecompress, createGunzip } from 'node:zlib'
-import { CliError } from './error.ts'
+import { CliError, reasonOf } from './error.ts'
 
 export const openInputAsBlob = async (
   filePath: string | undefined,
@@ -34,6 +34,15 @@ const openRawInputAsBlob = async (
   }
   if (stats.isDirectory()) {
     throw new CliError(`cannot read ${filePath}: is a directory`, 1)
+  }
+  // `openAsBlob` opens the file lazily, so an unreadable file fails on the
+  // first read instead of here, as a decompression error.
+  try {
+    await access(filePath, constants.R_OK)
+  } catch (error) {
+    throw new CliError(`cannot read ${filePath}: permission denied`, 1, {
+      cause: error,
+    })
   }
   // `openAsBlob` takes the content length from the file's size. For a pipe,
   // terminal, or socket that size is the bytes currently buffered, not the
@@ -100,9 +109,6 @@ const decompressBlob = async (
     )
   }
 }
-
-const reasonOf = (error: unknown): string =>
-  error instanceof Error ? error.message : String(error)
 
 /**
  * The output buffer size for the decompression transforms. With zlib's 16 KiB

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -15,6 +15,7 @@ import {
   sourceReferencePathOrName,
 } from '../location.ts'
 import type { EntryCategory, RegexCategory, RegexReplacement } from './cli.ts'
+import { CliError, reasonOf } from './error.ts'
 
 /**
  * Every flag the options are built from, each required so that a flag added to
@@ -169,20 +170,41 @@ const loadSourceMaps = async (
 
   return Promise.all(
     paths.map(async path => {
-      const content = await readFile(path, `utf8`)
-      const inlineSourceMap = convertSourceMap
-        .fromSource(content)
-        ?.toObject() as SourceMap | undefined
-      if (!inlineSourceMap) {
-        return resolveSourceMapSources(JSON.parse(content) as SourceMap, path)
+      let content
+      try {
+        content = await readFile(path, `utf8`)
+      } catch (error) {
+        throw new CliError(
+          `cannot read source map ${path}: ${reasonOf(error)}`,
+          1,
+          { cause: error },
+        )
       }
 
-      // Default `file` to the containing file so `normalizeSourceMaps` can
-      // associate the map with profile locations referencing this file.
-      inlineSourceMap.file ??= pathToFileURL(resolve(path)).href
-      return resolveSourceMapSources(inlineSourceMap, path)
+      try {
+        return parseSourceMap(content, path)
+      } catch (error) {
+        throw new CliError(
+          `cannot parse source map ${path}: ${reasonOf(error)}`,
+          1,
+          { cause: error },
+        )
+      }
     }),
   )
+}
+
+const parseSourceMap = (content: string, path: string): SourceMap => {
+  const inlineSourceMap = convertSourceMap.fromSource(content)?.toObject() as
+    SourceMap | undefined
+  if (!inlineSourceMap) {
+    return resolveSourceMapSources(JSON.parse(content) as SourceMap, path)
+  }
+
+  // Default `file` to the containing file, so the map matches profile
+  // locations that reference that file.
+  inlineSourceMap.file ??= pathToFileURL(resolve(path)).href
+  return resolveSourceMapSources(inlineSourceMap, path)
 }
 
 /**

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,4 +1,5 @@
 import { createWriteStream } from 'node:fs'
+import { CliError, reasonOf } from './error.ts'
 import { openPager } from './pager.ts'
 
 export type Output = {
@@ -47,14 +48,35 @@ const openOutput = async (outputPath: string): Promise<Output> => {
 
   const stream = createWriteStream(outputPath)
   await new Promise<void>((resolve, reject) => {
-    stream.once(`open`, () => resolve()).once(`error`, reject)
+    stream
+      .once(`open`, () => resolve())
+      .once(`error`, error => reject(writeError(outputPath, error)))
   })
   return {
     write: text =>
       new Promise((resolve, reject) => {
         stream.write(text, error =>
-          error ? reject(error) : stream.end(resolve),
+          error ? reject(writeError(outputPath, error)) : stream.end(resolve),
         )
       }),
   }
 }
+
+const writeError = (outputPath: string, error: unknown): CliError =>
+  new CliError(
+    `cannot write ${outputPath}: ${WRITE_ERROR_REASONS.get(errorCodeOf(error)) ?? reasonOf(error)}`,
+    1,
+    { cause: error },
+  )
+
+const errorCodeOf = (error: unknown): string | undefined =>
+  error instanceof Error && `code` in error && typeof error.code === `string`
+    ? error.code
+    : undefined
+
+const WRITE_ERROR_REASONS: ReadonlyMap<string | undefined, string> = new Map([
+  [`ENOENT`, `no such directory`],
+  [`EISDIR`, `is a directory`],
+  [`EACCES`, `permission denied`],
+  [`EPERM`, `permission denied`],
+])


### PR DESCRIPTION
A failed --output write, an unreadable profile, and a --source-maps file that cannot be read or parsed each threw a plain Error, so the run printed a stack trace instead of the path and reason. Each now throws a CliError that states the path and a plain reason, with the Node error as its cause.

`openAsBlob` opens the profile lazily, so an unreadable file failed on the first read and reported as a decompression error. The reader now checks read access before opening.