### PR TITLE
fix: reject invalid options with a stated reason

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -176,7 +176,7 @@ const parser = object({
     `-`,
   ),
   topN: optional(
-    option(`--top-n`, integer({ metavar: `N` }), {
+    option(`--top-n`, integer({ metavar: `N`, min: 0 }), {
       description: message`Entries to show per ranking, including category subsections (default: 20)`,
     }),
   ),

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -673,6 +673,12 @@ if (format === undefined) {
       expectedStatus: 1,
     },
     {
+      scenario: `a negative --top-n`,
+      args: [inputPath(`javascript.node.base.cpuprofile`), `--top-n`, `-1`],
+      expectedStderr: `greater than or equal to 0`,
+      expectedStatus: 2,
+    },
+    {
       scenario: `--match-location without an equals sign`,
       args: [
         inputPath(`javascript.node.base.cpuprofile`),

--- a/src/options.test.ts
+++ b/src/options.test.ts
@@ -52,9 +52,18 @@ describe(`normalizeProfileToMdOptions`, () => {
     expect(normalizeProfileToMdOptions().topN).toBe(20)
   })
 
-  test(`keeps an explicit topN`, () => {
-    expect(normalizeProfileToMdOptions({ topN: 5 }).topN).toBe(5)
+  test.each([0, 5])(`keeps an explicit topN of %s`, topN => {
+    expect(normalizeProfileToMdOptions({ topN }).topN).toBe(topN)
   })
+
+  test.each([-1, 2.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    `throws for a topN of %s`,
+    topN => {
+      expect(() => normalizeProfileToMdOptions({ topN })).toThrow(
+        `topN must be a non-negative integer, got: ${topN}`,
+      )
+    },
+  )
 
   describe(`minCategoryShare`, () => {
     test(`defaults to 0.01`, () => {

--- a/src/options.ts
+++ b/src/options.ts
@@ -335,7 +335,7 @@ export const normalizeProfileToMdOptions = ({
   categorizeFunctions = defaultCategorizeFunctions,
   showEntry = defaultShowEntry,
 }: ProfileToMdOptions = {}): NormalizedProfileToMdOptions => ({
-  topN,
+  topN: normalizeTopN(topN),
   minCategoryShare: normalizeMinCategoryShare(minCategoryShare),
   baseURL: normalizeBaseURL(baseURL),
   sourceMaps: normalizeSourceMaps(sourceMaps),
@@ -354,6 +354,15 @@ export const normalizeProfileToMdOptions = ({
   },
   showEntry: cacheEntryFunction(showEntry),
 })
+
+const normalizeTopN = (topN: number): number => {
+  if (!(Number.isSafeInteger(topN) && topN >= 0)) {
+    throw new ProfilerMdError(
+      `topN must be a non-negative integer, got: ${topN}`,
+    )
+  }
+  return topN
+}
 
 const normalizeMinCategoryShare = (minCategoryShare: number): number => {
   if (!(minCategoryShare >= 0 && minCategoryShare <= 1)) {

--- a/src/source-map.test.ts
+++ b/src/source-map.test.ts
@@ -39,6 +39,14 @@ test(`normalizeSourceMaps drops entries with an unknown file field`, () => {
   expect(sourceMaps).toHaveLength(0)
 })
 
+test(`normalizeSourceMaps throws for an invalid source map`, () => {
+  expect(() =>
+    normalizeSourceMaps([makeSourceMap({ file: `/app.js`, version: `2` })]),
+  ).toThrow(
+    `sourceMaps entry for /app.js is an invalid source map: Unsupported version: 2`,
+  )
+})
+
 test(`normalizeSourceMaps infers absolute location from absolute file path`, () => {
   const sourceMaps = normalizeSourceMaps([
     makeSourceMap({

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -1,5 +1,6 @@
 import { SourceMapConsumer } from 'source-map-js'
 import type { MappedPosition, RawSourceMap as SourceMap } from 'source-map-js'
+import { ProfilerMdError } from './error.ts'
 import { makeFileReference } from './location.ts'
 import type { FileReference, SourceLocation } from './location.ts'
 import type { FormattingProfileToMdOptions } from './options.ts'
@@ -27,7 +28,18 @@ export const normalizeSourceMaps = (
     if (!fileReference) {
       return []
     }
-    return { consumer: new SourceMapConsumer(sourceMap), fileReference }
+    let consumer: SourceMapConsumer
+    try {
+      consumer = new SourceMapConsumer(sourceMap)
+    } catch (error) {
+      throw new ProfilerMdError(
+        `sourceMaps entry for ${urlOrPath} is an invalid source map: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      )
+    }
+    return { consumer, fileReference }
   })
 }
 


### PR DESCRIPTION
A negative or fractional topN reached the ranking code, where a negative length threw a RangeError naming no option and a fraction was silently truncated. A categorizeFunctions callback returning a category outside the closed set flowed into the output unchecked, and an invalid --source-maps entry threw source-map-js's own error with no file to point at.

Option normalization now rejects a topN that is not a non-negative safe integer, rejects an unknown category with its index, and wraps a source map the consumer refuses in a ProfilerMdError stating the file and reason. The CLI's --top-n parser sets a minimum of 0 so the flag reports the same constraint before the conversion starts.