### PR TITLE
refactor: split the conversion pipeline by stage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,12 @@ profiler-md
 │   ├── formats/                  # Individual profile format implementations
 │   │   ├── converter.ts          # Format converter types
 │   │   ├── registry.ts           # Format converter registry
-│   │   ├── index.ts              # profileToMd(Async)/diffProfiles(Async) and format auto-detection
+│   │   ├── error.ts              # Parse and detection error classes
+│   │   ├── parse.ts              # Specified-format parse wrappers that report a rejection as the format's
+│   │   ├── detect.ts             # Format auto-detection and its undetected-format error
+│   │   ├── aggregate.ts          # Parsed input to aggregated input dispatch across modalities, with origin detection
+│   │   ├── format.ts             # Aggregated input and diff to Markdown dispatch across modalities
+│   │   ├── index.ts              # profileToMd(Async)/diffProfiles(Async): buffers the input, then parses or detects, aggregates, and formats
 │   │   ├── **/<name>/            # One per format, top-level (e.g. collapsed) or nested in a subdirectory (e.g. v8/cpu-profile)
 │   │   │   ├── matches.ts        # Cheap auto-detection check for the format
 │   │   │   ├── parse.ts          # Parses input into a modality's parsed type

--- a/src/formats/aggregate.ts
+++ b/src/formats/aggregate.ts
@@ -1,0 +1,56 @@
+import { CallGraphAggregator } from '../modalities/call-graph/index.ts'
+import { CallStackProfileAggregator } from '../modalities/call-stack-profile/index.ts'
+import { HeapSnapshotAggregator } from '../modalities/heap-snapshot/aggregate.ts'
+import type {
+  AggregationProfileToMdOptions,
+  ProfileToMdContext,
+  UnresolvedProfileToMdContext,
+} from '../options.ts'
+import { OriginDetector } from '../origins/index.ts'
+import type { Origin } from '../origins/index.ts'
+import type { AggregatedInput, ParsedInput } from './converter.ts'
+import type { Format } from './registry.ts'
+
+/**
+ * Aggregates each parsed input through its modality's uniform pipeline.
+ *
+ * The origin is detected once across all inputs.
+ */
+export const aggregateParsedInputs = (
+  parsed: ParsedInput[],
+  options: AggregationProfileToMdOptions,
+  context: UnresolvedProfileToMdContext,
+): AggregatedInput[] => {
+  const aggregators = parsed.map(input => {
+    switch (input.type) {
+      case `call-stack-profile`:
+        return new CallStackProfileAggregator(input)
+      case `call-graph`:
+        return new CallGraphAggregator(input)
+      case `heap-snapshot`:
+        return new HeapSnapshotAggregator(input)
+    }
+  })
+
+  const detector = new OriginDetector(context)
+  for (const aggregator of aggregators) {
+    aggregator.detectOrigin(detector)
+  }
+
+  const resolvedContext: ProfileToMdContext = {
+    format: context.format,
+    origin: detector.resolve(),
+  }
+  return aggregators.map(aggregator =>
+    aggregator.aggregate(options, resolvedContext),
+  )
+}
+
+/**
+ * Builds the conversion context, which contains the resolved format and the
+ * explicit origin (or `null` when none was given).
+ */
+export const makeContext = (
+  format: Format,
+  origin: Origin | undefined,
+): UnresolvedProfileToMdContext => ({ format, origin: origin ?? null })

--- a/src/formats/converter.ts
+++ b/src/formats/converter.ts
@@ -52,7 +52,7 @@ type FormatMeta = {
  * A cheap {@link Detect.matches} may be a loose prefilter because `parse` is
  * the real check.
  */
-type Parse<Input> = {
+export type Parse<Input> = {
   parse: (input: Input) => ParsedInput[]
 }
 
@@ -68,7 +68,7 @@ type Parse<Input> = {
  * keep ambiguous input (e.g. text a user could force) from being auto-detected
  * as this format.
  */
-type Detect<Input> = {
+export type Detect<Input> = {
   matches: (input: Input) => boolean
 }
 

--- a/src/formats/detect.ts
+++ b/src/formats/detect.ts
@@ -1,0 +1,136 @@
+import { reasonOf } from '../error.ts'
+import type {
+  BinaryFormatConverter,
+  Detect,
+  FormatConverter,
+  JsonFormatConverter,
+  Parse,
+  ParsedInput,
+} from './converter.ts'
+import { FormatDetectError } from './error.ts'
+import { describeParseFailure } from './parse.ts'
+import { formatConverters, formats } from './registry.ts'
+import type { Format } from './registry.ts'
+
+/** An input a format recognized and parsed during auto-detection. */
+export type DetectedInput = { format: Format; parsed: ParsedInput[] }
+
+/**
+ * A converter that recognized the input, but whose parse rejected it.
+ *
+ * Detection continues with the next format, and reports the rejections when no
+ * format parses the input.
+ */
+export type FormatRejection = { converter: FormatConverter; error: unknown }
+
+export const detectJsonFormat = (
+  json: unknown,
+  rejections: FormatRejection[],
+): DetectedInput | undefined => {
+  for (const [format, converter] of jsonFormatConverters) {
+    const parsed = detectWithConverter(converter, json, rejections)
+    if (parsed) {
+      return { format, parsed }
+    }
+  }
+  return undefined
+}
+
+export const detectBinaryFormat = (
+  bytes: Uint8Array,
+  rejections: FormatRejection[],
+): DetectedInput | undefined => {
+  for (const [format, converter] of binaryFormatConverters) {
+    const parsed = detectWithConverter(converter, bytes, rejections)
+    if (parsed) {
+      return { format, parsed }
+    }
+  }
+  return undefined
+}
+
+const formatConverterEntries: [Format, FormatConverter][] = formats.map(
+  format => [format, formatConverters[format]],
+)
+
+const jsonFormatConverters: [Format, JsonFormatConverter][] =
+  formatConverterEntries.filter(
+    (entry): entry is [Format, JsonFormatConverter] => entry[1].type === `json`,
+  )
+
+const binaryFormatConverters: [Format, BinaryFormatConverter][] =
+  formatConverterEntries.filter(
+    (entry): entry is [Format, BinaryFormatConverter] =>
+      entry[1].type === `binary`,
+  )
+
+/**
+ * Runs a converter's detection and parse, recording a rejection instead of
+ * throwing when the converter recognized the input but failed to parse it.
+ *
+ * A `matches` that throws counts as no match, because it is a cheap prefilter
+ * that never validates the input.
+ */
+const detectWithConverter = <Input>(
+  converter: FormatConverter & Detect<Input> & Parse<Input>,
+  input: Input,
+  rejections: FormatRejection[],
+): ParsedInput[] | undefined => {
+  try {
+    if (!converter.matches(input)) {
+      return undefined
+    }
+  } catch {
+    return undefined
+  }
+
+  try {
+    return converter.parse(input)
+  } catch (error: unknown) {
+    rejections.push({ converter, error })
+    return undefined
+  }
+}
+
+/**
+ * Reports why auto-detection resolved no format.
+ *
+ * A single rejection is reported as that format's failure, because the input
+ * is that format and failed to parse. Several rejections name each format with
+ * its reason. No rejection means no format recognized the input.
+ */
+export const toUndetectedFormatError = (
+  rejections: readonly FormatRejection[],
+  jsonError: unknown,
+): FormatDetectError => {
+  const [rejection] = rejections
+  if (rejections.length === 1) {
+    return new FormatDetectError(
+      describeParseFailure(rejection!.converter, rejection!.error),
+      [rejection!.error],
+      { cause: rejection!.error },
+    )
+  }
+
+  if (rejections.length > 1) {
+    return new FormatDetectError(
+      `could not detect the profile format, rejected by: ${rejections
+        .map(({ converter, error }) => describeParseFailure(converter, error))
+        .join(`, `)}`,
+      rejections.map(({ error }) => error),
+    )
+  }
+
+  if (jsonError !== undefined) {
+    return new FormatDetectError(
+      `could not detect the profile format, the input reads as JSON but failed to parse: ${reasonOf(jsonError)}`,
+      [jsonError],
+      { cause: jsonError },
+    )
+  }
+
+  return new FormatDetectError(
+    `could not detect the profile format, expected one of: ${formats.join(`, `)}`,
+    [],
+  )
+}

--- a/src/formats/format.ts
+++ b/src/formats/format.ts
@@ -1,0 +1,182 @@
+import type { RootContent } from 'mdast'
+import { ProfilerMdError } from '../error.ts'
+import { mdastToMarkdown, paragraph } from '../helpers/markdown.ts'
+import {
+  commonAncestorDirectoryURL,
+  isBaseURLInferableLocation,
+} from '../location.ts'
+import type { SourceLocation } from '../location.ts'
+import {
+  diffAggregatedCallGraphs,
+  formatCallGraph,
+  formatCallGraphDiff,
+} from '../modalities/call-graph/index.ts'
+import { diffAggregatedCallStackProfiles } from '../modalities/call-stack-profile/diff.ts'
+import {
+  formatCallStackProfile,
+  formatCallStackProfileDiff,
+} from '../modalities/call-stack-profile/format.ts'
+import { entityLocation } from '../modalities/heap-snapshot/aggregate.ts'
+import { diffAggregatedHeapSnapshots } from '../modalities/heap-snapshot/diff.ts'
+import {
+  formatHeapSnapshot,
+  formatHeapSnapshotDiff,
+} from '../modalities/heap-snapshot/format.ts'
+import type {
+  FormattingProfileToMdOptions,
+  NormalizedProfileToMdOptions,
+} from '../options.ts'
+import { sourceMapSourceLocation } from '../source-map.ts'
+import type { AggregatedInput, ParsedInput } from './converter.ts'
+
+export const formatAggregatedInputs = (
+  inputs: AggregatedInput[],
+  options: NormalizedProfileToMdOptions,
+): string => {
+  const formattingOptions = makeFormattingProfileToMdOptions(options, inputs)
+  const contents = inputs.flatMap(input => {
+    switch (input.type) {
+      case `call-stack-profile`:
+        return formatCallStackProfile(input, formattingOptions)
+      case `call-graph`:
+        return formatCallGraph(input, formattingOptions)
+      case `heap-snapshot`:
+        return formatHeapSnapshot(input, formattingOptions)
+    }
+  })
+  return toMarkdown(contents)
+}
+
+/**
+ * Diffs the aggregated {@link base} and {@link current} inputs element by
+ * element, returning the differences as Markdown.
+ *
+ * The two sides must have the same length and the same `type` at each index,
+ * otherwise they aren't comparable.
+ */
+export const formatAggregatedDiff = (
+  base: AggregatedInput[],
+  current: AggregatedInput[],
+  options: NormalizedProfileToMdOptions,
+): string => {
+  if (base.length !== current.length) {
+    throw new ProfilerMdError(
+      `cannot diff inputs containing different numbers of profiles, got: ${base.length} in the base and ${current.length} in the current`,
+    )
+  }
+
+  // Resolve over both sides at once so they share a single inferred base URL
+  // and format consistently.
+  const formattingOptions = makeFormattingProfileToMdOptions(options, [
+    ...base,
+    ...current,
+  ])
+  const contents = base.flatMap((baseInput, index) => {
+    const currentInput = current[index]!
+    if (
+      baseInput.type === `call-stack-profile` &&
+      currentInput.type === `call-stack-profile`
+    ) {
+      return formatCallStackProfileDiff(
+        diffAggregatedCallStackProfiles(
+          baseInput,
+          currentInput,
+          formattingOptions,
+        ),
+        formattingOptions,
+      )
+    }
+    if (baseInput.type === `call-graph` && currentInput.type === `call-graph`) {
+      return formatCallGraphDiff(
+        diffAggregatedCallGraphs(baseInput, currentInput, formattingOptions),
+        formattingOptions,
+      )
+    }
+    if (
+      baseInput.type === `heap-snapshot` &&
+      currentInput.type === `heap-snapshot`
+    ) {
+      return formatHeapSnapshotDiff(
+        diffAggregatedHeapSnapshots(baseInput, currentInput, formattingOptions),
+        formattingOptions,
+      )
+    }
+    throw new ProfilerMdError(
+      `cannot diff a ${modalityName(baseInput.type)} against a ${modalityName(currentInput.type)}`,
+    )
+  })
+  return toMarkdown(contents)
+}
+
+const modalityName = (type: ParsedInput[`type`]): string =>
+  type.replaceAll(`-`, ` `)
+
+const toMarkdown = (contents: RootContent[]): string =>
+  mdastToMarkdown(
+    contents.length > 0 ? contents : [paragraph(`No profiling data found.`)],
+  )
+
+/**
+ * Resolves a `baseURL` of `'auto'` to the common ancestor directory of the
+ * aggregated {@link inputs}.
+ *
+ * Any other `baseURL` passes through unchanged.
+ */
+const makeFormattingProfileToMdOptions = (
+  options: NormalizedProfileToMdOptions,
+  inputs: AggregatedInput[],
+): FormattingProfileToMdOptions => {
+  const { baseURL } = options
+  return baseURL === `auto`
+    ? {
+        ...options,
+        baseURL: commonAncestorDirectoryURL(
+          collectInferableURLs(inputs, { ...options, baseURL: undefined }),
+        ),
+      }
+    : { ...options, baseURL }
+}
+
+/**
+ * Collects the base-URL-inferable absolute URLs of {@link inputs}' entries.
+ *
+ * Applies source maps first so the base is inferred from the locations
+ * formatting will show.
+ */
+const collectInferableURLs = (
+  inputs: AggregatedInput[],
+  options: FormattingProfileToMdOptions,
+): URL[] => {
+  const urls: URL[] = []
+  const collect = (location: SourceLocation | undefined) => {
+    if (!location) {
+      return
+    }
+    const mappedLocation = sourceMapSourceLocation(location, options)
+    if (isBaseURLInferableLocation(mappedLocation)) {
+      urls.push(mappedLocation.url)
+    }
+  }
+
+  for (const input of inputs) {
+    switch (input.type) {
+      case `call-stack-profile`:
+      case `call-graph`:
+        for (const func of input.functions) {
+          // Only `ours`-categorized functions contribute, because a
+          // dependency's install path can be far outside the source tree and
+          // would raise the base to a shared root.
+          if (func.category === `ours`) {
+            collect(func.location)
+          }
+        }
+        break
+      case `heap-snapshot`:
+        for (const entity of [...input.constructors, ...input.functions]) {
+          collect(entityLocation(entity))
+        }
+        break
+    }
+  }
+  return urls
+}

--- a/src/formats/index.ts
+++ b/src/formats/index.ts
@@ -1,6 +1,4 @@
 import { JumboJSON } from 'jumbo-json'
-import type { RootContent } from 'mdast'
-import { ProfilerMdError, reasonOf } from '../error.ts'
 import { concatUint8Arrays, streamToUint8Array } from '../helpers/bytes.ts'
 import {
   maybeJson,
@@ -8,61 +6,28 @@ import {
   startsJsonDocument,
   startsJsonDocumentAsync,
 } from '../helpers/json.ts'
-import { mdastToMarkdown, paragraph } from '../helpers/markdown.ts'
-import {
-  commonAncestorDirectoryURL,
-  isBaseURLInferableLocation,
-} from '../location.ts'
-import type { SourceLocation } from '../location.ts'
-import {
-  CallGraphAggregator,
-  diffAggregatedCallGraphs,
-  formatCallGraph,
-  formatCallGraphDiff,
-} from '../modalities/call-graph/index.ts'
-import { diffAggregatedCallStackProfiles } from '../modalities/call-stack-profile/diff.ts'
-import {
-  formatCallStackProfile,
-  formatCallStackProfileDiff,
-} from '../modalities/call-stack-profile/format.ts'
-import { CallStackProfileAggregator } from '../modalities/call-stack-profile/index.ts'
-import {
-  entityLocation,
-  HeapSnapshotAggregator,
-} from '../modalities/heap-snapshot/aggregate.ts'
-import { diffAggregatedHeapSnapshots } from '../modalities/heap-snapshot/diff.ts'
-import {
-  formatHeapSnapshot,
-  formatHeapSnapshotDiff,
-} from '../modalities/heap-snapshot/format.ts'
 import type {
   AggregationProfileToMdOptions,
   AsyncProfileData,
-  FormattingProfileToMdOptions,
-  NormalizedProfileToMdOptions,
   ProfileData,
   ProfileInput,
-  ProfileToMdContext,
   ProfileToMdOptions,
-  UnresolvedProfileToMdContext,
 } from '../options.ts'
 import {
   normalizeProfileInput,
   normalizeProfileToMdOptions,
 } from '../options.ts'
-import { OriginDetector } from '../origins/index.ts'
-import type { Origin } from '../origins/index.ts'
-import { sourceMapSourceLocation } from '../source-map.ts'
-import type {
-  AggregatedInput,
-  BinaryFormatConverter,
-  FormatConverter,
-  JsonFormatConverter,
-  ParsedInput,
-} from './converter.ts'
-import { FormatDetectError, FormatParseError } from './error.ts'
-import { formatConverters, formats } from './registry.ts'
-import type { Format } from './registry.ts'
+import { aggregateParsedInputs, makeContext } from './aggregate.ts'
+import type { AggregatedInput } from './converter.ts'
+import {
+  detectBinaryFormat,
+  detectJsonFormat,
+  toUndetectedFormatError,
+} from './detect.ts'
+import type { FormatRejection } from './detect.ts'
+import { formatAggregatedDiff, formatAggregatedInputs } from './format.ts'
+import { dataToBytes, parseAsFormat, parseAsFormatAsync } from './parse.ts'
+import { formatConverters } from './registry.ts'
 
 export { formatConverters, formats } from './registry.ts'
 export type { Format } from './registry.ts'
@@ -150,12 +115,8 @@ export const aggregateInput = (
   const { data, format, origin } = normalizeProfileInput(input)
 
   if (format) {
-    // The format was specified, so delegate directly to its converter.
-    const converter = specifiedFormatConverter(format)
-    const context = makeContext(format, origin)
-    return converter.type === `json`
-      ? aggregateJsonInput(converter, JumboJSON.parse(data), options, context)
-      : aggregateBinaryInput(converter, dataToBytes(data), options, context)
+    const parsed = parseAsFormat(formatConverters[format], data)
+    return aggregateParsedInputs(parsed, options, makeContext(format, origin))
   }
 
   // Buffer an `Iterable` up front because it might be one-shot, but we need to
@@ -176,38 +137,20 @@ export const aggregateInput = (
       jsonError = startsJsonDocument(buffered) ? error : undefined
     }
   }
+
   const rejections: FormatRejection[] = []
-  if (json !== undefined) {
-    const inputs = detectFromJson(json, options, origin, rejections)
-    if (inputs !== undefined) {
-      return inputs
-    }
+  const detected =
+    (json === undefined ? undefined : detectJsonFormat(json, rejections)) ??
+    detectBinaryFormat(dataToBytes(buffered), rejections)
+  if (!detected) {
+    throw toUndetectedFormatError(rejections, jsonError)
   }
-
-  const inputs = detectFromBytes(
-    dataToBytes(buffered),
+  return aggregateParsedInputs(
+    detected.parsed,
     options,
-    origin,
-    rejections,
+    makeContext(detected.format, origin),
   )
-  if (inputs !== undefined) {
-    return inputs
-  }
-
-  throw undetectedFormatError(rejections, jsonError)
 }
-
-const dataToBytes = (data: ProfileData): Uint8Array => {
-  if (typeof data === `string`) {
-    return (textEncoder ??= new TextEncoder()).encode(data)
-  }
-  if (ArrayBuffer.isView(data)) {
-    return data
-  }
-  return concatUint8Arrays(data)
-}
-
-let textEncoder: InstanceType<typeof TextEncoder> | undefined
 
 const aggregateInputAsync = async (
   input: ProfileInput<AsyncProfileData>,
@@ -216,23 +159,8 @@ const aggregateInputAsync = async (
   const { data, format, origin } = normalizeProfileInput(input)
 
   if (format) {
-    // The format was specified, so delegate directly to its converter.
-    const converter = specifiedFormatConverter(format)
-    const context = makeContext(format, origin)
-    return converter.type === `json`
-      ? aggregateJsonInput(
-          converter,
-          await JumboJSON.parseAsync(data),
-          options,
-          context,
-        )
-      : aggregateBinaryInputAsync(
-          converter,
-          // Stream the binary data when possible.
-          data instanceof Blob ? data.stream() : data,
-          options,
-          context,
-        )
+    const parsed = await parseAsFormatAsync(formatConverters[format], data)
+    return aggregateParsedInputs(parsed, options, makeContext(format, origin))
   }
 
   // Buffer a `ReadableStream` up front because it might be one-shot, but we
@@ -264,434 +192,20 @@ const aggregateInputAsync = async (
         : undefined
     }
   }
+
   const rejections: FormatRejection[] = []
-  if (json !== undefined) {
-    const inputs = detectFromJson(json, options, origin, rejections)
-    if (inputs !== undefined) {
-      return inputs
-    }
-  }
-
-  const bytes = buffered instanceof Blob ? await buffered.bytes() : buffered
-  const inputs = detectFromBytes(bytes, options, origin, rejections)
-  if (inputs !== undefined) {
-    return inputs
-  }
-
-  throw undetectedFormatError(rejections, jsonError)
-}
-
-/**
- * The converter for a format the caller specified. Its parses report a
- * rejection as that format's, so the caller receives the reason and the format
- * that rejected the input.
- *
- * Auto-detection uses the registry's converters directly, because it names
- * each rejecting format when it reports the rejections together.
- */
-const specifiedFormatConverter = (format: Format): FormatConverter => {
-  const converter = formatConverters[format]
-  if (converter.type === `json`) {
-    return {
-      ...converter,
-      parse: (json: unknown) =>
-        rejectAsFormat(converter, () => converter.parse(json)),
-    }
-  }
-  return {
-    ...converter,
-    parse: (bytes: Uint8Array) =>
-      rejectAsFormat(converter, () => converter.parse(bytes)),
-    parseAsync: async stream => {
-      try {
-        return await converter.parseAsync(stream)
-      } catch (error: unknown) {
-        throw asFormatRejection(converter, error)
-      }
-    },
-  }
-}
-
-const rejectAsFormat = (
-  converter: FormatConverter,
-  parse: () => ParsedInput[],
-): ParsedInput[] => {
-  try {
-    return parse()
-  } catch (error: unknown) {
-    throw asFormatRejection(converter, error)
-  }
-}
-
-/**
- * Prefixes a {@link FormatParseError} with the format's title. Any other error
- * passes through, because it reports a bug instead of an unusable input.
- */
-const asFormatRejection = (
-  converter: FormatConverter,
-  error: unknown,
-): unknown =>
-  error instanceof FormatParseError
-    ? new ProfilerMdError(`${converter.title}: ${error.message}`, {
-        cause: error,
-      })
-    : error
-
-const detectFromJson = (
-  json: unknown,
-  options: AggregationProfileToMdOptions,
-  origin: Origin | undefined,
-  rejections: FormatRejection[],
-): AggregatedInput[] | undefined => {
-  for (const [format, converter] of jsonFormatConverters) {
-    const parsed = detectWithConverter(
-      converter,
-      () => converter.matches(json),
-      () => converter.parse(json),
+  const detected =
+    (json === undefined ? undefined : detectJsonFormat(json, rejections)) ??
+    detectBinaryFormat(
+      buffered instanceof Blob ? await buffered.bytes() : buffered,
       rejections,
     )
-    if (parsed) {
-      return aggregateParsedInputs(parsed, options, makeContext(format, origin))
-    }
+  if (!detected) {
+    throw toUndetectedFormatError(rejections, jsonError)
   }
-  return undefined
-}
-
-const formatConverterEntries: [Format, FormatConverter][] = formats.map(
-  format => [format, formatConverters[format]],
-)
-
-const jsonFormatConverters: [Format, JsonFormatConverter][] =
-  formatConverterEntries.filter(
-    (entry): entry is [Format, JsonFormatConverter] => entry[1].type === `json`,
+  return aggregateParsedInputs(
+    detected.parsed,
+    options,
+    makeContext(detected.format, origin),
   )
-
-const detectFromBytes = (
-  bytes: Uint8Array,
-  options: AggregationProfileToMdOptions,
-  origin: Origin | undefined,
-  rejections: FormatRejection[],
-): AggregatedInput[] | undefined => {
-  for (const [format, converter] of binaryFormatConverters) {
-    const parsed = detectWithConverter(
-      converter,
-      () => converter.matches(bytes),
-      () => converter.parse(bytes),
-      rejections,
-    )
-    if (parsed) {
-      return aggregateParsedInputs(parsed, options, makeContext(format, origin))
-    }
-  }
-  return undefined
-}
-
-/**
- * A converter that recognized the input, but whose parse rejected it.
- *
- * Detection continues with the next format, and reports the rejections when no
- * format parses the input.
- */
-type FormatRejection = { converter: FormatConverter; error: unknown }
-
-/**
- * Runs a converter's detection and parse, recording a rejection instead of
- * throwing when the converter recognized the input but failed to parse it.
- *
- * A `matches` that throws counts as no match, because it is a cheap prefilter
- * that never validates the input.
- */
-const detectWithConverter = (
-  converter: FormatConverter,
-  matches: () => boolean,
-  parse: () => ParsedInput[],
-  rejections: FormatRejection[],
-): ParsedInput[] | undefined => {
-  try {
-    if (!matches()) {
-      return undefined
-    }
-  } catch {
-    return undefined
-  }
-
-  try {
-    return parse()
-  } catch (error: unknown) {
-    rejections.push({ converter, error })
-    return undefined
-  }
-}
-
-export const aggregateJsonInput = (
-  converter: JsonFormatConverter,
-  json: unknown,
-  options: AggregationProfileToMdOptions,
-  context: UnresolvedProfileToMdContext,
-): AggregatedInput[] =>
-  aggregateParsedInputs(converter.parse(json), options, context)
-
-export const aggregateBinaryInput = (
-  converter: BinaryFormatConverter,
-  bytes: Uint8Array,
-  options: AggregationProfileToMdOptions,
-  context: UnresolvedProfileToMdContext,
-): AggregatedInput[] =>
-  aggregateParsedInputs(converter.parse(bytes), options, context)
-
-export const aggregateBinaryInputAsync = async (
-  converter: BinaryFormatConverter,
-  stream: ReadableStream<Uint8Array>,
-  options: AggregationProfileToMdOptions,
-  context: UnresolvedProfileToMdContext,
-): Promise<AggregatedInput[]> =>
-  aggregateParsedInputs(await converter.parseAsync(stream), options, context)
-
-/**
- * Aggregates each parsed input through its modality's uniform pipeline.
- *
- * The origin is detected once across all inputs.
- */
-const aggregateParsedInputs = (
-  parsed: ParsedInput[],
-  options: AggregationProfileToMdOptions,
-  context: UnresolvedProfileToMdContext,
-): AggregatedInput[] => {
-  const aggregators = parsed.map(input => {
-    switch (input.type) {
-      case `call-stack-profile`:
-        return new CallStackProfileAggregator(input)
-      case `call-graph`:
-        return new CallGraphAggregator(input)
-      case `heap-snapshot`:
-        return new HeapSnapshotAggregator(input)
-    }
-  })
-
-  const detector = new OriginDetector(context)
-  for (const aggregator of aggregators) {
-    aggregator.detectOrigin(detector)
-  }
-
-  const resolvedContext: ProfileToMdContext = {
-    format: context.format,
-    origin: detector.resolve(),
-  }
-  return aggregators.map(aggregator =>
-    aggregator.aggregate(options, resolvedContext),
-  )
-}
-
-/**
- * Builds the conversion context, which carries the resolved format and the
- * explicit origin (or `null` when none was given).
- */
-const makeContext = (
-  format: Format,
-  origin: Origin | undefined,
-): UnresolvedProfileToMdContext => ({ format, origin: origin ?? null })
-
-const binaryFormatConverters: [Format, BinaryFormatConverter][] =
-  formatConverterEntries.filter(
-    (entry): entry is [Format, BinaryFormatConverter] =>
-      entry[1].type === `binary`,
-  )
-
-/**
- * Reports why auto-detection resolved no format.
- *
- * A single rejection is reported as that format's failure, because the input
- * is that format and failed to parse. Several rejections name each format with
- * its reason. No rejection means no format recognized the input.
- */
-const undetectedFormatError = (
-  rejections: readonly FormatRejection[],
-  jsonError: unknown,
-): Error => {
-  const [rejection] = rejections
-  if (rejections.length === 1) {
-    return new FormatDetectError(
-      describeRejection(rejection!),
-      [rejection!.error],
-      { cause: rejection!.error },
-    )
-  }
-
-  if (rejections.length > 1) {
-    return new FormatDetectError(
-      `could not detect the profile format, rejected by: ${rejections
-        .map(rejected => describeRejection(rejected))
-        .join(`, `)}`,
-      rejections.map(({ error }) => error),
-    )
-  }
-
-  if (jsonError !== undefined) {
-    return new FormatDetectError(
-      `could not detect the profile format, the input reads as JSON but failed to parse: ${reasonOf(jsonError)}`,
-      [jsonError],
-      { cause: jsonError },
-    )
-  }
-
-  return new FormatDetectError(
-    `could not detect the profile format, expected one of: ${formats.join(`, `)}`,
-    [],
-  )
-}
-
-/** A rejection as `<title>: <reason>`. */
-const describeRejection = ({ converter, error }: FormatRejection): string =>
-  `${converter.title}: ${reasonOf(error)}`
-
-export const formatAggregatedInputs = (
-  inputs: AggregatedInput[],
-  options: NormalizedProfileToMdOptions,
-): string => {
-  const formattingOptions = makeFormattingProfileToMdOptions(options, inputs)
-  const contents = inputs.flatMap(input => {
-    switch (input.type) {
-      case `call-stack-profile`:
-        return formatCallStackProfile(input, formattingOptions)
-      case `call-graph`:
-        return formatCallGraph(input, formattingOptions)
-      case `heap-snapshot`:
-        return formatHeapSnapshot(input, formattingOptions)
-    }
-  })
-  return toMarkdown(contents)
-}
-
-/**
- * Diffs the aggregated {@link base} and {@link current} inputs element by
- * element, returning the differences as Markdown.
- *
- * The two sides must have the same length and the same `type` at each index,
- * otherwise they aren't comparable.
- */
-const formatAggregatedDiff = (
-  base: AggregatedInput[],
-  current: AggregatedInput[],
-  options: NormalizedProfileToMdOptions,
-): string => {
-  if (base.length !== current.length) {
-    throw new ProfilerMdError(
-      `cannot diff inputs containing different numbers of profiles, got: ${base.length} in the base and ${current.length} in the current`,
-    )
-  }
-
-  // Resolve over both sides at once so they share a single inferred base URL
-  // and format consistently.
-  const formattingOptions = makeFormattingProfileToMdOptions(options, [
-    ...base,
-    ...current,
-  ])
-  const contents = base.flatMap((baseInput, index) => {
-    const currentInput = current[index]!
-    if (
-      baseInput.type === `call-stack-profile` &&
-      currentInput.type === `call-stack-profile`
-    ) {
-      return formatCallStackProfileDiff(
-        diffAggregatedCallStackProfiles(
-          baseInput,
-          currentInput,
-          formattingOptions,
-        ),
-        formattingOptions,
-      )
-    }
-    if (baseInput.type === `call-graph` && currentInput.type === `call-graph`) {
-      return formatCallGraphDiff(
-        diffAggregatedCallGraphs(baseInput, currentInput, formattingOptions),
-        formattingOptions,
-      )
-    }
-    if (
-      baseInput.type === `heap-snapshot` &&
-      currentInput.type === `heap-snapshot`
-    ) {
-      return formatHeapSnapshotDiff(
-        diffAggregatedHeapSnapshots(baseInput, currentInput, formattingOptions),
-        formattingOptions,
-      )
-    }
-    throw new ProfilerMdError(
-      `cannot diff a ${modalityName(baseInput.type)} against a ${modalityName(currentInput.type)}`,
-    )
-  })
-  return toMarkdown(contents)
-}
-
-const modalityName = (type: ParsedInput[`type`]): string =>
-  type.replaceAll(`-`, ` `)
-
-const toMarkdown = (contents: RootContent[]): string =>
-  mdastToMarkdown(
-    contents.length > 0 ? contents : [paragraph(`No profiling data found.`)],
-  )
-
-/**
- * Resolves a `baseURL` of `'auto'` to the common ancestor directory of the
- * aggregated {@link inputs}.
- *
- * Any other `baseURL` passes through unchanged.
- */
-const makeFormattingProfileToMdOptions = (
-  options: NormalizedProfileToMdOptions,
-  inputs: AggregatedInput[],
-): FormattingProfileToMdOptions => {
-  const { baseURL } = options
-  return baseURL === `auto`
-    ? {
-        ...options,
-        baseURL: commonAncestorDirectoryURL(
-          collectInferableURLs(inputs, { ...options, baseURL: undefined }),
-        ),
-      }
-    : { ...options, baseURL }
-}
-
-/**
- * Collects the base-URL-inferable absolute URLs of {@link inputs}' entries.
- *
- * Applies source maps first so the base is inferred from the locations
- * formatting will show.
- */
-const collectInferableURLs = (
-  inputs: AggregatedInput[],
-  options: FormattingProfileToMdOptions,
-): URL[] => {
-  const urls: URL[] = []
-  const collect = (location: SourceLocation | undefined) => {
-    if (!location) {
-      return
-    }
-    const mappedLocation = sourceMapSourceLocation(location, options)
-    if (isBaseURLInferableLocation(mappedLocation)) {
-      urls.push(mappedLocation.url)
-    }
-  }
-
-  for (const input of inputs) {
-    switch (input.type) {
-      case `call-stack-profile`:
-      case `call-graph`:
-        for (const func of input.functions) {
-          // Onky `ours`-categorized functions contribute, because a
-          // dependency's install path can be far outside the source tree and
-          // would raise the base to a shared root.
-          if (func.category === `ours`) {
-            collect(func.location)
-          }
-        }
-        break
-      case `heap-snapshot`:
-        for (const entity of [...input.constructors, ...input.functions]) {
-          collect(entityLocation(entity))
-        }
-        break
-    }
-  }
-  return urls
 }

--- a/src/formats/parse.ts
+++ b/src/formats/parse.ts
@@ -1,0 +1,70 @@
+import { JumboJSON } from 'jumbo-json'
+import { ProfilerMdError, reasonOf } from '../error.ts'
+import { concatUint8Arrays } from '../helpers/bytes.ts'
+import type { AsyncProfileData, ProfileData } from '../options.ts'
+import type { FormatConverter, ParsedInput } from './converter.ts'
+import { FormatParseError } from './error.ts'
+
+/**
+ * Parses the input as the format the caller specified, reporting a rejection
+ * as that format's, so the caller receives the reason and the format that
+ * rejected the input.
+ */
+export const parseAsFormat = (
+  converter: FormatConverter,
+  data: ProfileData,
+): ParsedInput[] => {
+  try {
+    return converter.type === `json`
+      ? converter.parse(JumboJSON.parse(data))
+      : converter.parse(dataToBytes(data))
+  } catch (error: unknown) {
+    throw toFormatRejection(converter, error)
+  }
+}
+
+export const parseAsFormatAsync = async (
+  converter: FormatConverter,
+  data: AsyncProfileData,
+): Promise<ParsedInput[]> => {
+  try {
+    return converter.type === `json`
+      ? converter.parse(await JumboJSON.parseAsync(data))
+      : // Stream the binary data when possible.
+        await converter.parseAsync(data instanceof Blob ? data.stream() : data)
+  } catch (error: unknown) {
+    throw toFormatRejection(converter, error)
+  }
+}
+
+/**
+ * Prefixes a {@link FormatParseError} with the format's title. Any other error
+ * passes through, because it reports a bug instead of an unusable input.
+ */
+const toFormatRejection = (
+  converter: FormatConverter,
+  error: unknown,
+): unknown =>
+  error instanceof FormatParseError
+    ? new ProfilerMdError(`${converter.title}: ${error.message}`, {
+        cause: error,
+      })
+    : error
+
+export const dataToBytes = (data: ProfileData): Uint8Array => {
+  if (typeof data === `string`) {
+    return (textEncoder ??= new TextEncoder()).encode(data)
+  }
+  if (ArrayBuffer.isView(data)) {
+    return data
+  }
+  return concatUint8Arrays(data)
+}
+
+let textEncoder: InstanceType<typeof TextEncoder> | undefined
+
+/** A parse's failure as `<title>: <reason>`. */
+export const describeParseFailure = (
+  converter: FormatConverter,
+  error: unknown,
+): string => `${converter.title}: ${reasonOf(error)}`

--- a/src/formats/testing.ts
+++ b/src/formats/testing.ts
@@ -3,18 +3,14 @@ import path from 'node:path'
 import { gunzipSync } from 'node:zlib'
 import { inject } from 'vitest'
 import type { NormalizedProfileToMdOptions } from '../options.ts'
+import { aggregateParsedInputs } from './aggregate.ts'
 import type {
   BinaryFormatConverter,
   FormatConverter,
   JsonFormatConverter,
 } from './converter.ts'
-import {
-  aggregateBinaryInput,
-  aggregateBinaryInputAsync,
-  aggregateJsonInput,
-  formatAggregatedInputs,
-  formatConverters,
-} from './index.ts'
+import { formatAggregatedInputs } from './format.ts'
+import { formatConverters } from './index.ts'
 import type { Format } from './index.ts'
 
 declare module 'vitest' {
@@ -81,9 +77,8 @@ export const convertJsonToMd = (
   format?: Format,
 ): string =>
   formatAggregatedInputs(
-    aggregateJsonInput(
-      converter,
-      json,
+    aggregateParsedInputs(
+      converter.parse(json),
       options,
       format ? { format, origin: null } : profileToMdContext(converter),
     ),
@@ -96,9 +91,8 @@ export const convertBytesToMd = (
   options: NormalizedProfileToMdOptions,
 ): string =>
   formatAggregatedInputs(
-    aggregateBinaryInput(
-      converter,
-      bytes,
+    aggregateParsedInputs(
+      converter.parse(bytes),
       options,
       profileToMdContext(converter),
     ),
@@ -115,9 +109,8 @@ export const convertToMdAsync = async (
   options: NormalizedProfileToMdOptions,
 ): Promise<string> =>
   formatAggregatedInputs(
-    await aggregateBinaryInputAsync(
-      converter,
-      stream,
+    aggregateParsedInputs(
+      await converter.parseAsync(stream),
       options,
       profileToMdContext(converter),
     ),


### PR DESCRIPTION
src/formats/index.ts held the whole pipeline: the specified-format parse wrappers, auto-detection, aggregation dispatch, and Markdown formatting dispatch. Each stage now has its own module, and index.ts buffers the input and calls them in order. No behavior changes.