### PR TITLE
fix(cli): clamp the help width to what the terminal reports

### DIFF
--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import { getHelpText } from './cli.ts'
+
+const stdoutColumns = Object.getOwnPropertyDescriptor(process.stdout, `columns`)
+
+const setStdoutColumns = (columns: number | undefined): void => {
+  Object.defineProperty(process.stdout, `columns`, {
+    value: columns,
+    configurable: true,
+    writable: true,
+  })
+}
+
+beforeEach(() => {
+  vi.stubEnv(`COLUMNS`, undefined)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  if (stdoutColumns) {
+    Object.defineProperty(process.stdout, `columns`, stdoutColumns)
+  } else {
+    delete (process.stdout as { columns?: number }).columns
+  }
+})
+
+test(`getHelpText wraps to 80 columns when the terminal reports zero`, () => {
+  setStdoutColumns(80)
+  const expected = getHelpText()
+
+  setStdoutColumns(0)
+
+  expect(getHelpText()).toBe(expected)
+})
+
+test(`getHelpText wraps to COLUMNS when stdout is not a terminal`, () => {
+  setStdoutColumns(60)
+  const expected = getHelpText()
+
+  setStdoutColumns(undefined)
+  vi.stubEnv(`COLUMNS`, `60`)
+
+  expect(getHelpText()).toBe(expected)
+})
+
+test(`getHelpText wraps to a minimum width on a narrower terminal`, () => {
+  setStdoutColumns(10)
+
+  expect(getHelpText()).toMatch(/^Usage: /u)
+})

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -296,8 +296,7 @@ export const getHelpText = (): string => {
   return `${[
     formatDocPage(program.metadata.name, docPage, {
       termWidth,
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      maxWidth: process.stdout.columns ?? 80,
+      maxWidth: getMaxWidth(),
     }),
     `Formats: ${formats.join(`, `)}`,
     `Origins: ${origins.join(`, `)}`,
@@ -316,8 +315,7 @@ export type CLIArgs = InferValue<typeof program.parser>
 export const parseArgs = (): CLIArgs =>
   runParser(parser, program.metadata.name, process.argv.slice(2), {
     colors: false,
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    maxWidth: process.stdout.columns ?? 80,
+    maxWidth: getMaxWidth(),
     version: {
       value: packageJson.version,
       option: true,
@@ -334,3 +332,13 @@ export const parseArgs = (): CLIArgs =>
     },
     onError: () => process.exit(2),
   })
+
+const getMaxWidth = (): number =>
+  Math.max(
+    MIN_WIDTH,
+    // A terminal with no window size reports zero columns
+    process.stdout.columns || Number(process.env.COLUMNS) || 80,
+  )
+
+// Optique throws below the width its narrowest layout requires
+const MIN_WIDTH = 40


### PR DESCRIPTION
The help and usage text wrapped to `process.stdout.columns ?? 80`. A terminal with no window size reports zero columns, which is not nullish, so the text wrapped at width zero. When stdout is not a terminal, `columns` is undefined and the `COLUMNS` variable was ignored. On a terminal narrower than Optique's narrowest layout, Optique threw instead of printing help.

The width now falls back from a zero or undefined `columns` to `COLUMNS`, then to 80, and never drops below 40.