### PR TITLE
refactor: share one reasonOf between the CLI and the pipeline

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -11,6 +11,7 @@ import { choice, float, integer, string } from '@optique/core/valueparser'
 import type { ValueParser } from '@optique/core/valueparser'
 import { path } from '@optique/run'
 import packageJson from '../../package.json' with { type: 'json' }
+import { reasonOf } from '../error.ts'
 import { formats } from '../formats/index.ts'
 import { HEAP_SNAPSHOT_NODE_CATEGORIES } from '../modalities/heap-snapshot/type.ts'
 import type { HeapSnapshotNodeCategory } from '../modalities/heap-snapshot/type.ts'
@@ -53,9 +54,7 @@ const parseRegex = (
   } catch (error) {
     return {
       success: false,
-      error: message`expected a valid regex, got: ${value(pattern)} (${text(
-        error instanceof Error ? error.message : String(error),
-      )})`,
+      error: message`expected a valid regex, got: ${value(pattern)} (${text(reasonOf(error))})`,
     }
   }
 }

--- a/src/cli/error.ts
+++ b/src/cli/error.ts
@@ -27,6 +27,3 @@ export const reportError = (error: unknown): never => {
   process.stderr.write(`error: ${String(error)}\n`)
   process.exit(1)
 }
-
-export const reasonOf = (error: unknown): string =>
-  error instanceof Error ? error.message : String(error)

--- a/src/cli/input.ts
+++ b/src/cli/input.ts
@@ -4,7 +4,8 @@ import type { Transform } from 'node:stream'
 import { blob } from 'node:stream/consumers'
 import { pipeline } from 'node:stream/promises'
 import { createBrotliDecompress, createGunzip } from 'node:zlib'
-import { CliError, reasonOf } from './error.ts'
+import { reasonOf } from '../error.ts'
+import { CliError } from './error.ts'
 
 export const openInputAsBlob = async (
   filePath: string | undefined,

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -2,6 +2,7 @@ import { glob, readFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import convertSourceMap from 'convert-source-map'
+import { reasonOf } from '../error.ts'
 import type { DeepReadonly } from '../helpers/types.ts'
 import {
   defaultCategorizeFunctions,
@@ -15,7 +16,7 @@ import {
   sourceReferencePathOrName,
 } from '../location.ts'
 import type { EntryCategory, RegexCategory, RegexReplacement } from './cli.ts'
-import { CliError, reasonOf } from './error.ts'
+import { CliError } from './error.ts'
 
 /**
  * Every flag the options are built from, each required so that a flag added to

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,7 +1,8 @@
 import { createWriteStream } from 'node:fs'
 import { access, constants, stat } from 'node:fs/promises'
 import { dirname } from 'node:path'
-import { CliError, reasonOf } from './error.ts'
+import { reasonOf } from '../error.ts'
+import { CliError } from './error.ts'
 import { openPager } from './pager.ts'
 
 export type Output = {

--- a/src/error.ts
+++ b/src/error.ts
@@ -12,3 +12,9 @@ export class ProfilerMdError extends Error {
     this.name = 'ProfilerMdError'
   }
 }
+
+/** An error's message on one line, for embedding in another message. */
+export const reasonOf = (error: unknown): string =>
+  (error instanceof Error ? error.message : String(error))
+    .replaceAll(/\s+/gu, ` `)
+    .trim()

--- a/src/formats/index.ts
+++ b/src/formats/index.ts
@@ -1,6 +1,6 @@
 import { JumboJSON } from 'jumbo-json'
 import type { RootContent } from 'mdast'
-import { ProfilerMdError } from '../error.ts'
+import { ProfilerMdError, reasonOf } from '../error.ts'
 import { concatUint8Arrays, streamToUint8Array } from '../helpers/bytes.ts'
 import {
   maybeJson,
@@ -543,12 +543,6 @@ const undetectedFormatError = (
 /** A rejection as `<title>: <reason>`. */
 const describeRejection = ({ converter, error }: FormatRejection): string =>
   `${converter.title}: ${reasonOf(error)}`
-
-/** An error's message on one line, for embedding in another message. */
-const reasonOf = (error: unknown): string =>
-  (error instanceof Error ? error.message : String(error))
-    .replaceAll(/\s+/gu, ` `)
-    .trim()
 
 export const formatAggregatedInputs = (
   inputs: AggregatedInput[],

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -1,6 +1,6 @@
 import { SourceMapConsumer } from 'source-map-js'
 import type { MappedPosition, RawSourceMap as SourceMap } from 'source-map-js'
-import { ProfilerMdError } from './error.ts'
+import { ProfilerMdError, reasonOf } from './error.ts'
 import { makeFileReference } from './location.ts'
 import type { FileReference, SourceLocation } from './location.ts'
 import type { FormattingProfileToMdOptions } from './options.ts'
@@ -33,9 +33,9 @@ export const normalizeSourceMaps = (
       consumer = new SourceMapConsumer(sourceMap)
     } catch (error) {
       throw new ProfilerMdError(
-        `sourceMaps entry for ${urlOrPath} is an invalid source map: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `sourceMaps entry for ${urlOrPath} is an invalid source map: ${reasonOf(
+          error,
+        )}`,
         { cause: error },
       )
     }


### PR DESCRIPTION
The CLI and the conversion pipeline each had a private copy of the helper that flattens a caught error to its message, and the CLI's copy kept the message's line breaks. Both now use the one in src/error.ts, which collapses the whitespace so the message fits on one line of another message.