### PR TITLE
fix: report a decoding failure as the specified format's rejection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ profiler-md
 │   │   ├── converter.ts          # Format converter types
 │   │   ├── registry.ts           # Format converter registry
 │   │   ├── error.ts              # Parse and detection error classes
-│   │   ├── parse.ts              # Specified-format parse wrappers that report a rejection as the format's
+│   │   ├── parse.ts              # JSON decode and specified-format parse wrappers that report a rejection as the format's
 │   │   ├── detect.ts             # Format auto-detection and its undetected-format error
 │   │   ├── aggregate.ts          # Parsed input to aggregated input dispatch across modalities, with origin detection
 │   │   ├── format.ts             # Aggregated input and diff to Markdown dispatch across modalities
@@ -263,6 +263,9 @@ pnpm generate-inputs go ruby   # Limit to named workload scripts
   accept anything of the format, including a version or variant the parser
   rejects, so auto-detection reports that reason instead of an undetectable
   input
+- Wrap a third-party decoder's error (e.g. `JSON.parse`) in a `FormatParseError`
+  at its call site. The parser cannot check anything before decoding succeeds,
+  so a decoding failure is the input's, however the decoder reports it
 - Write a message as `<what failed>: <detail>`, or as a single clause when there
   is no useful prefix. Put the offending value last, after `got: `.
   `eslint-rules/error-message.js` checks the remaining wording conventions

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -650,7 +650,20 @@ if (format === undefined) {
       scenario: `stdin with a truncated JSON profile`,
       args: [],
       input: `{"nodes": [`,
-      expectedStderr: `the input reads as JSON but failed to parse`,
+      expectedStderr: `the input reads as JSON but is invalid JSON: `,
+      expectedStatus: 1,
+    },
+    {
+      scenario: `stdin with invalid JSON under an explicit JSON format`,
+      args: [`--format`, `v8-cpu-profile`],
+      input: `garbage\n`,
+      expectedStderr: `error: V8 CPU profile: invalid JSON: `,
+      expectedStatus: 1,
+    },
+    {
+      scenario: `a JSON file under --format pprof`,
+      args: [`--format`, `pprof`, inputPath(`javascript.node.base.cpuprofile`)],
+      expectedStderr: `error: pprof: invalid protobuf encoding: `,
       expectedStatus: 1,
     },
     {

--- a/src/formats/detect.ts
+++ b/src/formats/detect.ts
@@ -123,7 +123,7 @@ export const toUndetectedFormatError = (
 
   if (jsonError !== undefined) {
     return new FormatDetectError(
-      `could not detect the profile format, the input reads as JSON but failed to parse: ${reasonOf(jsonError)}`,
+      `could not detect the profile format, the input reads as JSON but is ${reasonOf(jsonError)}`,
       [jsonError],
       { cause: jsonError },
     )

--- a/src/formats/index.test.ts
+++ b/src/formats/index.test.ts
@@ -508,10 +508,75 @@ describe(`profileToMd`, () => {
       )
     })
 
-    test(`detection reports a malformed JSON document as unparseable JSON`, () => {
+    test(`detection reports a malformed JSON document as invalid JSON`, () => {
       expect(() => profileToMd(`{"nodes": [`)).toThrow(
-        /could not detect the profile format, the input reads as JSON but failed to parse: /u,
+        /could not detect the profile format, the input reads as JSON but is invalid JSON: /u,
       )
+    })
+
+    test(`a specified JSON format reports invalid JSON as its rejection`, () => {
+      expect(() =>
+        profileToMd({ data: `garbage\n`, format: `v8-cpu-profile` }),
+      ).toThrow(/^V8 CPU profile: invalid JSON: /u)
+    })
+
+    test(`a specified JSON format reports invalid JSON as its rejection when async`, async () => {
+      await expect(
+        profileToMdAsync({
+          data: new Blob([`garbage\n`]),
+          format: `v8-cpu-profile`,
+        }),
+      ).rejects.toThrow(/^V8 CPU profile: invalid JSON: /u)
+    })
+
+    test(`a specified binary format reports its decoder's failure as its rejection`, () => {
+      expect(() => profileToMd({ data: `garbage\n`, format: `pprof` })).toThrow(
+        /^pprof: invalid protobuf encoding: /u,
+      )
+    })
+
+    describe(`a failure to read the data escapes unwrapped`, () => {
+      const readError = new Error(`EIO`)
+      function* failingIterable(): Iterable<Uint8Array> {
+        yield new TextEncoder().encode(`{`)
+        throw readError
+      }
+      const failingStream = (): ReadableStream<Uint8Array> =>
+        new ReadableStream({
+          pull: () => {
+            throw readError
+          },
+        })
+
+      test.each([
+        { scenario: `under a specified JSON format`, format: `v8-cpu-profile` },
+        { scenario: `under a specified binary format`, format: `pprof` },
+        { scenario: `under auto-detection`, format: undefined },
+      ] as const)(`from an iterable $scenario`, ({ format }) => {
+        let thrown
+        try {
+          profileToMd({ data: failingIterable(), format })
+        } catch (error: unknown) {
+          thrown = error
+        }
+
+        expect(thrown).toBe(readError)
+      })
+
+      test.each([
+        { scenario: `under a specified JSON format`, format: `v8-cpu-profile` },
+        { scenario: `under a specified binary format`, format: `pprof` },
+        { scenario: `under auto-detection`, format: undefined },
+      ] as const)(`from a stream $scenario`, async ({ format }) => {
+        let thrown
+        try {
+          await profileToMdAsync({ data: failingStream(), format })
+        } catch (error: unknown) {
+          thrown = error
+        }
+
+        expect(thrown).toBe(readError)
+      })
     })
 
     test(`a detection error contains the error from each format that rejected the input`, () => {

--- a/src/formats/index.ts
+++ b/src/formats/index.ts
@@ -1,4 +1,3 @@
-import { JumboJSON } from 'jumbo-json'
 import { concatUint8Arrays, streamToUint8Array } from '../helpers/bytes.ts'
 import {
   maybeJson,
@@ -26,7 +25,14 @@ import {
 } from './detect.ts'
 import type { FormatRejection } from './detect.ts'
 import { formatAggregatedDiff, formatAggregatedInputs } from './format.ts'
-import { dataToBytes, parseAsFormat, parseAsFormatAsync } from './parse.ts'
+import {
+  dataToBytes,
+  parseAsFormat,
+  parseAsFormatAsync,
+  parseJson,
+  parseJsonAsync,
+  rethrowInputReadFailure,
+} from './parse.ts'
 import { formatConverters } from './registry.ts'
 
 export { formatConverters, formats } from './registry.ts'
@@ -130,7 +136,7 @@ export const aggregateInput = (
   let jsonError: unknown
   if (maybeJson(buffered)) {
     try {
-      json = JumboJSON.parse(buffered)
+      json = parseJson(buffered)
     } catch (error: unknown) {
       // Report unusable JSON only for an input that opens a JSON document,
       // because `maybeJson` also admits text starting like a bare JSON value.
@@ -178,9 +184,10 @@ const aggregateInputAsync = async (
     try {
       json =
         buffered instanceof Blob
-          ? await JumboJSON.parseAsync(buffered)
-          : JumboJSON.parse(buffered)
+          ? await parseJsonAsync(buffered)
+          : parseJson(buffered)
     } catch (error: unknown) {
+      rethrowInputReadFailure(error)
       // Report unusable JSON only for an input that opens a JSON document,
       // because `maybeJson` also admits text starting like a bare JSON value.
       jsonError = (

--- a/src/formats/parse.ts
+++ b/src/formats/parse.ts
@@ -9,16 +9,26 @@ import { FormatParseError } from './error.ts'
  * Parses the input as the format the caller specified, reporting a rejection
  * as that format's, so the caller receives the reason and the format that
  * rejected the input.
+ *
+ * A failure to read the input is the input's own error, and escapes unwrapped.
  */
 export const parseAsFormat = (
   converter: FormatConverter,
   data: ProfileData,
 ): ParsedInput[] => {
+  if (converter.type === `binary`) {
+    const bytes = dataToBytes(data)
+    try {
+      return converter.parse(bytes)
+    } catch (error: unknown) {
+      throw toFormatRejection(converter, error)
+    }
+  }
+
   try {
-    return converter.type === `json`
-      ? converter.parse(JumboJSON.parse(data))
-      : converter.parse(dataToBytes(data))
+    return converter.parse(parseJson(data))
   } catch (error: unknown) {
+    rethrowInputReadFailure(error)
     throw toFormatRejection(converter, error)
   }
 }
@@ -29,13 +39,122 @@ export const parseAsFormatAsync = async (
 ): Promise<ParsedInput[]> => {
   try {
     return converter.type === `json`
-      ? converter.parse(await JumboJSON.parseAsync(data))
+      ? converter.parse(await parseJsonAsync(data))
       : // Stream the binary data when possible.
-        await converter.parseAsync(data instanceof Blob ? data.stream() : data)
+        await converter.parseAsync(guardStreamReads(dataToStream(data)))
   } catch (error: unknown) {
+    rethrowInputReadFailure(error)
     throw toFormatRejection(converter, error)
   }
 }
+
+/**
+ * Decodes JSON, wrapping a decoding failure in a {@link FormatParseError}.
+ *
+ * A JSON format's parser cannot check anything before decoding succeeds, so a
+ * decoding failure is the input's, however the decoder reports it. A failure to
+ * read the data propagates as an {@link InputReadError} instead.
+ */
+export const parseJson = (
+  data: string | Uint8Array | Iterable<Uint8Array>,
+): unknown => {
+  try {
+    return JumboJSON.parse(
+      // Reading an array cannot fail, and the decoder concatenates one up front
+      // instead of streaming it.
+      typeof data === `string` ||
+        ArrayBuffer.isView(data) ||
+        Array.isArray(data)
+        ? data
+        : guardIterableReads(data),
+    )
+  } catch (error: unknown) {
+    throw toInvalidJsonError(error)
+  }
+}
+
+export const parseJsonAsync = async (
+  data: Blob | ReadableStream<Uint8Array>,
+): Promise<unknown> => {
+  try {
+    return await JumboJSON.parseAsync(guardStreamReads(dataToStream(data)), {
+      sizeHint: data instanceof Blob ? data.size : undefined,
+    })
+  } catch (error: unknown) {
+    throw toInvalidJsonError(error)
+  }
+}
+
+const toInvalidJsonError = (error: unknown): unknown =>
+  error instanceof InputReadError
+    ? error
+    : new FormatParseError(`invalid JSON: ${reasonOf(error)}`, { cause: error })
+
+/**
+ * Thrown in place of an error the caller's data threw while a parser read it,
+ * so a failure to read the data is told apart from a failure to parse it.
+ */
+class InputReadError extends Error {
+  public constructor(cause: unknown) {
+    super(`failed to read the input`, { cause })
+    // eslint-disable-next-line stylistic/quotes
+    this.name = 'InputReadError'
+  }
+}
+
+/** Rethrows the error the caller's data threw, when the error stands in for one. */
+export const rethrowInputReadFailure = (error: unknown): void => {
+  if (error instanceof InputReadError) {
+    throw error.cause
+  }
+}
+
+function* guardIterableReads(
+  iterable: Iterable<Uint8Array>,
+): Iterable<Uint8Array> {
+  try {
+    yield* iterable
+  } catch (error: unknown) {
+    throw new InputReadError(error)
+  }
+}
+
+const guardStreamReads = (
+  stream: ReadableStream<Uint8Array>,
+): ReadableStream<Uint8Array> => {
+  const reader = stream.getReader()
+  return new ReadableStream<Uint8Array>({
+    pull: async controller => {
+      let result
+      try {
+        result = await reader.read()
+      } catch (error: unknown) {
+        throw new InputReadError(error)
+      }
+      if (result.done) {
+        controller.close()
+      } else {
+        controller.enqueue(result.value)
+      }
+    },
+    cancel: reason => reader.cancel(reason),
+  })
+}
+
+const dataToStream = (data: AsyncProfileData): ReadableStream<Uint8Array> =>
+  data instanceof Blob ? data.stream() : data
+
+export const dataToBytes = (data: ProfileData): Uint8Array => {
+  if (typeof data === `string`) {
+    return (textEncoder ??= new TextEncoder()).encode(data)
+  }
+  if (ArrayBuffer.isView(data)) {
+    return data
+  }
+  return concatUint8Arrays(data)
+}
+
+let textEncoder: InstanceType<typeof TextEncoder> | undefined
 
 /**
  * Prefixes a {@link FormatParseError} with the format's title. Any other error
@@ -50,18 +169,6 @@ const toFormatRejection = (
         cause: error,
       })
     : error
-
-export const dataToBytes = (data: ProfileData): Uint8Array => {
-  if (typeof data === `string`) {
-    return (textEncoder ??= new TextEncoder()).encode(data)
-  }
-  if (ArrayBuffer.isView(data)) {
-    return data
-  }
-  return concatUint8Arrays(data)
-}
-
-let textEncoder: InstanceType<typeof TextEncoder> | undefined
 
 /** A parse's failure as `<title>: <reason>`. */
 export const describeParseFailure = (

--- a/src/formats/pprof/index.test.ts
+++ b/src/formats/pprof/index.test.ts
@@ -14,6 +14,7 @@ import {
   profileTitles,
   summaryLines,
 } from '../../testing.ts'
+import { FormatParseError } from '../error.ts'
 import { convertBytesToMd, convertToMdAsync } from '../testing.ts'
 import { pprofConverter } from './index.ts'
 import { makePprof } from './testing.ts'
@@ -67,15 +68,17 @@ describe(`parse and matches`, () => {
   test(`rejects invalid binary data`, () => {
     expect(() =>
       pprofConverter.parse(new Uint8Array([0xff, 0xfe, 0xfd])),
-    ).toThrow()
+    ).toThrow(FormatParseError)
   })
 
-  test(`rejects non-pprof binary`, () => {
+  test(`rejects non-pprof binary as invalid protobuf encoding`, () => {
     const bytes = new TextEncoder().encode(
       JSON.stringify({ nodes: [], timeDeltas: [] }),
     )
 
-    expect(() => pprofConverter.parse(bytes)).toThrow()
+    expect(() => pprofConverter.parse(bytes)).toThrow(
+      /^invalid protobuf encoding: /u,
+    )
   })
 })
 

--- a/src/formats/pprof/parse.ts
+++ b/src/formats/pprof/parse.ts
@@ -1,4 +1,5 @@
 import { Profile as PprofProto } from 'pprof-format'
+import { reasonOf } from '../../error.ts'
 import type {
   CallStackProfile,
   Observation,
@@ -7,9 +8,18 @@ import { countMetricOf } from '../../modalities/metric.ts'
 import type { CountMetric, Metric } from '../../modalities/metric.ts'
 import { parseMetric, SAMPLES } from '../../modalities/metrics.ts'
 import type { StackFrame } from '../../modalities/stack-frame.ts'
+import { FormatParseError } from '../error.ts'
 
 export const parsePprof = (bytes: Uint8Array): CallStackProfile[] => {
-  const profile = PprofProto.decode(bytes)
+  let profile
+  try {
+    profile = PprofProto.decode(bytes)
+  } catch (error) {
+    throw new FormatParseError(
+      `invalid protobuf encoding: ${reasonOf(error)}`,
+      { cause: error },
+    )
+  }
   const string = makeStringReader(profile)
 
   const originHint = pprofOriginHint(profile, string)

--- a/src/formats/systing/index.test.ts
+++ b/src/formats/systing/index.test.ts
@@ -15,6 +15,7 @@ import {
   profileTitles,
   summaryLines,
 } from '../../testing.ts'
+import { FormatParseError } from '../error.ts'
 import { convertBytesToMd, convertToMdAsync } from '../testing.ts'
 import { systingConverter } from './index.ts'
 import { parseSysting } from './parse.ts'
@@ -82,6 +83,28 @@ describe(`matches`, () => {
         makeSysting([], { ...systingHeader, stack_order: `root_first` }),
       ),
     ).toThrow(`root_first`)
+  })
+
+  test.each([
+    {
+      scenario: `a truncated header line`,
+      input: `{"systing_profile_export": 1, "sample_event": "cpu-clock`,
+    },
+    {
+      scenario: `a truncated record line`,
+      input: `${JSON.stringify(systingHeader)}\n["f", 1, "main`,
+    },
+  ])(`parse classifies $scenario as invalid JSON`, ({ input }) => {
+    let thrown
+    try {
+      parseSysting(new TextEncoder().encode(input))
+    } catch (error: unknown) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(FormatParseError)
+    expect((thrown as Error).message).toMatch(/^invalid JSON: /u)
+    expect((thrown as Error).cause).toBeInstanceOf(SyntaxError)
   })
 
   test(`parse rejects records that aren't arrays`, () => {

--- a/src/formats/systing/parse.ts
+++ b/src/formats/systing/parse.ts
@@ -13,6 +13,7 @@ import {
 } from '../../modalities/metrics.ts'
 import type { StackFrame } from '../../modalities/stack-frame.ts'
 import { FormatParseError } from '../error.ts'
+import { parseJson } from '../parse.ts'
 
 export const parseSysting = (bytes: Uint8Array): CallStackProfile[] => {
   const builder = new SystingProfileBuilder()
@@ -162,7 +163,7 @@ class SystingProfileBuilder {
   }
 
   #addRecord(line: string): void {
-    const record: unknown = JSON.parse(line)
+    const record = parseJson(line)
     if (!Array.isArray(record)) {
       throw new FormatParseError(`record is not an array`)
     }
@@ -305,12 +306,7 @@ const cpuMetric = (header: SystingHeader): Metric | undefined => {
  * stack order is unsupported.
  */
 const parseSystingHeader = (line: string): SystingHeader => {
-  let json: unknown
-  try {
-    json = JSON.parse(line)
-  } catch {
-    throw new FormatParseError(`header is not JSON`)
-  }
+  const json = parseJson(line)
   if (typeof json !== `object` || json === null || Array.isArray(json)) {
     throw new FormatParseError(`header is not an object`)
   }


### PR DESCRIPTION
A specified format could not prefix a JSON or protobuf decoding failure with its title, because JSON.parse and pprof-format threw their own errors and the pipeline prefixes only a FormatParseError. The call sites now wrap both in a FormatParseError, so a specified format reports `invalid JSON` or `invalid protobuf encoding` as its own rejection, and auto-detection reports an unusable JSON document the same way.

The JSON decoder reads the caller's data while it decodes, so an error the data throws would now read as invalid JSON. The pipeline marks an error thrown by a read and rethrows it unwrapped.