### PR TITLE
fix(cli): write the output to stdout when the pager fails

### DIFF
--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -15,10 +15,10 @@ export const writeOutput = async (
   outputPath: string,
   { pager }: WriteOutputOptions,
 ): Promise<void> => {
-  const output =
-    (pager && isTTYOutput(outputPath) ? await openPager() : null) ??
-    (await openOutput(outputPath))
-  await output.write(text)
+  const output = await openOutput(outputPath)
+  const pagerOutput =
+    pager && isTTYOutput(outputPath) ? await openPager(output) : null
+  await (pagerOutput ?? output).write(text)
 }
 
 export const isTTYOutput = (outputPath: string): boolean =>

--- a/src/cli/pager.test.ts
+++ b/src/cli/pager.test.ts
@@ -1,0 +1,125 @@
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, afterEach, beforeAll, expect, test, vi } from 'vitest'
+import type { Output } from './output.ts'
+import { openPager } from './pager.ts'
+
+let dir: string
+
+beforeAll(async () => {
+  dir = await mkdtemp(join(tmpdir(), `profiler-md-pager-`))
+})
+
+afterAll(() => rm(dir, { recursive: true }))
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
+
+const pagerScript = async (name: string, body: string): Promise<string> => {
+  const path = join(dir, name)
+  await writeFile(path, `#!/bin/sh\n${body}\n`)
+  await chmod(path, 0o755)
+  return path
+}
+
+const recordingOutput = (): Output & { texts: string[] } => {
+  const texts: string[] = []
+  return {
+    texts,
+    write: text => {
+      texts.push(text)
+      return Promise.resolve()
+    },
+  }
+}
+
+const page = async (
+  text: string,
+): Promise<{ fallback: string[]; stderr: string }> => {
+  const fallback = recordingOutput()
+  let stderr = ``
+  vi.spyOn(process.stderr, `write`).mockImplementation(chunk => {
+    stderr += String(chunk)
+    return true
+  })
+
+  const output = await openPager(fallback)
+  expect(output).not.toBeNull()
+  await output!.write(text)
+
+  return { fallback: fallback.texts, stderr }
+}
+
+test(`passes the output to the pager and writes nothing else`, async () => {
+  const received = join(dir, `received.txt`)
+  vi.stubEnv(`PAGER`, await pagerScript(`cat-pager`, `cat > "${received}"`))
+
+  const { fallback, stderr } = await page(`# Hello\n`)
+
+  expect(await readFile(received, `utf8`)).toBe(`# Hello\n`)
+  expect(fallback).toEqual([])
+  expect(stderr).toBe(``)
+})
+
+test(`defaults LESS to case-insensitive search and keeps the user's LESS`, async () => {
+  const received = join(dir, `less.txt`)
+  vi.stubEnv(
+    `PAGER`,
+    await pagerScript(
+      `less-pager`,
+      `printf '%s' "$LESS" > "${received}"; cat > /dev/null`,
+    ),
+  )
+
+  vi.stubEnv(`LESS`, undefined)
+  await page(``)
+  expect(await readFile(received, `utf8`)).toBe(`FIRSX -#6`)
+
+  vi.stubEnv(`LESS`, `R`)
+  await page(``)
+  expect(await readFile(received, `utf8`)).toBe(`R`)
+})
+
+test(`falls back to the output and warns when the pager exits non-zero`, async () => {
+  vi.stubEnv(`PAGER`, `false`)
+
+  const { fallback, stderr } = await page(`# Hello\n`)
+
+  expect(fallback).toEqual([`# Hello\n`])
+  expect(stderr).toBe(`warning: pager exited with status 1\n`)
+})
+
+test(`keeps the output in the pager when the user quits it early`, async () => {
+  // Quitting `less` closes its stdin before the write finishes, and exits 0.
+  vi.stubEnv(`PAGER`, await pagerScript(`quit-pager`, `exit 0`))
+
+  const { fallback, stderr } = await page(`# Hello\n`.repeat(100_000))
+
+  expect(fallback).toEqual([])
+  expect(stderr).toBe(``)
+})
+
+test(`ignores SIGINT while the pager runs and restores it after`, async () => {
+  const listenersBefore = process.listenerCount(`SIGINT`)
+  const gate = join(dir, `gate`)
+  vi.stubEnv(
+    `PAGER`,
+    await pagerScript(
+      `waiting-pager`,
+      `cat > /dev/null; while [ ! -e "${gate}" ]; do sleep 0.05; done`,
+    ),
+  )
+  const output = await openPager(recordingOutput())
+
+  const writePromise = output!.write(`# Hello\n`)
+  await vi.waitFor(() =>
+    expect(process.listenerCount(`SIGINT`)).toBe(listenersBefore + 1),
+  )
+  await writeFile(gate, ``)
+  await writePromise
+
+  expect(process.listenerCount(`SIGINT`)).toBe(listenersBefore)
+})

--- a/src/cli/pager.ts
+++ b/src/cli/pager.ts
@@ -3,7 +3,15 @@ import type { ChildProcessByStdio } from 'node:child_process'
 import type { Writable } from 'node:stream'
 import type { Output } from './output.ts'
 
-export const openPager = async (): Promise<Output | null> => {
+/**
+ * Opens the user's pager, or `less`, for stdout output. Returns `null` when an
+ * empty `PAGER` opts out of paging or no pager spawns.
+ *
+ * A pager that fails before it shows anything would lose the output, so the
+ * returned output writes to `fallback` when the pager exits with a non-zero
+ * status.
+ */
+export const openPager = async (fallback: Output): Promise<Output | null> => {
   const raw = process.env.PAGER
   // Explicit `PAGER=` opts out of paging entirely (matches git/systemctl).
   if (raw?.trim() === ``) {
@@ -13,11 +21,12 @@ export const openPager = async (): Promise<Output | null> => {
   const env = {
     // Default `less` flags (overridable via the user's `LESS`):
     // - `F`: Quit if output fits one screen
+    // - `I`: Ignore case in searches
     // - `R`: Pass through ANSI colors
     // - `S`: Chop long lines instead of wrapping
     // - `X`: Don't clear the screen on exit
     // - `-#6`: Scroll horizontally 6 columns at a time
-    LESS: `FRSX -#6`,
+    LESS: `FIRSX -#6`,
     ...process.env,
   }
   const child =
@@ -29,15 +38,45 @@ export const openPager = async (): Promise<Output | null> => {
 
   return {
     write: async text => {
-      await new Promise<void>(resolve => {
-        child.stdin.write(text, () => child.stdin.end(resolve))
-      })
-      await waitForExit(child)
+      const exitCode = await page(child, text)
+      if (exitCode !== 0 && exitCode !== null) {
+        process.stderr.write(`warning: pager exited with status ${exitCode}\n`)
+        await fallback.write(text)
+      }
     },
   }
 }
 
 type PagerProcess = ChildProcessByStdio<Writable, null, null>
+
+/**
+ * Writes the text to the pager and resolves to its exit status once it quits,
+ * or `null` when a signal killed it.
+ *
+ * A terminal's Ctrl-C signals this process and the pager together. The pager
+ * handles its own interrupt and keeps running, so exiting here would orphan
+ * it on the terminal. This process ignores SIGINT while the pager runs, as
+ * git does, so quitting the pager ends the run instead.
+ */
+const page = async (
+  child: PagerProcess,
+  text: string,
+): Promise<number | null> => {
+  process.on(`SIGINT`, ignoreSignal)
+  try {
+    // The pager can exit before the write settles, so listen for its exit
+    // before writing or the `exit` event is missed.
+    const [exitCode] = await Promise.all([
+      waitForExit(child),
+      writeStdin(child, text),
+    ])
+    return exitCode
+  } finally {
+    process.off(`SIGINT`, ignoreSignal)
+  }
+}
+
+const ignoreSignal = () => {}
 
 const trySpawn = (
   command: string,
@@ -54,23 +93,33 @@ const trySpawn = (
   })
 
   return new Promise(resolve => {
-    child.once(`spawn`, () => {
-      child.stdin.on(`error`, (error: NodeJS.ErrnoException) => {
-        // The user can quit the pager (e.g. `q` in `less`) before we finish
-        // writing, which closes its stdin and makes our next write reject with
-        // EPIPE. That's a normal exit path, not a failure.
-        if (error.code !== `EPIPE`) {
-          throw error
-        }
-      })
-      resolve(child)
-    })
+    child.once(`spawn`, () => resolve(child))
     child.once(`error`, () => resolve(null))
   })
 }
 
-const waitForExit = (child: PagerProcess): Promise<void> =>
+const writeStdin = (child: PagerProcess, text: string): Promise<void> =>
   new Promise((resolve, reject) => {
-    child.once(`exit`, () => resolve())
+    const finish = (error?: NodeJS.ErrnoException | null) => {
+      // Quitting the pager (e.g. `q` in `less`) before the write finishes
+      // fails the write, a normal exit path. The code is `EPIPE` when the
+      // pager closed its stdin first, and `ECANCELED` when Node destroyed the
+      // pipe on the pager's exit first.
+      if (!error || error.code === `EPIPE` || error.code === `ECANCELED`) {
+        resolve()
+      } else {
+        reject(error)
+      }
+    }
+    child.stdin.on(`error`, finish)
+    child.stdin.write(text, error =>
+      error ? finish(error) : child.stdin.end(finish),
+    )
+  })
+
+/** Resolves to the pager's exit status, or `null` when a signal killed it. */
+const waitForExit = (child: PagerProcess): Promise<number | null> =>
+  new Promise((resolve, reject) => {
+    child.once(`exit`, code => resolve(code))
     child.once(`error`, reject)
   })


### PR DESCRIPTION
A pager that exited before it showed anything, such as a broken $PAGER command, lost the output. The CLI now writes the output to stdout, with a warning, when the pager exits with a non-zero status. A pager the user quits early exits 0 after it showed the output, so no warning follows.

A terminal's Ctrl-C signalled this process and the pager together. less handles the interrupt and keeps running, so the CLI exited and left the pager orphaned on the terminal. The CLI now ignores SIGINT while the pager runs, as git does, and quitting the pager ends the run.

The default LESS flags now include I, so searches ignore case.