### PR TITLE
fix: report an unclassified parse failure as unusable input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,12 @@ profiler-md
 │   ├── formats/                  # Individual profile format implementations
 │   │   ├── converter.ts          # Format converter types
 │   │   ├── registry.ts           # Format converter registry
-│   │   ├── index.ts              # profileToMd(Async)/diffProfiles(Async) and format auto-detection
+│   │   ├── error.ts              # Parse, rejection, and detection error classes, and the bug report caveat check
+│   │   ├── parse.ts              # JSON decode and specified-format parse wrappers that classify a parse failure
+│   │   ├── detect.ts             # Format auto-detection and its undetected-format error
+│   │   ├── aggregate.ts          # Parsed input to aggregated input dispatch across modalities, with origin detection
+│   │   ├── format.ts             # Aggregated input and diff to Markdown dispatch across modalities
+│   │   ├── index.ts              # profileToMd(Async)/diffProfiles(Async): buffers the input, then parses or detects, aggregates, and formats
 │   │   ├── **/<name>/            # One per format, top-level (e.g. collapsed) or nested in a subdirectory (e.g. v8/cpu-profile)
 │   │   │   ├── matches.ts        # Cheap auto-detection check for the format
 │   │   │   ├── parse.ts          # Parses input into a modality's parsed type
@@ -258,6 +263,20 @@ pnpm generate-inputs go ruby   # Limit to named workload scripts
   accept anything of the format, including a version or variant the parser
   rejects, so auto-detection reports that reason instead of an undetectable
   input
+- The pipeline classifies a failure `parse` throws by the error's class, at the
+  boundary it catches it. A `FormatParseError` is a violation the parser
+  identified. Any other error escaping `parse` is one the parser did not
+  classify: the input violates the format in a way the parser does not check, or
+  the parser has a bug. The pipeline reports both as unusable input. It reports
+  the second as `<title>: failed to parse the input: <reason>`, and the CLI adds
+  a bug report caveat to it (`mayBeParserBug`). The classification is the same
+  under auto-detection and a specified format, and the same for an error a
+  parsed input's lazy iterable throws while aggregation consumes it. An error
+  the caller's data throws while `parse` reads it is the caller's, and the
+  pipeline rethrows it unwrapped. Any other error after `parse` is a bug
+- Wrap a third-party decoder's error (e.g. `JSON.parse`) in a `FormatParseError`
+  at its call site. The parser cannot check anything before decoding succeeds,
+  so a decoding failure is the input's, however the decoder reports it
 - Write a message as `<what failed>: <detail>`, or as a single clause when there
   is no useful prefix. Put the offending value last, after `got: `.
   `eslint-rules/error-message.js` checks the remaining wording conventions
@@ -278,7 +297,13 @@ pnpm generate-inputs go ruby   # Limit to named workload scripts
 ### Parsing
 
 - Cast untyped profile data to typed data for performance. Validate only when
-  necessary to make progress
+  necessary to make progress. Check the shape of what a lazy iterable reads
+  (e.g. that `samples` is an array) before `parse` returns, because
+  auto-detection moves on to the next format only while `parse` is running.
+  Check for a wrong cast that would crash formatting, because the pipeline
+  reports that error as a bug. NEVER add a check to a parser for a nicer message
+  alone: the pipeline already reports an error escaping `parse` as unusable
+  input
 - Parse a specified format to its spec, accepting every shape the spec allows.
   Add handling for a shape the spec forbids only when an input contains it, and
   name the emitter that writes it in a comment

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -11,6 +11,7 @@ import { choice, float, integer, string } from '@optique/core/valueparser'
 import type { ValueParser } from '@optique/core/valueparser'
 import { path } from '@optique/run'
 import packageJson from '../../package.json' with { type: 'json' }
+import { reasonOf } from '../error.ts'
 import { formats } from '../formats/index.ts'
 import { HEAP_SNAPSHOT_NODE_CATEGORIES } from '../modalities/heap-snapshot/type.ts'
 import type { HeapSnapshotNodeCategory } from '../modalities/heap-snapshot/type.ts'
@@ -53,9 +54,7 @@ const parseRegex = (
   } catch (error) {
     return {
       success: false,
-      error: message`expected a valid regex, got: ${value(pattern)} (${text(
-        error instanceof Error ? error.message : String(error),
-      )})`,
+      error: message`expected a valid regex, got: ${value(pattern)} (${text(reasonOf(error))})`,
     }
   }
 }

--- a/src/cli/error.ts
+++ b/src/cli/error.ts
@@ -1,4 +1,6 @@
+import packageJson from '../../package.json' with { type: 'json' }
 import { ProfilerMdError } from '../error.ts'
+import { unclassifiedParseFailures } from '../formats/error.ts'
 
 export class CliError extends ProfilerMdError {
   public readonly exitCode: 1 | 2
@@ -14,19 +16,27 @@ export class CliError extends ProfilerMdError {
 export const reportError = (error: unknown): never => {
   if (error instanceof ProfilerMdError) {
     process.stderr.write(`error: ${error.message}\n`)
+    const parseFailures = unclassifiedParseFailures(error)
+    if (parseFailures.length > 0) {
+      process.stderr.write(
+        [
+          `If the input opens in its profiler, report this as a bug in ${packageJson.name}:`,
+          `${packageJson.bugs.url}/new`,
+          `Include the command you ran, the input if you can share it, and this trace:`,
+          ...parseFailures.map(stackOf),
+          ``,
+        ].join(`\n`),
+      )
+    }
     process.exit(error instanceof CliError ? error.exitCode : 1)
   }
 
-  if (error instanceof Error) {
-    process.stderr.write(
-      error.stack ? `${error.stack}\n` : `error: ${error.message}\n`,
-    )
-    process.exit(1)
-  }
-
-  process.stderr.write(`error: ${String(error)}\n`)
+  process.stderr.write(`${stackOf(error)}\n`)
   process.exit(1)
 }
 
-export const reasonOf = (error: unknown): string =>
-  error instanceof Error ? error.message : String(error)
+/** An error's stack trace, or its description when it has none. */
+const stackOf = (error: unknown): string =>
+  error instanceof Error
+    ? (error.stack ?? `${error.name}: ${error.message}`)
+    : `error: ${String(error)}`

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -13,6 +13,10 @@ import {
   inputPath,
   smallestInput,
 } from '../formats/testing.ts'
+import {
+  crashingV8CpuProfile,
+  lazilyCrashingV8CpuProfile,
+} from '../formats/v8/cpu-profile/testing.ts'
 import { languageExtensionToPrimary } from './languages.ts'
 
 // Each test spawns the CLI in a subprocess, which can outlast the default 5s.
@@ -619,6 +623,64 @@ if (format === undefined) {
 
   test.concurrent.each([
     {
+      scenario: `under an explicit format`,
+      args: [`--format`, `v8-cpu-profile`],
+      input: crashingV8CpuProfile,
+    },
+    {
+      scenario: `under auto-detection`,
+      args: [],
+      input: crashingV8CpuProfile,
+    },
+    {
+      scenario: `lazily, under an explicit format`,
+      args: [`--format`, `v8-cpu-profile`],
+      input: lazilyCrashingV8CpuProfile,
+    },
+    {
+      scenario: `lazily, under auto-detection`,
+      args: [],
+      input: lazilyCrashingV8CpuProfile,
+    },
+  ])(
+    `reports an input that crashes a parser as unusable, with a bug report caveat, $scenario`,
+    async ({ args, input }) => {
+      const { status, stderr } = await runCli(args, input)
+
+      expect(status).toBe(1)
+      const [errorLine, ...caveatLines] = stderr.split(`\n`)
+      expect(errorLine).toContain(
+        `error: V8 CPU profile: failed to parse the input: `,
+      )
+      const traceLines = caveatLines.splice(3)
+      expect(caveatLines).toEqual([
+        `If the input opens in its profiler, report this as a bug in ${packageJson.name}:`,
+        `${packageJson.bugs.url}/new`,
+        `Include the command you ran, the input if you can share it, and this trace:`,
+      ])
+      expect(traceLines[0]).toMatch(/^TypeError: /u)
+      expect(
+        traceLines.slice(1, -1).every(line => line.startsWith(`    at `)),
+      ).toBe(true)
+      expect(traceLines.at(-1)).toBe(``)
+    },
+  )
+
+  test.concurrent(
+    `reports a classified rejection without a bug report caveat`,
+    async () => {
+      const { status, stderr } = await runCli(
+        [`--format`, `collapsed`],
+        `funcA;funcB`,
+      )
+
+      expect(status).toBe(1)
+      expect(stderr).toBe(`error: Collapsed stacks: missing sample count\n`)
+    },
+  )
+
+  test.concurrent.each([
+    {
       scenario: `stdin with unrecognizable content`,
       args: [],
       input: `{}`,
@@ -629,7 +691,20 @@ if (format === undefined) {
       scenario: `stdin with a truncated JSON profile`,
       args: [],
       input: `{"nodes": [`,
-      expectedStderr: `the input reads as JSON but failed to parse`,
+      expectedStderr: `the input reads as JSON but is invalid JSON: `,
+      expectedStatus: 1,
+    },
+    {
+      scenario: `stdin with invalid JSON under an explicit JSON format`,
+      args: [`--format`, `v8-cpu-profile`],
+      input: `garbage\n`,
+      expectedStderr: `error: V8 CPU profile: invalid JSON: `,
+      expectedStatus: 1,
+    },
+    {
+      scenario: `a JSON file under --format pprof`,
+      args: [`--format`, `pprof`, inputPath(`javascript.node.base.cpuprofile`)],
+      expectedStderr: `error: pprof: invalid protobuf encoding: `,
       expectedStatus: 1,
     },
     {

--- a/src/cli/input.ts
+++ b/src/cli/input.ts
@@ -4,7 +4,8 @@ import type { Transform } from 'node:stream'
 import { blob } from 'node:stream/consumers'
 import { pipeline } from 'node:stream/promises'
 import { createBrotliDecompress, createGunzip } from 'node:zlib'
-import { CliError, reasonOf } from './error.ts'
+import { reasonOf } from '../error.ts'
+import { CliError } from './error.ts'
 
 export const openInputAsBlob = async (
   filePath: string | undefined,

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -2,6 +2,7 @@ import { glob, readFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import convertSourceMap from 'convert-source-map'
+import { reasonOf } from '../error.ts'
 import type { DeepReadonly } from '../helpers/types.ts'
 import {
   defaultCategorizeFunctions,
@@ -15,7 +16,7 @@ import {
   sourceReferencePathOrName,
 } from '../location.ts'
 import type { EntryCategory, RegexCategory, RegexReplacement } from './cli.ts'
-import { CliError, reasonOf } from './error.ts'
+import { CliError } from './error.ts'
 
 /**
  * Every flag the options are built from, each required so that a flag added to

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,5 +1,6 @@
 import { createWriteStream } from 'node:fs'
-import { CliError, reasonOf } from './error.ts'
+import { reasonOf } from '../error.ts'
+import { CliError } from './error.ts'
 import { openPager } from './pager.ts'
 
 export type Output = {

--- a/src/error.ts
+++ b/src/error.ts
@@ -3,7 +3,10 @@
  * format, a malformed profile, an invalid option.
  *
  * A failure the caller cannot fix throws a plain `Error` instead, because such
- * a failure is a bug in this package.
+ * a failure is a bug in this package. The exception is a parser failing on an
+ * error it did not classify, which is either an input violating the format in
+ * a way the parser does not check or a parser bug. That failure throws a
+ * `ProfilerMdError` too, and `mayBeParserBug` identifies it.
  */
 export class ProfilerMdError extends Error {
   public constructor(message: string, options?: ErrorOptions) {
@@ -12,3 +15,9 @@ export class ProfilerMdError extends Error {
     this.name = 'ProfilerMdError'
   }
 }
+
+/** An error's message on one line, for embedding in another message. */
+export const reasonOf = (error: unknown): string =>
+  (error instanceof Error ? error.message : String(error))
+    .replaceAll(/\s+/gu, ` `)
+    .trim()

--- a/src/formats/aggregate.ts
+++ b/src/formats/aggregate.ts
@@ -1,0 +1,56 @@
+import { CallGraphAggregator } from '../modalities/call-graph/index.ts'
+import { CallStackProfileAggregator } from '../modalities/call-stack-profile/index.ts'
+import { HeapSnapshotAggregator } from '../modalities/heap-snapshot/aggregate.ts'
+import type {
+  AggregationProfileToMdOptions,
+  ProfileToMdContext,
+  UnresolvedProfileToMdContext,
+} from '../options.ts'
+import { OriginDetector } from '../origins/index.ts'
+import type { Origin } from '../origins/index.ts'
+import type { AggregatedInput, ParsedInput } from './converter.ts'
+import type { Format } from './registry.ts'
+
+/**
+ * Aggregates each parsed input through its modality's uniform pipeline.
+ *
+ * The origin is detected once across all inputs.
+ */
+export const aggregateParsedInputs = (
+  parsed: ParsedInput[],
+  options: AggregationProfileToMdOptions,
+  context: UnresolvedProfileToMdContext,
+): AggregatedInput[] => {
+  const aggregators = parsed.map(input => {
+    switch (input.type) {
+      case `call-stack-profile`:
+        return new CallStackProfileAggregator(input)
+      case `call-graph`:
+        return new CallGraphAggregator(input)
+      case `heap-snapshot`:
+        return new HeapSnapshotAggregator(input)
+    }
+  })
+
+  const detector = new OriginDetector(context)
+  for (const aggregator of aggregators) {
+    aggregator.detectOrigin(detector)
+  }
+
+  const resolvedContext: ProfileToMdContext = {
+    format: context.format,
+    origin: detector.resolve(),
+  }
+  return aggregators.map(aggregator =>
+    aggregator.aggregate(options, resolvedContext),
+  )
+}
+
+/**
+ * Builds the conversion context, which contains the resolved format and the
+ * explicit origin (or `null` when none was given).
+ */
+export const makeContext = (
+  format: Format,
+  origin: Origin | undefined,
+): UnresolvedProfileToMdContext => ({ format, origin: origin ?? null })

--- a/src/formats/converter.ts
+++ b/src/formats/converter.ts
@@ -52,7 +52,7 @@ type FormatMeta = {
  * A cheap {@link Detect.matches} may be a loose prefilter because `parse` is
  * the real check.
  */
-type Parse<Input> = {
+export type Parse<Input> = {
   parse: (input: Input) => ParsedInput[]
 }
 
@@ -68,7 +68,7 @@ type Parse<Input> = {
  * keep ambiguous input (e.g. text a user could force) from being auto-detected
  * as this format.
  */
-type Detect<Input> = {
+export type Detect<Input> = {
   matches: (input: Input) => boolean
 }
 

--- a/src/formats/detect.ts
+++ b/src/formats/detect.ts
@@ -1,0 +1,136 @@
+import { reasonOf } from '../error.ts'
+import type {
+  BinaryFormatConverter,
+  Detect,
+  FormatConverter,
+  JsonFormatConverter,
+  Parse,
+  ParsedInput,
+} from './converter.ts'
+import { FormatDetectError } from './error.ts'
+import { classifyLazyParseFailures, describeParseFailure } from './parse.ts'
+import { formatConverters, formats } from './registry.ts'
+import type { Format } from './registry.ts'
+
+/** An input a format recognized and parsed during auto-detection. */
+export type DetectedInput = { format: Format; parsed: ParsedInput[] }
+
+/**
+ * A converter that recognized the input, but whose parse rejected it.
+ *
+ * Detection continues with the next format, and reports the rejections when no
+ * format parses the input.
+ */
+export type FormatRejection = { converter: FormatConverter; error: unknown }
+
+export const detectJsonFormat = (
+  json: unknown,
+  rejections: FormatRejection[],
+): DetectedInput | undefined => {
+  for (const [format, converter] of jsonFormatConverters) {
+    const parsed = detectWithConverter(converter, json, rejections)
+    if (parsed) {
+      return { format, parsed }
+    }
+  }
+  return undefined
+}
+
+export const detectBinaryFormat = (
+  bytes: Uint8Array,
+  rejections: FormatRejection[],
+): DetectedInput | undefined => {
+  for (const [format, converter] of binaryFormatConverters) {
+    const parsed = detectWithConverter(converter, bytes, rejections)
+    if (parsed) {
+      return { format, parsed }
+    }
+  }
+  return undefined
+}
+
+const formatConverterEntries: [Format, FormatConverter][] = formats.map(
+  format => [format, formatConverters[format]],
+)
+
+const jsonFormatConverters: [Format, JsonFormatConverter][] =
+  formatConverterEntries.filter(
+    (entry): entry is [Format, JsonFormatConverter] => entry[1].type === `json`,
+  )
+
+const binaryFormatConverters: [Format, BinaryFormatConverter][] =
+  formatConverterEntries.filter(
+    (entry): entry is [Format, BinaryFormatConverter] =>
+      entry[1].type === `binary`,
+  )
+
+/**
+ * Runs a converter's detection and parse, recording a rejection instead of
+ * throwing when the converter recognized the input but failed to parse it.
+ *
+ * A `matches` that throws counts as no match, because it is a cheap prefilter
+ * that never validates the input.
+ */
+const detectWithConverter = <Input>(
+  converter: FormatConverter & Detect<Input> & Parse<Input>,
+  input: Input,
+  rejections: FormatRejection[],
+): ParsedInput[] | undefined => {
+  try {
+    if (!converter.matches(input)) {
+      return undefined
+    }
+  } catch {
+    return undefined
+  }
+
+  try {
+    return classifyLazyParseFailures(converter, converter.parse(input))
+  } catch (error: unknown) {
+    rejections.push({ converter, error })
+    return undefined
+  }
+}
+
+/**
+ * Reports why auto-detection resolved no format.
+ *
+ * A single rejection is reported as that format's failure, because the input
+ * is that format and failed to parse. Several rejections name each format with
+ * its reason. No rejection means no format recognized the input.
+ */
+export const toUndetectedFormatError = (
+  rejections: readonly FormatRejection[],
+  jsonError: unknown,
+): FormatDetectError => {
+  const [rejection] = rejections
+  if (rejections.length === 1) {
+    return new FormatDetectError(
+      describeParseFailure(rejection!.converter, rejection!.error),
+      [rejection!.error],
+      { cause: rejection!.error },
+    )
+  }
+
+  if (rejections.length > 1) {
+    return new FormatDetectError(
+      `could not detect the profile format, rejected by: ${rejections
+        .map(({ converter, error }) => describeParseFailure(converter, error))
+        .join(`, `)}`,
+      rejections.map(({ error }) => error),
+    )
+  }
+
+  if (jsonError !== undefined) {
+    return new FormatDetectError(
+      `could not detect the profile format, the input reads as JSON but is ${reasonOf(jsonError)}`,
+      [jsonError],
+      { cause: jsonError },
+    )
+  }
+
+  return new FormatDetectError(
+    `could not detect the profile format, expected one of: ${formats.join(`, `)}`,
+    [],
+  )
+}

--- a/src/formats/error.ts
+++ b/src/formats/error.ts
@@ -34,3 +34,48 @@ export class FormatDetectError extends ProfilerMdError {
     this.errors = errors
   }
 }
+
+/**
+ * Thrown when the format the caller specified rejected the input.
+ *
+ * {@link FormatRejectionError.cause} is the error the format's parse threw.
+ */
+export class FormatRejectionError extends ProfilerMdError {
+  public constructor(message: string, options: ErrorOptions) {
+    super(message, options)
+    // eslint-disable-next-line stylistic/quotes
+    this.name = 'FormatRejectionError'
+  }
+}
+
+/**
+ * Whether a conversion error may be a bug in this package rather than an
+ * unusable input.
+ *
+ * A parse that throws a {@link FormatParseError} identified the violation. One
+ * that throws anything else failed on an error it did not classify: either the
+ * input violates the format in a way the parser does not check, or the parser
+ * has a bug. The pipeline reports both as unusable input, because the parser's
+ * input is the only variable on its code path. A caller whose input opens in
+ * its profiler has the evidence that distinguishes the two.
+ */
+export const mayBeParserBug = (error: unknown): boolean =>
+  unclassifiedParseFailures(error).length > 0
+
+/**
+ * The errors a conversion error wraps that a parser threw without classifying
+ * them, in detection order. Empty when the error is not a conversion error, or
+ * when every wrapped error is a {@link FormatParseError}.
+ */
+export const unclassifiedParseFailures = (error: unknown): unknown[] => {
+  if (error instanceof FormatDetectError) {
+    return error.errors.filter(isUnclassifiedParseFailure)
+  }
+  if (error instanceof FormatRejectionError) {
+    return isUnclassifiedParseFailure(error.cause) ? [error.cause] : []
+  }
+  return []
+}
+
+const isUnclassifiedParseFailure = (error: unknown): boolean =>
+  !(error instanceof FormatParseError)

--- a/src/formats/format.ts
+++ b/src/formats/format.ts
@@ -1,0 +1,182 @@
+import type { RootContent } from 'mdast'
+import { ProfilerMdError } from '../error.ts'
+import { mdastToMarkdown, paragraph } from '../helpers/markdown.ts'
+import {
+  commonAncestorDirectoryURL,
+  isBaseURLInferableLocation,
+} from '../location.ts'
+import type { SourceLocation } from '../location.ts'
+import {
+  diffAggregatedCallGraphs,
+  formatCallGraph,
+  formatCallGraphDiff,
+} from '../modalities/call-graph/index.ts'
+import { diffAggregatedCallStackProfiles } from '../modalities/call-stack-profile/diff.ts'
+import {
+  formatCallStackProfile,
+  formatCallStackProfileDiff,
+} from '../modalities/call-stack-profile/format.ts'
+import { entityLocation } from '../modalities/heap-snapshot/aggregate.ts'
+import { diffAggregatedHeapSnapshots } from '../modalities/heap-snapshot/diff.ts'
+import {
+  formatHeapSnapshot,
+  formatHeapSnapshotDiff,
+} from '../modalities/heap-snapshot/format.ts'
+import type {
+  FormattingProfileToMdOptions,
+  NormalizedProfileToMdOptions,
+} from '../options.ts'
+import { sourceMapSourceLocation } from '../source-map.ts'
+import type { AggregatedInput, ParsedInput } from './converter.ts'
+
+export const formatAggregatedInputs = (
+  inputs: AggregatedInput[],
+  options: NormalizedProfileToMdOptions,
+): string => {
+  const formattingOptions = makeFormattingProfileToMdOptions(options, inputs)
+  const contents = inputs.flatMap(input => {
+    switch (input.type) {
+      case `call-stack-profile`:
+        return formatCallStackProfile(input, formattingOptions)
+      case `call-graph`:
+        return formatCallGraph(input, formattingOptions)
+      case `heap-snapshot`:
+        return formatHeapSnapshot(input, formattingOptions)
+    }
+  })
+  return toMarkdown(contents)
+}
+
+/**
+ * Diffs the aggregated {@link base} and {@link current} inputs element by
+ * element, returning the differences as Markdown.
+ *
+ * The two sides must have the same length and the same `type` at each index,
+ * otherwise they aren't comparable.
+ */
+export const formatAggregatedDiff = (
+  base: AggregatedInput[],
+  current: AggregatedInput[],
+  options: NormalizedProfileToMdOptions,
+): string => {
+  if (base.length !== current.length) {
+    throw new ProfilerMdError(
+      `cannot diff inputs containing different numbers of profiles, got: ${base.length} in the base and ${current.length} in the current`,
+    )
+  }
+
+  // Resolve over both sides at once so they share a single inferred base URL
+  // and format consistently.
+  const formattingOptions = makeFormattingProfileToMdOptions(options, [
+    ...base,
+    ...current,
+  ])
+  const contents = base.flatMap((baseInput, index) => {
+    const currentInput = current[index]!
+    if (
+      baseInput.type === `call-stack-profile` &&
+      currentInput.type === `call-stack-profile`
+    ) {
+      return formatCallStackProfileDiff(
+        diffAggregatedCallStackProfiles(
+          baseInput,
+          currentInput,
+          formattingOptions,
+        ),
+        formattingOptions,
+      )
+    }
+    if (baseInput.type === `call-graph` && currentInput.type === `call-graph`) {
+      return formatCallGraphDiff(
+        diffAggregatedCallGraphs(baseInput, currentInput, formattingOptions),
+        formattingOptions,
+      )
+    }
+    if (
+      baseInput.type === `heap-snapshot` &&
+      currentInput.type === `heap-snapshot`
+    ) {
+      return formatHeapSnapshotDiff(
+        diffAggregatedHeapSnapshots(baseInput, currentInput, formattingOptions),
+        formattingOptions,
+      )
+    }
+    throw new ProfilerMdError(
+      `cannot diff a ${modalityName(baseInput.type)} against a ${modalityName(currentInput.type)}`,
+    )
+  })
+  return toMarkdown(contents)
+}
+
+const modalityName = (type: ParsedInput[`type`]): string =>
+  type.replaceAll(`-`, ` `)
+
+const toMarkdown = (contents: RootContent[]): string =>
+  mdastToMarkdown(
+    contents.length > 0 ? contents : [paragraph(`No profiling data found.`)],
+  )
+
+/**
+ * Resolves a `baseURL` of `'auto'` to the common ancestor directory of the
+ * aggregated {@link inputs}.
+ *
+ * Any other `baseURL` passes through unchanged.
+ */
+const makeFormattingProfileToMdOptions = (
+  options: NormalizedProfileToMdOptions,
+  inputs: AggregatedInput[],
+): FormattingProfileToMdOptions => {
+  const { baseURL } = options
+  return baseURL === `auto`
+    ? {
+        ...options,
+        baseURL: commonAncestorDirectoryURL(
+          collectInferableURLs(inputs, { ...options, baseURL: undefined }),
+        ),
+      }
+    : { ...options, baseURL }
+}
+
+/**
+ * Collects the base-URL-inferable absolute URLs of {@link inputs}' entries.
+ *
+ * Applies source maps first so the base is inferred from the locations
+ * formatting will show.
+ */
+const collectInferableURLs = (
+  inputs: AggregatedInput[],
+  options: FormattingProfileToMdOptions,
+): URL[] => {
+  const urls: URL[] = []
+  const collect = (location: SourceLocation | undefined) => {
+    if (!location) {
+      return
+    }
+    const mappedLocation = sourceMapSourceLocation(location, options)
+    if (isBaseURLInferableLocation(mappedLocation)) {
+      urls.push(mappedLocation.url)
+    }
+  }
+
+  for (const input of inputs) {
+    switch (input.type) {
+      case `call-stack-profile`:
+      case `call-graph`:
+        for (const func of input.functions) {
+          // Only `ours`-categorized functions contribute, because a
+          // dependency's install path can be far outside the source tree and
+          // would raise the base to a shared root.
+          if (func.category === `ours`) {
+            collect(func.location)
+          }
+        }
+        break
+      case `heap-snapshot`:
+        for (const entity of [...input.constructors, ...input.functions]) {
+          collect(entityLocation(entity))
+        }
+        break
+    }
+  }
+  return urls
+}

--- a/src/formats/index.test.ts
+++ b/src/formats/index.test.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync } from 'node:fs'
 import { describe, expect, test, vi } from 'vitest'
 import { projects } from '../../vitest.config.ts'
 import { parseExampleFilename } from '../cli/examples.ts'
+import { ProfilerMdError } from '../error.ts'
 import { sourceReferenceId } from '../location.ts'
 import type { CallStackProfile } from '../modalities/call-stack-profile/index.ts'
 import {
@@ -12,7 +13,7 @@ import { SAMPLES } from '../modalities/metrics.ts'
 import { normalizeProfileToMdOptions } from '../options.ts'
 import { categoryTables, profileTitles, rankingTables } from '../testing.ts'
 import type { JsonFormatConverter } from './converter.ts'
-import { FormatDetectError } from './error.ts'
+import { FormatDetectError, mayBeParserBug } from './error.ts'
 import {
   diffProfiles,
   diffProfilesAsync,
@@ -29,6 +30,8 @@ import {
   smallestInput,
 } from './testing.ts'
 import {
+  crashingV8CpuProfile,
+  lazilyCrashingV8CpuProfile,
   makeV8CallFrame,
   makeV8CpuProfileRoot,
 } from './v8/cpu-profile/testing.ts'
@@ -508,10 +511,181 @@ describe(`profileToMd`, () => {
       )
     })
 
-    test(`detection reports a malformed JSON document as unparseable JSON`, () => {
+    test(`detection reports a malformed JSON document as invalid JSON`, () => {
       expect(() => profileToMd(`{"nodes": [`)).toThrow(
-        /could not detect the profile format, the input reads as JSON but failed to parse: /u,
+        /could not detect the profile format, the input reads as JSON but is invalid JSON: /u,
       )
+    })
+
+    test(`a specified JSON format reports invalid JSON as its rejection`, () => {
+      expect(() =>
+        profileToMd({ data: `garbage\n`, format: `v8-cpu-profile` }),
+      ).toThrow(/^V8 CPU profile: invalid JSON: /u)
+    })
+
+    test(`a specified JSON format reports invalid JSON as its rejection when async`, async () => {
+      await expect(
+        profileToMdAsync({
+          data: new Blob([`garbage\n`]),
+          format: `v8-cpu-profile`,
+        }),
+      ).rejects.toThrow(/^V8 CPU profile: invalid JSON: /u)
+    })
+
+    test(`a specified binary format reports its decoder's failure as its rejection`, () => {
+      expect(() => profileToMd({ data: `garbage\n`, format: `pprof` })).toThrow(
+        /^pprof: invalid protobuf encoding: /u,
+      )
+    })
+
+    const unclassifiedInputs = [
+      { scenario: `before parse returns`, data: crashingV8CpuProfile },
+      {
+        scenario: `while aggregation consumes the parse's lazy iterable`,
+        data: lazilyCrashingV8CpuProfile,
+      },
+    ]
+
+    test.each(unclassifiedInputs)(
+      `a specified format reports an error its parser did not classify as a failure to parse, thrown $scenario`,
+      ({ data }) => {
+        let thrown
+        try {
+          profileToMd({ data, format: `v8-cpu-profile` })
+        } catch (error: unknown) {
+          thrown = error
+        }
+
+        expect(thrown).toBeInstanceOf(ProfilerMdError)
+        expect((thrown as Error).message).toMatch(
+          /^V8 CPU profile: failed to parse the input: /u,
+        )
+        expect(mayBeParserBug(thrown)).toBe(true)
+      },
+    )
+
+    test.each(unclassifiedInputs)(
+      `a specified format reports an error its parser did not classify as a failure to parse when async, thrown $scenario`,
+      async ({ data }) => {
+        let thrown
+        try {
+          await profileToMdAsync({
+            data: new Blob([data]),
+            format: `v8-cpu-profile`,
+          })
+        } catch (error: unknown) {
+          thrown = error
+        }
+
+        expect(thrown).toBeInstanceOf(ProfilerMdError)
+        expect((thrown as Error).message).toMatch(
+          /^V8 CPU profile: failed to parse the input: /u,
+        )
+        expect(mayBeParserBug(thrown)).toBe(true)
+      },
+    )
+
+    test.each(unclassifiedInputs)(
+      `detection reports an error a parser did not classify the same way a specified format does, thrown $scenario`,
+      ({ data }) => {
+        let detected
+        try {
+          profileToMd(data)
+        } catch (error: unknown) {
+          detected = error
+        }
+        let specified
+        try {
+          profileToMd({ data, format: `v8-cpu-profile` })
+        } catch (error: unknown) {
+          specified = error
+        }
+
+        expect((detected as Error).message).toBe((specified as Error).message)
+        expect(mayBeParserBug(detected)).toBe(true)
+      },
+    )
+
+    test(`a rejection the parser classified is not a possible bug`, () => {
+      let thrown
+      try {
+        profileToMd({ data: `funcA;funcB`, format: `collapsed` })
+      } catch (error: unknown) {
+        thrown = error
+      }
+
+      expect(mayBeParserBug(thrown)).toBe(false)
+    })
+
+    test.each([
+      { scenario: `under auto-detection`, format: undefined },
+      { scenario: `under a specified format`, format: `hprof` as const },
+    ])(
+      `a rejection's message collapses the whitespace of the value it reports, $scenario`,
+      ({ format }) => {
+        const data = new TextEncoder().encode(
+          `JAVA PROFILE \nfoo\n  1.0\tbar\0${`\0`.repeat(20)}`,
+        )
+
+        expect(() => profileToMd(format ? { data, format } : data)).toThrow(
+          `HPROF: unsupported format name, got: JAVA PROFILE foo 1.0 bar`,
+        )
+      },
+    )
+
+    test(`a specified format's rejection wraps the parser's error as its cause`, () => {
+      let thrown
+      try {
+        profileToMd({ data: crashingV8CpuProfile, format: `v8-cpu-profile` })
+      } catch (error: unknown) {
+        thrown = error
+      }
+
+      expect((thrown as Error).cause).toBeInstanceOf(TypeError)
+    })
+
+    describe(`a failure to read the data escapes unwrapped`, () => {
+      const readError = new Error(`EIO`)
+      function* failingIterable(): Iterable<Uint8Array> {
+        yield new TextEncoder().encode(`{`)
+        throw readError
+      }
+      const failingStream = (): ReadableStream<Uint8Array> =>
+        new ReadableStream({
+          pull: () => {
+            throw readError
+          },
+        })
+
+      test.each([
+        { scenario: `under a specified JSON format`, format: `v8-cpu-profile` },
+        { scenario: `under a specified binary format`, format: `pprof` },
+        { scenario: `under auto-detection`, format: undefined },
+      ] as const)(`from an iterable $scenario`, ({ format }) => {
+        let thrown
+        try {
+          profileToMd({ data: failingIterable(), format })
+        } catch (error: unknown) {
+          thrown = error
+        }
+
+        expect(thrown).toBe(readError)
+      })
+
+      test.each([
+        { scenario: `under a specified JSON format`, format: `v8-cpu-profile` },
+        { scenario: `under a specified binary format`, format: `pprof` },
+        { scenario: `under auto-detection`, format: undefined },
+      ] as const)(`from a stream $scenario`, async ({ format }) => {
+        let thrown
+        try {
+          await profileToMdAsync({ data: failingStream(), format })
+        } catch (error: unknown) {
+          thrown = error
+        }
+
+        expect(thrown).toBe(readError)
+      })
     })
 
     test(`a detection error contains the error from each format that rejected the input`, () => {

--- a/src/formats/index.ts
+++ b/src/formats/index.ts
@@ -1,6 +1,3 @@
-import { JumboJSON } from 'jumbo-json'
-import type { RootContent } from 'mdast'
-import { ProfilerMdError } from '../error.ts'
 import { concatUint8Arrays, streamToUint8Array } from '../helpers/bytes.ts'
 import {
   maybeJson,
@@ -8,61 +5,35 @@ import {
   startsJsonDocument,
   startsJsonDocumentAsync,
 } from '../helpers/json.ts'
-import { mdastToMarkdown, paragraph } from '../helpers/markdown.ts'
-import {
-  commonAncestorDirectoryURL,
-  isBaseURLInferableLocation,
-} from '../location.ts'
-import type { SourceLocation } from '../location.ts'
-import {
-  CallGraphAggregator,
-  diffAggregatedCallGraphs,
-  formatCallGraph,
-  formatCallGraphDiff,
-} from '../modalities/call-graph/index.ts'
-import { diffAggregatedCallStackProfiles } from '../modalities/call-stack-profile/diff.ts'
-import {
-  formatCallStackProfile,
-  formatCallStackProfileDiff,
-} from '../modalities/call-stack-profile/format.ts'
-import { CallStackProfileAggregator } from '../modalities/call-stack-profile/index.ts'
-import {
-  entityLocation,
-  HeapSnapshotAggregator,
-} from '../modalities/heap-snapshot/aggregate.ts'
-import { diffAggregatedHeapSnapshots } from '../modalities/heap-snapshot/diff.ts'
-import {
-  formatHeapSnapshot,
-  formatHeapSnapshotDiff,
-} from '../modalities/heap-snapshot/format.ts'
 import type {
   AggregationProfileToMdOptions,
   AsyncProfileData,
-  FormattingProfileToMdOptions,
-  NormalizedProfileToMdOptions,
   ProfileData,
   ProfileInput,
-  ProfileToMdContext,
   ProfileToMdOptions,
-  UnresolvedProfileToMdContext,
 } from '../options.ts'
 import {
   normalizeProfileInput,
   normalizeProfileToMdOptions,
 } from '../options.ts'
-import { OriginDetector } from '../origins/index.ts'
-import type { Origin } from '../origins/index.ts'
-import { sourceMapSourceLocation } from '../source-map.ts'
-import type {
-  AggregatedInput,
-  BinaryFormatConverter,
-  FormatConverter,
-  JsonFormatConverter,
-  ParsedInput,
-} from './converter.ts'
-import { FormatDetectError, FormatParseError } from './error.ts'
-import { formatConverters, formats } from './registry.ts'
-import type { Format } from './registry.ts'
+import { aggregateParsedInputs, makeContext } from './aggregate.ts'
+import type { AggregatedInput } from './converter.ts'
+import {
+  detectBinaryFormat,
+  detectJsonFormat,
+  toUndetectedFormatError,
+} from './detect.ts'
+import type { FormatRejection } from './detect.ts'
+import { formatAggregatedDiff, formatAggregatedInputs } from './format.ts'
+import {
+  dataToBytes,
+  parseAsFormat,
+  parseAsFormatAsync,
+  parseJson,
+  parseJsonAsync,
+  rethrowInputReadFailure,
+} from './parse.ts'
+import { formatConverters } from './registry.ts'
 
 export { formatConverters, formats } from './registry.ts'
 export type { Format } from './registry.ts'
@@ -150,12 +121,8 @@ export const aggregateInput = (
   const { data, format, origin } = normalizeProfileInput(input)
 
   if (format) {
-    // The format was specified, so delegate directly to its converter.
-    const converter = specifiedFormatConverter(format)
-    const context = makeContext(format, origin)
-    return converter.type === `json`
-      ? aggregateJsonInput(converter, JumboJSON.parse(data), options, context)
-      : aggregateBinaryInput(converter, dataToBytes(data), options, context)
+    const parsed = parseAsFormat(formatConverters[format], data)
+    return aggregateParsedInputs(parsed, options, makeContext(format, origin))
   }
 
   // Buffer an `Iterable` up front because it might be one-shot, but we need to
@@ -169,45 +136,27 @@ export const aggregateInput = (
   let jsonError: unknown
   if (maybeJson(buffered)) {
     try {
-      json = JumboJSON.parse(buffered)
+      json = parseJson(buffered)
     } catch (error: unknown) {
       // Report unusable JSON only for an input that opens a JSON document,
       // because `maybeJson` also admits text starting like a bare JSON value.
       jsonError = startsJsonDocument(buffered) ? error : undefined
     }
   }
+
   const rejections: FormatRejection[] = []
-  if (json !== undefined) {
-    const inputs = detectFromJson(json, options, origin, rejections)
-    if (inputs !== undefined) {
-      return inputs
-    }
+  const detected =
+    (json === undefined ? undefined : detectJsonFormat(json, rejections)) ??
+    detectBinaryFormat(dataToBytes(buffered), rejections)
+  if (!detected) {
+    throw toUndetectedFormatError(rejections, jsonError)
   }
-
-  const inputs = detectFromBytes(
-    dataToBytes(buffered),
+  return aggregateParsedInputs(
+    detected.parsed,
     options,
-    origin,
-    rejections,
+    makeContext(detected.format, origin),
   )
-  if (inputs !== undefined) {
-    return inputs
-  }
-
-  throw undetectedFormatError(rejections, jsonError)
 }
-
-const dataToBytes = (data: ProfileData): Uint8Array => {
-  if (typeof data === `string`) {
-    return (textEncoder ??= new TextEncoder()).encode(data)
-  }
-  if (ArrayBuffer.isView(data)) {
-    return data
-  }
-  return concatUint8Arrays(data)
-}
-
-let textEncoder: InstanceType<typeof TextEncoder> | undefined
 
 const aggregateInputAsync = async (
   input: ProfileInput<AsyncProfileData>,
@@ -216,23 +165,8 @@ const aggregateInputAsync = async (
   const { data, format, origin } = normalizeProfileInput(input)
 
   if (format) {
-    // The format was specified, so delegate directly to its converter.
-    const converter = specifiedFormatConverter(format)
-    const context = makeContext(format, origin)
-    return converter.type === `json`
-      ? aggregateJsonInput(
-          converter,
-          await JumboJSON.parseAsync(data),
-          options,
-          context,
-        )
-      : aggregateBinaryInputAsync(
-          converter,
-          // Stream the binary data when possible.
-          data instanceof Blob ? data.stream() : data,
-          options,
-          context,
-        )
+    const parsed = await parseAsFormatAsync(formatConverters[format], data)
+    return aggregateParsedInputs(parsed, options, makeContext(format, origin))
   }
 
   // Buffer a `ReadableStream` up front because it might be one-shot, but we
@@ -250,9 +184,10 @@ const aggregateInputAsync = async (
     try {
       json =
         buffered instanceof Blob
-          ? await JumboJSON.parseAsync(buffered)
-          : JumboJSON.parse(buffered)
+          ? await parseJsonAsync(buffered)
+          : parseJson(buffered)
     } catch (error: unknown) {
+      rethrowInputReadFailure(error)
       // Report unusable JSON only for an input that opens a JSON document,
       // because `maybeJson` also admits text starting like a bare JSON value.
       jsonError = (
@@ -264,440 +199,20 @@ const aggregateInputAsync = async (
         : undefined
     }
   }
+
   const rejections: FormatRejection[] = []
-  if (json !== undefined) {
-    const inputs = detectFromJson(json, options, origin, rejections)
-    if (inputs !== undefined) {
-      return inputs
-    }
-  }
-
-  const bytes = buffered instanceof Blob ? await buffered.bytes() : buffered
-  const inputs = detectFromBytes(bytes, options, origin, rejections)
-  if (inputs !== undefined) {
-    return inputs
-  }
-
-  throw undetectedFormatError(rejections, jsonError)
-}
-
-/**
- * The converter for a format the caller specified. Its parses report a
- * rejection as that format's, so the caller receives the reason and the format
- * that rejected the input.
- *
- * Auto-detection uses the registry's converters directly, because it names
- * each rejecting format when it reports the rejections together.
- */
-const specifiedFormatConverter = (format: Format): FormatConverter => {
-  const converter = formatConverters[format]
-  if (converter.type === `json`) {
-    return {
-      ...converter,
-      parse: (json: unknown) =>
-        rejectAsFormat(converter, () => converter.parse(json)),
-    }
-  }
-  return {
-    ...converter,
-    parse: (bytes: Uint8Array) =>
-      rejectAsFormat(converter, () => converter.parse(bytes)),
-    parseAsync: async stream => {
-      try {
-        return await converter.parseAsync(stream)
-      } catch (error: unknown) {
-        throw asFormatRejection(converter, error)
-      }
-    },
-  }
-}
-
-const rejectAsFormat = (
-  converter: FormatConverter,
-  parse: () => ParsedInput[],
-): ParsedInput[] => {
-  try {
-    return parse()
-  } catch (error: unknown) {
-    throw asFormatRejection(converter, error)
-  }
-}
-
-/**
- * Prefixes a {@link FormatParseError} with the format's title. Any other error
- * passes through, because it reports a bug instead of an unusable input.
- */
-const asFormatRejection = (
-  converter: FormatConverter,
-  error: unknown,
-): unknown =>
-  error instanceof FormatParseError
-    ? new ProfilerMdError(`${converter.title}: ${error.message}`, {
-        cause: error,
-      })
-    : error
-
-const detectFromJson = (
-  json: unknown,
-  options: AggregationProfileToMdOptions,
-  origin: Origin | undefined,
-  rejections: FormatRejection[],
-): AggregatedInput[] | undefined => {
-  for (const [format, converter] of jsonFormatConverters) {
-    const parsed = detectWithConverter(
-      converter,
-      () => converter.matches(json),
-      () => converter.parse(json),
+  const detected =
+    (json === undefined ? undefined : detectJsonFormat(json, rejections)) ??
+    detectBinaryFormat(
+      buffered instanceof Blob ? await buffered.bytes() : buffered,
       rejections,
     )
-    if (parsed) {
-      return aggregateParsedInputs(parsed, options, makeContext(format, origin))
-    }
+  if (!detected) {
+    throw toUndetectedFormatError(rejections, jsonError)
   }
-  return undefined
-}
-
-const formatConverterEntries: [Format, FormatConverter][] = formats.map(
-  format => [format, formatConverters[format]],
-)
-
-const jsonFormatConverters: [Format, JsonFormatConverter][] =
-  formatConverterEntries.filter(
-    (entry): entry is [Format, JsonFormatConverter] => entry[1].type === `json`,
+  return aggregateParsedInputs(
+    detected.parsed,
+    options,
+    makeContext(detected.format, origin),
   )
-
-const detectFromBytes = (
-  bytes: Uint8Array,
-  options: AggregationProfileToMdOptions,
-  origin: Origin | undefined,
-  rejections: FormatRejection[],
-): AggregatedInput[] | undefined => {
-  for (const [format, converter] of binaryFormatConverters) {
-    const parsed = detectWithConverter(
-      converter,
-      () => converter.matches(bytes),
-      () => converter.parse(bytes),
-      rejections,
-    )
-    if (parsed) {
-      return aggregateParsedInputs(parsed, options, makeContext(format, origin))
-    }
-  }
-  return undefined
-}
-
-/**
- * A converter that recognized the input, but whose parse rejected it.
- *
- * Detection continues with the next format, and reports the rejections when no
- * format parses the input.
- */
-type FormatRejection = { converter: FormatConverter; error: unknown }
-
-/**
- * Runs a converter's detection and parse, recording a rejection instead of
- * throwing when the converter recognized the input but failed to parse it.
- *
- * A `matches` that throws counts as no match, because it is a cheap prefilter
- * that never validates the input.
- */
-const detectWithConverter = (
-  converter: FormatConverter,
-  matches: () => boolean,
-  parse: () => ParsedInput[],
-  rejections: FormatRejection[],
-): ParsedInput[] | undefined => {
-  try {
-    if (!matches()) {
-      return undefined
-    }
-  } catch {
-    return undefined
-  }
-
-  try {
-    return parse()
-  } catch (error: unknown) {
-    rejections.push({ converter, error })
-    return undefined
-  }
-}
-
-export const aggregateJsonInput = (
-  converter: JsonFormatConverter,
-  json: unknown,
-  options: AggregationProfileToMdOptions,
-  context: UnresolvedProfileToMdContext,
-): AggregatedInput[] =>
-  aggregateParsedInputs(converter.parse(json), options, context)
-
-export const aggregateBinaryInput = (
-  converter: BinaryFormatConverter,
-  bytes: Uint8Array,
-  options: AggregationProfileToMdOptions,
-  context: UnresolvedProfileToMdContext,
-): AggregatedInput[] =>
-  aggregateParsedInputs(converter.parse(bytes), options, context)
-
-export const aggregateBinaryInputAsync = async (
-  converter: BinaryFormatConverter,
-  stream: ReadableStream<Uint8Array>,
-  options: AggregationProfileToMdOptions,
-  context: UnresolvedProfileToMdContext,
-): Promise<AggregatedInput[]> =>
-  aggregateParsedInputs(await converter.parseAsync(stream), options, context)
-
-/**
- * Aggregates each parsed input through its modality's uniform pipeline.
- *
- * The origin is detected once across all inputs.
- */
-const aggregateParsedInputs = (
-  parsed: ParsedInput[],
-  options: AggregationProfileToMdOptions,
-  context: UnresolvedProfileToMdContext,
-): AggregatedInput[] => {
-  const aggregators = parsed.map(input => {
-    switch (input.type) {
-      case `call-stack-profile`:
-        return new CallStackProfileAggregator(input)
-      case `call-graph`:
-        return new CallGraphAggregator(input)
-      case `heap-snapshot`:
-        return new HeapSnapshotAggregator(input)
-    }
-  })
-
-  const detector = new OriginDetector(context)
-  for (const aggregator of aggregators) {
-    aggregator.detectOrigin(detector)
-  }
-
-  const resolvedContext: ProfileToMdContext = {
-    format: context.format,
-    origin: detector.resolve(),
-  }
-  return aggregators.map(aggregator =>
-    aggregator.aggregate(options, resolvedContext),
-  )
-}
-
-/**
- * Builds the conversion context, which carries the resolved format and the
- * explicit origin (or `null` when none was given).
- */
-const makeContext = (
-  format: Format,
-  origin: Origin | undefined,
-): UnresolvedProfileToMdContext => ({ format, origin: origin ?? null })
-
-const binaryFormatConverters: [Format, BinaryFormatConverter][] =
-  formatConverterEntries.filter(
-    (entry): entry is [Format, BinaryFormatConverter] =>
-      entry[1].type === `binary`,
-  )
-
-/**
- * Reports why auto-detection resolved no format.
- *
- * A single rejection is reported as that format's failure, because the input
- * is that format and failed to parse. Several rejections name each format with
- * its reason. No rejection means no format recognized the input.
- */
-const undetectedFormatError = (
-  rejections: readonly FormatRejection[],
-  jsonError: unknown,
-): Error => {
-  const [rejection] = rejections
-  if (rejections.length === 1) {
-    return new FormatDetectError(
-      describeRejection(rejection!),
-      [rejection!.error],
-      { cause: rejection!.error },
-    )
-  }
-
-  if (rejections.length > 1) {
-    return new FormatDetectError(
-      `could not detect the profile format, rejected by: ${rejections
-        .map(rejected => describeRejection(rejected))
-        .join(`, `)}`,
-      rejections.map(({ error }) => error),
-    )
-  }
-
-  if (jsonError !== undefined) {
-    return new FormatDetectError(
-      `could not detect the profile format, the input reads as JSON but failed to parse: ${reasonOf(jsonError)}`,
-      [jsonError],
-      { cause: jsonError },
-    )
-  }
-
-  return new FormatDetectError(
-    `could not detect the profile format, expected one of: ${formats.join(`, `)}`,
-    [],
-  )
-}
-
-/** A rejection as `<title>: <reason>`. */
-const describeRejection = ({ converter, error }: FormatRejection): string =>
-  `${converter.title}: ${reasonOf(error)}`
-
-/** An error's message on one line, for embedding in another message. */
-const reasonOf = (error: unknown): string =>
-  (error instanceof Error ? error.message : String(error))
-    .replaceAll(/\s+/gu, ` `)
-    .trim()
-
-export const formatAggregatedInputs = (
-  inputs: AggregatedInput[],
-  options: NormalizedProfileToMdOptions,
-): string => {
-  const formattingOptions = makeFormattingProfileToMdOptions(options, inputs)
-  const contents = inputs.flatMap(input => {
-    switch (input.type) {
-      case `call-stack-profile`:
-        return formatCallStackProfile(input, formattingOptions)
-      case `call-graph`:
-        return formatCallGraph(input, formattingOptions)
-      case `heap-snapshot`:
-        return formatHeapSnapshot(input, formattingOptions)
-    }
-  })
-  return toMarkdown(contents)
-}
-
-/**
- * Diffs the aggregated {@link base} and {@link current} inputs element by
- * element, returning the differences as Markdown.
- *
- * The two sides must have the same length and the same `type` at each index,
- * otherwise they aren't comparable.
- */
-const formatAggregatedDiff = (
-  base: AggregatedInput[],
-  current: AggregatedInput[],
-  options: NormalizedProfileToMdOptions,
-): string => {
-  if (base.length !== current.length) {
-    throw new ProfilerMdError(
-      `cannot diff inputs containing different numbers of profiles, got: ${base.length} in the base and ${current.length} in the current`,
-    )
-  }
-
-  // Resolve over both sides at once so they share a single inferred base URL
-  // and format consistently.
-  const formattingOptions = makeFormattingProfileToMdOptions(options, [
-    ...base,
-    ...current,
-  ])
-  const contents = base.flatMap((baseInput, index) => {
-    const currentInput = current[index]!
-    if (
-      baseInput.type === `call-stack-profile` &&
-      currentInput.type === `call-stack-profile`
-    ) {
-      return formatCallStackProfileDiff(
-        diffAggregatedCallStackProfiles(
-          baseInput,
-          currentInput,
-          formattingOptions,
-        ),
-        formattingOptions,
-      )
-    }
-    if (baseInput.type === `call-graph` && currentInput.type === `call-graph`) {
-      return formatCallGraphDiff(
-        diffAggregatedCallGraphs(baseInput, currentInput, formattingOptions),
-        formattingOptions,
-      )
-    }
-    if (
-      baseInput.type === `heap-snapshot` &&
-      currentInput.type === `heap-snapshot`
-    ) {
-      return formatHeapSnapshotDiff(
-        diffAggregatedHeapSnapshots(baseInput, currentInput, formattingOptions),
-        formattingOptions,
-      )
-    }
-    throw new ProfilerMdError(
-      `cannot diff a ${modalityName(baseInput.type)} against a ${modalityName(currentInput.type)}`,
-    )
-  })
-  return toMarkdown(contents)
-}
-
-const modalityName = (type: ParsedInput[`type`]): string =>
-  type.replaceAll(`-`, ` `)
-
-const toMarkdown = (contents: RootContent[]): string =>
-  mdastToMarkdown(
-    contents.length > 0 ? contents : [paragraph(`No profiling data found.`)],
-  )
-
-/**
- * Resolves a `baseURL` of `'auto'` to the common ancestor directory of the
- * aggregated {@link inputs}.
- *
- * Any other `baseURL` passes through unchanged.
- */
-const makeFormattingProfileToMdOptions = (
-  options: NormalizedProfileToMdOptions,
-  inputs: AggregatedInput[],
-): FormattingProfileToMdOptions => {
-  const { baseURL } = options
-  return baseURL === `auto`
-    ? {
-        ...options,
-        baseURL: commonAncestorDirectoryURL(
-          collectInferableURLs(inputs, { ...options, baseURL: undefined }),
-        ),
-      }
-    : { ...options, baseURL }
-}
-
-/**
- * Collects the base-URL-inferable absolute URLs of {@link inputs}' entries.
- *
- * Applies source maps first so the base is inferred from the locations
- * formatting will show.
- */
-const collectInferableURLs = (
-  inputs: AggregatedInput[],
-  options: FormattingProfileToMdOptions,
-): URL[] => {
-  const urls: URL[] = []
-  const collect = (location: SourceLocation | undefined) => {
-    if (!location) {
-      return
-    }
-    const mappedLocation = sourceMapSourceLocation(location, options)
-    if (isBaseURLInferableLocation(mappedLocation)) {
-      urls.push(mappedLocation.url)
-    }
-  }
-
-  for (const input of inputs) {
-    switch (input.type) {
-      case `call-stack-profile`:
-      case `call-graph`:
-        for (const func of input.functions) {
-          // Onky `ours`-categorized functions contribute, because a
-          // dependency's install path can be far outside the source tree and
-          // would raise the base to a shared root.
-          if (func.category === `ours`) {
-            collect(func.location)
-          }
-        }
-        break
-      case `heap-snapshot`:
-        for (const entity of [...input.constructors, ...input.functions]) {
-          collect(entityLocation(entity))
-        }
-        break
-    }
-  }
-  return urls
 }

--- a/src/formats/parse.ts
+++ b/src/formats/parse.ts
@@ -1,0 +1,243 @@
+import { JumboJSON } from 'jumbo-json'
+import { reasonOf } from '../error.ts'
+import { concatUint8Arrays } from '../helpers/bytes.ts'
+import type { AsyncProfileData, ProfileData } from '../options.ts'
+import type { FormatConverter, ParsedInput } from './converter.ts'
+import { FormatParseError, FormatRejectionError } from './error.ts'
+
+/**
+ * Parses the input as the format the caller specified, reporting a failure as
+ * that format's rejection, so the caller receives the reason and the format
+ * that rejected the input.
+ *
+ * A failure to read the input is the input's own error, and escapes unwrapped.
+ */
+export const parseAsFormat = (
+  converter: FormatConverter,
+  data: ProfileData,
+): ParsedInput[] => {
+  if (converter.type === `binary`) {
+    const bytes = dataToBytes(data)
+    try {
+      return classifyLazyParseFailures(converter, converter.parse(bytes))
+    } catch (error: unknown) {
+      throw toFormatRejectionError(converter, error)
+    }
+  }
+
+  try {
+    return classifyLazyParseFailures(
+      converter,
+      converter.parse(parseJson(data)),
+    )
+  } catch (error: unknown) {
+    rethrowInputReadFailure(error)
+    throw toFormatRejectionError(converter, error)
+  }
+}
+
+export const parseAsFormatAsync = async (
+  converter: FormatConverter,
+  data: AsyncProfileData,
+): Promise<ParsedInput[]> => {
+  try {
+    return classifyLazyParseFailures(
+      converter,
+      converter.type === `json`
+        ? converter.parse(await parseJsonAsync(data))
+        : // Stream the binary data when possible.
+          await converter.parseAsync(guardStreamReads(dataToStream(data))),
+    )
+  } catch (error: unknown) {
+    rethrowInputReadFailure(error)
+    throw toFormatRejectionError(converter, error)
+  }
+}
+
+/**
+ * Wraps each lazily consumed iterable of the parsed inputs, so an error the
+ * parser throws while aggregation consumes it is classified the same way as
+ * one it throws before returning.
+ *
+ * The wrapper is a plain iterator object, because a delegating generator costs
+ * more per item.
+ */
+export const classifyLazyParseFailures = (
+  converter: FormatConverter,
+  parsed: ParsedInput[],
+): ParsedInput[] => {
+  const toError = (error: unknown): FormatRejectionError =>
+    toFormatRejectionError(converter, error)
+  return parsed.map(input => {
+    switch (input.type) {
+      case `call-stack-profile`:
+        return {
+          ...input,
+          observations: classifyIterableFailures(input.observations, toError),
+          ...(input.lineMetrics && {
+            lineMetrics: classifyIterableFailures(input.lineMetrics, toError),
+          }),
+        }
+      case `call-graph`:
+        return input
+      case `heap-snapshot`:
+        return {
+          ...input,
+          nodes: classifyIterableFailures(input.nodes, toError),
+        }
+    }
+  })
+}
+
+const classifyIterableFailures = <Value>(
+  iterable: Iterable<Value>,
+  toError: (error: unknown) => Error,
+): Iterable<Value> => ({
+  [Symbol.iterator]: () => {
+    const iterator = iterable[Symbol.iterator]()
+    return {
+      next: () => {
+        try {
+          return iterator.next()
+        } catch (error: unknown) {
+          throw toError(error)
+        }
+      },
+      return: value =>
+        iterator.return?.(value) ?? { done: true, value: undefined },
+    }
+  },
+})
+
+/**
+ * Decodes JSON, wrapping a decoding failure in a {@link FormatParseError}.
+ *
+ * A JSON format's parser cannot check anything before decoding succeeds, so a
+ * decoding failure is the input's, however the decoder reports it. A failure to
+ * read the data propagates as an {@link InputReadError} instead.
+ */
+export const parseJson = (
+  data: string | Uint8Array | Iterable<Uint8Array>,
+): unknown => {
+  try {
+    return JumboJSON.parse(
+      // Reading an array cannot fail, and the decoder concatenates one up front
+      // instead of streaming it.
+      typeof data === `string` ||
+        ArrayBuffer.isView(data) ||
+        Array.isArray(data)
+        ? data
+        : guardIterableReads(data),
+    )
+  } catch (error: unknown) {
+    throw toInvalidJsonError(error)
+  }
+}
+
+export const parseJsonAsync = async (
+  data: Blob | ReadableStream<Uint8Array>,
+): Promise<unknown> => {
+  try {
+    return await JumboJSON.parseAsync(guardStreamReads(dataToStream(data)), {
+      sizeHint: data instanceof Blob ? data.size : undefined,
+    })
+  } catch (error: unknown) {
+    throw toInvalidJsonError(error)
+  }
+}
+
+const toInvalidJsonError = (error: unknown): unknown =>
+  error instanceof InputReadError
+    ? error
+    : new FormatParseError(`invalid JSON: ${reasonOf(error)}`, { cause: error })
+
+/**
+ * Thrown in place of an error the caller's data threw while a parser read it,
+ * so a failure to read the data is told apart from a failure to parse it.
+ */
+class InputReadError extends Error {
+  public constructor(cause: unknown) {
+    super(`failed to read the input`, { cause })
+    // eslint-disable-next-line stylistic/quotes
+    this.name = 'InputReadError'
+  }
+}
+
+/** Rethrows the error the caller's data threw, when the error stands in for one. */
+export const rethrowInputReadFailure = (error: unknown): void => {
+  if (error instanceof InputReadError) {
+    throw error.cause
+  }
+}
+
+function* guardIterableReads(
+  iterable: Iterable<Uint8Array>,
+): Iterable<Uint8Array> {
+  try {
+    yield* iterable
+  } catch (error: unknown) {
+    throw new InputReadError(error)
+  }
+}
+
+const guardStreamReads = (
+  stream: ReadableStream<Uint8Array>,
+): ReadableStream<Uint8Array> => {
+  const reader = stream.getReader()
+  return new ReadableStream<Uint8Array>({
+    pull: async controller => {
+      let result
+      try {
+        result = await reader.read()
+      } catch (error: unknown) {
+        throw new InputReadError(error)
+      }
+      if (result.done) {
+        controller.close()
+      } else {
+        controller.enqueue(result.value)
+      }
+    },
+    cancel: reason => reader.cancel(reason),
+  })
+}
+
+const dataToStream = (data: AsyncProfileData): ReadableStream<Uint8Array> =>
+  data instanceof Blob ? data.stream() : data
+
+export const dataToBytes = (data: ProfileData): Uint8Array => {
+  if (typeof data === `string`) {
+    return (textEncoder ??= new TextEncoder()).encode(data)
+  }
+  if (ArrayBuffer.isView(data)) {
+    return data
+  }
+  return concatUint8Arrays(data)
+}
+
+let textEncoder: InstanceType<typeof TextEncoder> | undefined
+
+const toFormatRejectionError = (
+  converter: FormatConverter,
+  error: unknown,
+): FormatRejectionError =>
+  new FormatRejectionError(describeParseFailure(converter, error), {
+    cause: error,
+  })
+
+/**
+ * A parse's failure as `<title>: <reason>`.
+ *
+ * A {@link FormatParseError}'s message states the violation the parser
+ * identified. The parser did not classify any other error, so its reason is
+ * `failed to parse the input: <message>`.
+ */
+export const describeParseFailure = (
+  converter: FormatConverter,
+  error: unknown,
+): string =>
+  `${converter.title}: ${
+    error instanceof FormatParseError
+      ? reasonOf(error)
+      : `failed to parse the input: ${reasonOf(error)}`
+  }`

--- a/src/formats/pprof/index.test.ts
+++ b/src/formats/pprof/index.test.ts
@@ -14,6 +14,7 @@ import {
   profileTitles,
   summaryLines,
 } from '../../testing.ts'
+import { FormatParseError } from '../error.ts'
 import { convertBytesToMd, convertToMdAsync } from '../testing.ts'
 import { pprofConverter } from './index.ts'
 import { makePprof } from './testing.ts'
@@ -67,15 +68,17 @@ describe(`parse and matches`, () => {
   test(`rejects invalid binary data`, () => {
     expect(() =>
       pprofConverter.parse(new Uint8Array([0xff, 0xfe, 0xfd])),
-    ).toThrow()
+    ).toThrow(FormatParseError)
   })
 
-  test(`rejects non-pprof binary`, () => {
+  test(`rejects non-pprof binary as invalid protobuf encoding`, () => {
     const bytes = new TextEncoder().encode(
       JSON.stringify({ nodes: [], timeDeltas: [] }),
     )
 
-    expect(() => pprofConverter.parse(bytes)).toThrow()
+    expect(() => pprofConverter.parse(bytes)).toThrow(
+      /^invalid protobuf encoding: /u,
+    )
   })
 })
 

--- a/src/formats/pprof/parse.ts
+++ b/src/formats/pprof/parse.ts
@@ -1,4 +1,5 @@
 import { Profile as PprofProto } from 'pprof-format'
+import { reasonOf } from '../../error.ts'
 import type {
   CallStackProfile,
   Observation,
@@ -7,9 +8,18 @@ import { countMetricOf } from '../../modalities/metric.ts'
 import type { CountMetric, Metric } from '../../modalities/metric.ts'
 import { parseMetric, SAMPLES } from '../../modalities/metrics.ts'
 import type { StackFrame } from '../../modalities/stack-frame.ts'
+import { FormatParseError } from '../error.ts'
 
 export const parsePprof = (bytes: Uint8Array): CallStackProfile[] => {
-  const profile = PprofProto.decode(bytes)
+  let profile
+  try {
+    profile = PprofProto.decode(bytes)
+  } catch (error) {
+    throw new FormatParseError(
+      `invalid protobuf encoding: ${reasonOf(error)}`,
+      { cause: error },
+    )
+  }
   const string = makeStringReader(profile)
 
   const originHint = pprofOriginHint(profile, string)

--- a/src/formats/systing/index.test.ts
+++ b/src/formats/systing/index.test.ts
@@ -15,6 +15,7 @@ import {
   profileTitles,
   summaryLines,
 } from '../../testing.ts'
+import { FormatParseError } from '../error.ts'
 import { convertBytesToMd, convertToMdAsync } from '../testing.ts'
 import { systingConverter } from './index.ts'
 import { parseSysting } from './parse.ts'
@@ -82,6 +83,28 @@ describe(`matches`, () => {
         makeSysting([], { ...systingHeader, stack_order: `root_first` }),
       ),
     ).toThrow(`root_first`)
+  })
+
+  test.each([
+    {
+      scenario: `a truncated header line`,
+      input: `{"systing_profile_export": 1, "sample_event": "cpu-clock`,
+    },
+    {
+      scenario: `a truncated record line`,
+      input: `${JSON.stringify(systingHeader)}\n["f", 1, "main`,
+    },
+  ])(`parse classifies $scenario as invalid JSON`, ({ input }) => {
+    let thrown
+    try {
+      parseSysting(new TextEncoder().encode(input))
+    } catch (error: unknown) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(FormatParseError)
+    expect((thrown as Error).message).toMatch(/^invalid JSON: /u)
+    expect((thrown as Error).cause).toBeInstanceOf(SyntaxError)
   })
 
   test(`parse rejects records that aren't arrays`, () => {

--- a/src/formats/systing/parse.ts
+++ b/src/formats/systing/parse.ts
@@ -13,6 +13,7 @@ import {
 } from '../../modalities/metrics.ts'
 import type { StackFrame } from '../../modalities/stack-frame.ts'
 import { FormatParseError } from '../error.ts'
+import { parseJson } from '../parse.ts'
 
 export const parseSysting = (bytes: Uint8Array): CallStackProfile[] => {
   const builder = new SystingProfileBuilder()
@@ -162,7 +163,7 @@ class SystingProfileBuilder {
   }
 
   #addRecord(line: string): void {
-    const record: unknown = JSON.parse(line)
+    const record = parseJson(line)
     if (!Array.isArray(record)) {
       throw new FormatParseError(`record is not an array`)
     }
@@ -305,12 +306,7 @@ const cpuMetric = (header: SystingHeader): Metric | undefined => {
  * stack order is unsupported.
  */
 const parseSystingHeader = (line: string): SystingHeader => {
-  let json: unknown
-  try {
-    json = JSON.parse(line)
-  } catch {
-    throw new FormatParseError(`header is not JSON`)
-  }
+  const json = parseJson(line)
   if (typeof json !== `object` || json === null || Array.isArray(json)) {
     throw new FormatParseError(`header is not an object`)
   }

--- a/src/formats/testing.ts
+++ b/src/formats/testing.ts
@@ -3,18 +3,14 @@ import path from 'node:path'
 import { gunzipSync } from 'node:zlib'
 import { inject } from 'vitest'
 import type { NormalizedProfileToMdOptions } from '../options.ts'
+import { aggregateParsedInputs } from './aggregate.ts'
 import type {
   BinaryFormatConverter,
   FormatConverter,
   JsonFormatConverter,
 } from './converter.ts'
-import {
-  aggregateBinaryInput,
-  aggregateBinaryInputAsync,
-  aggregateJsonInput,
-  formatAggregatedInputs,
-  formatConverters,
-} from './index.ts'
+import { formatAggregatedInputs } from './format.ts'
+import { formatConverters } from './index.ts'
 import type { Format } from './index.ts'
 
 declare module 'vitest' {
@@ -81,9 +77,8 @@ export const convertJsonToMd = (
   format?: Format,
 ): string =>
   formatAggregatedInputs(
-    aggregateJsonInput(
-      converter,
-      json,
+    aggregateParsedInputs(
+      converter.parse(json),
       options,
       format ? { format, origin: null } : profileToMdContext(converter),
     ),
@@ -96,9 +91,8 @@ export const convertBytesToMd = (
   options: NormalizedProfileToMdOptions,
 ): string =>
   formatAggregatedInputs(
-    aggregateBinaryInput(
-      converter,
-      bytes,
+    aggregateParsedInputs(
+      converter.parse(bytes),
       options,
       profileToMdContext(converter),
     ),
@@ -115,9 +109,8 @@ export const convertToMdAsync = async (
   options: NormalizedProfileToMdOptions,
 ): Promise<string> =>
   formatAggregatedInputs(
-    await aggregateBinaryInputAsync(
-      converter,
-      stream,
+    aggregateParsedInputs(
+      await converter.parseAsync(stream),
       options,
       profileToMdContext(converter),
     ),

--- a/src/formats/v8/cpu-profile/testing.ts
+++ b/src/formats/v8/cpu-profile/testing.ts
@@ -18,3 +18,27 @@ export const makeV8CpuProfileRoot = (children: number[]): V8CpuProfileNode => ({
   callFrame: makeV8CallFrame(`(root)`, ``),
   children,
 })
+
+/**
+ * A serialized input that passes the format's `matches` prefilter and crashes
+ * its parse on a shape the parser does not check.
+ */
+export const crashingV8CpuProfile = JSON.stringify({
+  nodes: [{ id: 1, callFrame: null }],
+  timeDeltas: [1],
+})
+
+/**
+ * A serialized input that passes the format's `matches` prefilter and parses,
+ * then crashes the observations its parse returns lazily.
+ */
+export const lazilyCrashingV8CpuProfile = JSON.stringify({
+  nodes: [
+    {
+      id: 1,
+      callFrame: makeV8CallFrame(`a`, ``),
+    },
+  ],
+  samples: null,
+  timeDeltas: [1],
+})


### PR DESCRIPTION
A parser that crashed on a shape it does not check threw a plain Error, so the run printed a stack trace. Only the input varies on a parser's code path, so the pipeline now reports any error escaping parse as `<title>: failed to parse the input: <reason>`, the same way under a specified format and auto-detection. The CLI adds a caveat asking for a bug report when the input opens in its profiler, since that is the evidence that separates an unchecked input from a parser bug.

A JSON decoding failure and a protobuf decoding failure were the one rejection a specified format could not prefix with its title, because `JSON.parse` and `pprof-format` threw their own errors. Both are now wrapped in a FormatParseError at the call site, so a specified format reports `invalid JSON` or `invalid protobuf encoding` as its own rejection.