### PR TITLE
fix(cli): check the --output path before converting the input

### DIFF
--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -226,6 +226,27 @@ if (format === undefined) {
     await rm(dir, { recursive: true })
   })
 
+  test.concurrent(
+    `checks the --output path before converting the input`,
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), `profiler-md-`))
+      const outputPath = join(dir, `nonexistent`, `out.md`)
+
+      const { status, stdout, stderr } = await runCli(
+        [`--output`, outputPath],
+        `not a profile`,
+      )
+
+      expect(status).toBe(1)
+      expect(stdout).toBe(``)
+      expect(stderr).toBe(
+        `error: cannot write ${outputPath}: no such directory\n`,
+      )
+
+      await rm(dir, { recursive: true })
+    },
+  )
+
   // Root reads a file regardless of its mode.
   test
     .skipIf(process.getuid?.() === 0)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,7 +6,7 @@ import { printHelpTopic } from './help.ts'
 import { highlightMarkdown } from './highlight.ts'
 import { openInputAsBlob } from './input.ts'
 import { buildOptions } from './options.ts'
-import { writeOutput } from './output.ts'
+import { checkOutputPath, writeOutput } from './output.ts'
 
 try {
   const {
@@ -40,6 +40,8 @@ try {
   if (basePath === undefined && process.stdin.isTTY) {
     await printHelpTopic(undefined, { pager })
   }
+
+  await checkOutputPath(outputPath)
 
   const toInput = <Data>(data: Data): ProfileInput<Data> =>
     format || origin ? { data, format, origin } : data

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,4 +1,6 @@
 import { createWriteStream } from 'node:fs'
+import { access, constants, stat } from 'node:fs/promises'
+import { dirname } from 'node:path'
 import { CliError, reasonOf } from './error.ts'
 import { openPager } from './pager.ts'
 
@@ -23,6 +25,37 @@ export const writeOutput = async (
 
 export const isTTYOutput = (outputPath: string): boolean =>
   outputPath === `-` && Boolean(process.stdout.isTTY)
+
+/**
+ * Rejects an output path that cannot be written.
+ *
+ * A path must be a writable file, or absent from a writable directory. The
+ * check creates no file.
+ */
+export const checkOutputPath = async (outputPath: string): Promise<void> => {
+  if (outputPath === `-`) {
+    return
+  }
+
+  let isDirectory
+  try {
+    isDirectory = (await stat(outputPath)).isDirectory()
+    await access(outputPath, constants.W_OK)
+  } catch (error) {
+    if (errorCodeOf(error) !== `ENOENT`) {
+      throw writeError(outputPath, error)
+    }
+    try {
+      await access(dirname(outputPath), constants.W_OK)
+    } catch (directoryError) {
+      throw writeError(outputPath, directoryError)
+    }
+    return
+  }
+  if (isDirectory) {
+    throw new CliError(`cannot write ${outputPath}: is a directory`, 1)
+  }
+}
 
 const openOutput = async (outputPath: string): Promise<Output> => {
   if (outputPath === `-`) {
@@ -76,6 +109,7 @@ const errorCodeOf = (error: unknown): string | undefined =>
 
 const WRITE_ERROR_REASONS: ReadonlyMap<string | undefined, string> = new Map([
   [`ENOENT`, `no such directory`],
+  [`ENOTDIR`, `no such directory`],
   [`EISDIR`, `is a directory`],
   [`EACCES`, `permission denied`],
   [`EPERM`, `permission denied`],


### PR DESCRIPTION
A missing directory, a directory path, or an unwritable file given to --output failed only at the write, after the whole conversion had run. On a large profile that was a long wait for an error the CLI could have reported at startup.

The CLI now checks the path first: a file must be writable, or absent from a writable directory. The check creates nothing, so a conversion that fails leaves no empty output file behind. A path with a file where a directory is expected (ENOTDIR) reports as a missing directory, like ENOENT.