### PR TITLE
fix: report an unclassified parse failure as unusable input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,8 @@ profiler-md
 │   ├── formats/                  # Individual profile format implementations
 │   │   ├── converter.ts          # Format converter types
 │   │   ├── registry.ts           # Format converter registry
-│   │   ├── error.ts              # Parse and detection error classes
-│   │   ├── parse.ts              # JSON decode and specified-format parse wrappers that report a rejection as the format's
+│   │   ├── error.ts              # Parse, rejection, and detection error classes, and the bug report caveat check
+│   │   ├── parse.ts              # JSON decode and specified-format parse wrappers that classify a parse failure
 │   │   ├── detect.ts             # Format auto-detection and its undetected-format error
 │   │   ├── aggregate.ts          # Parsed input to aggregated input dispatch across modalities, with origin detection
 │   │   ├── format.ts             # Aggregated input and diff to Markdown dispatch across modalities
@@ -263,6 +263,17 @@ pnpm generate-inputs go ruby   # Limit to named workload scripts
   accept anything of the format, including a version or variant the parser
   rejects, so auto-detection reports that reason instead of an undetectable
   input
+- The pipeline classifies a failure `parse` throws by the error's class, at the
+  boundary it catches it. A `FormatParseError` is a violation the parser
+  identified. Any other error escaping `parse` is one the parser did not
+  classify: the input violates the format in a way the parser does not check, or
+  the parser has a bug. The pipeline reports both as unusable input. It reports
+  the second as `<title>: failed to parse the input: <reason>`, and the CLI adds
+  a bug report caveat to it (`mayBeParserBug`). The classification is the same
+  under auto-detection and a specified format, and the same for an error a
+  parsed input's lazy iterable throws while aggregation consumes it. An error
+  the caller's data throws while `parse` reads it is the caller's, and the
+  pipeline rethrows it unwrapped. Any other error after `parse` is a bug
 - Wrap a third-party decoder's error (e.g. `JSON.parse`) in a `FormatParseError`
   at its call site. The parser cannot check anything before decoding succeeds,
   so a decoding failure is the input's, however the decoder reports it
@@ -286,7 +297,13 @@ pnpm generate-inputs go ruby   # Limit to named workload scripts
 ### Parsing
 
 - Cast untyped profile data to typed data for performance. Validate only when
-  necessary to make progress
+  necessary to make progress. Check the shape of what a lazy iterable reads
+  (e.g. that `samples` is an array) before `parse` returns, because
+  auto-detection moves on to the next format only while `parse` is running.
+  Check for a wrong cast that would crash formatting, because the pipeline
+  reports that error as a bug. NEVER add a check to a parser for a nicer message
+  alone: the pipeline already reports an error escaping `parse` as unusable
+  input
 - Parse a specified format to its spec, accepting every shape the spec allows.
   Add handling for a shape the spec forbids only when an input contains it, and
   name the emitter that writes it in a comment

--- a/src/cli/error.ts
+++ b/src/cli/error.ts
@@ -1,4 +1,6 @@
+import packageJson from '../../package.json' with { type: 'json' }
 import { ProfilerMdError } from '../error.ts'
+import { unclassifiedParseFailures } from '../formats/error.ts'
 
 export class CliError extends ProfilerMdError {
   public readonly exitCode: 1 | 2
@@ -14,16 +16,27 @@ export class CliError extends ProfilerMdError {
 export const reportError = (error: unknown): never => {
   if (error instanceof ProfilerMdError) {
     process.stderr.write(`error: ${error.message}\n`)
+    const parseFailures = unclassifiedParseFailures(error)
+    if (parseFailures.length > 0) {
+      process.stderr.write(
+        [
+          `If the input opens in its profiler, report this as a bug in ${packageJson.name}:`,
+          `${packageJson.bugs.url}/new`,
+          `Include the command you ran, the input if you can share it, and this trace:`,
+          ...parseFailures.map(stackOf),
+          ``,
+        ].join(`\n`),
+      )
+    }
     process.exit(error instanceof CliError ? error.exitCode : 1)
   }
 
-  if (error instanceof Error) {
-    process.stderr.write(
-      error.stack ? `${error.stack}\n` : `error: ${error.message}\n`,
-    )
-    process.exit(1)
-  }
-
-  process.stderr.write(`error: ${String(error)}\n`)
+  process.stderr.write(`${stackOf(error)}\n`)
   process.exit(1)
 }
+
+/** An error's stack trace, or its description when it has none. */
+const stackOf = (error: unknown): string =>
+  error instanceof Error
+    ? (error.stack ?? `${error.name}: ${error.message}`)
+    : `error: ${String(error)}`

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -13,6 +13,10 @@ import {
   inputPath,
   smallestInput,
 } from '../formats/testing.ts'
+import {
+  crashingV8CpuProfile,
+  lazilyCrashingV8CpuProfile,
+} from '../formats/v8/cpu-profile/testing.ts'
 import { languageExtensionToPrimary } from './languages.ts'
 
 // Each test spawns the CLI in a subprocess, which can outlast the default 5s.
@@ -635,6 +639,64 @@ if (format === undefined) {
       )
 
       await rm(dir, { recursive: true })
+    },
+  )
+
+  test.concurrent.each([
+    {
+      scenario: `under an explicit format`,
+      args: [`--format`, `v8-cpu-profile`],
+      input: crashingV8CpuProfile,
+    },
+    {
+      scenario: `under auto-detection`,
+      args: [],
+      input: crashingV8CpuProfile,
+    },
+    {
+      scenario: `lazily, under an explicit format`,
+      args: [`--format`, `v8-cpu-profile`],
+      input: lazilyCrashingV8CpuProfile,
+    },
+    {
+      scenario: `lazily, under auto-detection`,
+      args: [],
+      input: lazilyCrashingV8CpuProfile,
+    },
+  ])(
+    `reports an input that crashes a parser as unusable, with a bug report caveat, $scenario`,
+    async ({ args, input }) => {
+      const { status, stderr } = await runCli(args, input)
+
+      expect(status).toBe(1)
+      const [errorLine, ...caveatLines] = stderr.split(`\n`)
+      expect(errorLine).toContain(
+        `error: V8 CPU profile: failed to parse the input: `,
+      )
+      const traceLines = caveatLines.splice(3)
+      expect(caveatLines).toEqual([
+        `If the input opens in its profiler, report this as a bug in ${packageJson.name}:`,
+        `${packageJson.bugs.url}/new`,
+        `Include the command you ran, the input if you can share it, and this trace:`,
+      ])
+      expect(traceLines[0]).toMatch(/^TypeError: /u)
+      expect(
+        traceLines.slice(1, -1).every(line => line.startsWith(`    at `)),
+      ).toBe(true)
+      expect(traceLines.at(-1)).toBe(``)
+    },
+  )
+
+  test.concurrent(
+    `reports a classified rejection without a bug report caveat`,
+    async () => {
+      const { status, stderr } = await runCli(
+        [`--format`, `collapsed`],
+        `funcA;funcB`,
+      )
+
+      expect(status).toBe(1)
+      expect(stderr).toBe(`error: Collapsed stacks: missing sample count\n`)
     },
   )
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -3,7 +3,10 @@
  * format, a malformed profile, an invalid option.
  *
  * A failure the caller cannot fix throws a plain `Error` instead, because such
- * a failure is a bug in this package.
+ * a failure is a bug in this package. The exception is a parser failing on an
+ * error it did not classify, which is either an input violating the format in
+ * a way the parser does not check or a parser bug. That failure throws a
+ * `ProfilerMdError` too, and `mayBeParserBug` identifies it.
  */
 export class ProfilerMdError extends Error {
   public constructor(message: string, options?: ErrorOptions) {

--- a/src/formats/detect.ts
+++ b/src/formats/detect.ts
@@ -8,7 +8,7 @@ import type {
   ParsedInput,
 } from './converter.ts'
 import { FormatDetectError } from './error.ts'
-import { describeParseFailure } from './parse.ts'
+import { classifyLazyParseFailures, describeParseFailure } from './parse.ts'
 import { formatConverters, formats } from './registry.ts'
 import type { Format } from './registry.ts'
 
@@ -85,7 +85,7 @@ const detectWithConverter = <Input>(
   }
 
   try {
-    return converter.parse(input)
+    return classifyLazyParseFailures(converter, converter.parse(input))
   } catch (error: unknown) {
     rejections.push({ converter, error })
     return undefined

--- a/src/formats/error.ts
+++ b/src/formats/error.ts
@@ -34,3 +34,48 @@ export class FormatDetectError extends ProfilerMdError {
     this.errors = errors
   }
 }
+
+/**
+ * Thrown when the format the caller specified rejected the input.
+ *
+ * {@link FormatRejectionError.cause} is the error the format's parse threw.
+ */
+export class FormatRejectionError extends ProfilerMdError {
+  public constructor(message: string, options: ErrorOptions) {
+    super(message, options)
+    // eslint-disable-next-line stylistic/quotes
+    this.name = 'FormatRejectionError'
+  }
+}
+
+/**
+ * Whether a conversion error may be a bug in this package rather than an
+ * unusable input.
+ *
+ * A parse that throws a {@link FormatParseError} identified the violation. One
+ * that throws anything else failed on an error it did not classify: either the
+ * input violates the format in a way the parser does not check, or the parser
+ * has a bug. The pipeline reports both as unusable input, because the parser's
+ * input is the only variable on its code path. A caller whose input opens in
+ * its profiler has the evidence that distinguishes the two.
+ */
+export const mayBeParserBug = (error: unknown): boolean =>
+  unclassifiedParseFailures(error).length > 0
+
+/**
+ * The errors a conversion error wraps that a parser threw without classifying
+ * them, in detection order. Empty when the error is not a conversion error, or
+ * when every wrapped error is a {@link FormatParseError}.
+ */
+export const unclassifiedParseFailures = (error: unknown): unknown[] => {
+  if (error instanceof FormatDetectError) {
+    return error.errors.filter(isUnclassifiedParseFailure)
+  }
+  if (error instanceof FormatRejectionError) {
+    return isUnclassifiedParseFailure(error.cause) ? [error.cause] : []
+  }
+  return []
+}
+
+const isUnclassifiedParseFailure = (error: unknown): boolean =>
+  !(error instanceof FormatParseError)

--- a/src/formats/index.test.ts
+++ b/src/formats/index.test.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync } from 'node:fs'
 import { describe, expect, test, vi } from 'vitest'
 import { projects } from '../../vitest.config.ts'
 import { parseExampleFilename } from '../cli/examples.ts'
+import { ProfilerMdError } from '../error.ts'
 import { sourceReferenceId } from '../location.ts'
 import type { CallStackProfile } from '../modalities/call-stack-profile/index.ts'
 import {
@@ -12,7 +13,7 @@ import { SAMPLES } from '../modalities/metrics.ts'
 import { normalizeProfileToMdOptions } from '../options.ts'
 import { categoryTables, profileTitles, rankingTables } from '../testing.ts'
 import type { JsonFormatConverter } from './converter.ts'
-import { FormatDetectError } from './error.ts'
+import { FormatDetectError, mayBeParserBug } from './error.ts'
 import {
   diffProfiles,
   diffProfilesAsync,
@@ -29,6 +30,8 @@ import {
   smallestInput,
 } from './testing.ts'
 import {
+  crashingV8CpuProfile,
+  lazilyCrashingV8CpuProfile,
   makeV8CallFrame,
   makeV8CpuProfileRoot,
 } from './v8/cpu-profile/testing.ts'
@@ -533,6 +536,112 @@ describe(`profileToMd`, () => {
       expect(() => profileToMd({ data: `garbage\n`, format: `pprof` })).toThrow(
         /^pprof: invalid protobuf encoding: /u,
       )
+    })
+
+    const unclassifiedInputs = [
+      { scenario: `before parse returns`, data: crashingV8CpuProfile },
+      {
+        scenario: `while aggregation consumes the parse's lazy iterable`,
+        data: lazilyCrashingV8CpuProfile,
+      },
+    ]
+
+    test.each(unclassifiedInputs)(
+      `a specified format reports an error its parser did not classify as a failure to parse, thrown $scenario`,
+      ({ data }) => {
+        let thrown
+        try {
+          profileToMd({ data, format: `v8-cpu-profile` })
+        } catch (error: unknown) {
+          thrown = error
+        }
+
+        expect(thrown).toBeInstanceOf(ProfilerMdError)
+        expect((thrown as Error).message).toMatch(
+          /^V8 CPU profile: failed to parse the input: /u,
+        )
+        expect(mayBeParserBug(thrown)).toBe(true)
+      },
+    )
+
+    test.each(unclassifiedInputs)(
+      `a specified format reports an error its parser did not classify as a failure to parse when async, thrown $scenario`,
+      async ({ data }) => {
+        let thrown
+        try {
+          await profileToMdAsync({
+            data: new Blob([data]),
+            format: `v8-cpu-profile`,
+          })
+        } catch (error: unknown) {
+          thrown = error
+        }
+
+        expect(thrown).toBeInstanceOf(ProfilerMdError)
+        expect((thrown as Error).message).toMatch(
+          /^V8 CPU profile: failed to parse the input: /u,
+        )
+        expect(mayBeParserBug(thrown)).toBe(true)
+      },
+    )
+
+    test.each(unclassifiedInputs)(
+      `detection reports an error a parser did not classify the same way a specified format does, thrown $scenario`,
+      ({ data }) => {
+        let detected
+        try {
+          profileToMd(data)
+        } catch (error: unknown) {
+          detected = error
+        }
+        let specified
+        try {
+          profileToMd({ data, format: `v8-cpu-profile` })
+        } catch (error: unknown) {
+          specified = error
+        }
+
+        expect((detected as Error).message).toBe((specified as Error).message)
+        expect(mayBeParserBug(detected)).toBe(true)
+      },
+    )
+
+    test(`a rejection the parser classified is not a possible bug`, () => {
+      let thrown
+      try {
+        profileToMd({ data: `funcA;funcB`, format: `collapsed` })
+      } catch (error: unknown) {
+        thrown = error
+      }
+
+      expect(mayBeParserBug(thrown)).toBe(false)
+    })
+
+    test.each([
+      { scenario: `under auto-detection`, format: undefined },
+      { scenario: `under a specified format`, format: `hprof` as const },
+    ])(
+      `a rejection's message collapses the whitespace of the value it reports, $scenario`,
+      ({ format }) => {
+        const data = new TextEncoder().encode(
+          `JAVA PROFILE \nfoo\n  1.0\tbar\0${`\0`.repeat(20)}`,
+        )
+
+        expect(() => profileToMd(format ? { data, format } : data)).toThrow(
+          `HPROF: unsupported format name, got: JAVA PROFILE foo 1.0 bar`,
+        )
+      },
+    )
+
+    test(`a specified format's rejection wraps the parser's error as its cause`, () => {
+      let thrown
+      try {
+        profileToMd({ data: crashingV8CpuProfile, format: `v8-cpu-profile` })
+      } catch (error: unknown) {
+        thrown = error
+      }
+
+      expect((thrown as Error).cause).toBeInstanceOf(TypeError)
     })
 
     describe(`a failure to read the data escapes unwrapped`, () => {

--- a/src/formats/parse.ts
+++ b/src/formats/parse.ts
@@ -1,14 +1,14 @@
 import { JumboJSON } from 'jumbo-json'
-import { ProfilerMdError, reasonOf } from '../error.ts'
+import { reasonOf } from '../error.ts'
 import { concatUint8Arrays } from '../helpers/bytes.ts'
 import type { AsyncProfileData, ProfileData } from '../options.ts'
 import type { FormatConverter, ParsedInput } from './converter.ts'
-import { FormatParseError } from './error.ts'
+import { FormatParseError, FormatRejectionError } from './error.ts'
 
 /**
- * Parses the input as the format the caller specified, reporting a rejection
- * as that format's, so the caller receives the reason and the format that
- * rejected the input.
+ * Parses the input as the format the caller specified, reporting a failure as
+ * that format's rejection, so the caller receives the reason and the format
+ * that rejected the input.
  *
  * A failure to read the input is the input's own error, and escapes unwrapped.
  */
@@ -19,17 +19,20 @@ export const parseAsFormat = (
   if (converter.type === `binary`) {
     const bytes = dataToBytes(data)
     try {
-      return converter.parse(bytes)
+      return classifyLazyParseFailures(converter, converter.parse(bytes))
     } catch (error: unknown) {
-      throw toFormatRejection(converter, error)
+      throw toFormatRejectionError(converter, error)
     }
   }
 
   try {
-    return converter.parse(parseJson(data))
+    return classifyLazyParseFailures(
+      converter,
+      converter.parse(parseJson(data)),
+    )
   } catch (error: unknown) {
     rethrowInputReadFailure(error)
-    throw toFormatRejection(converter, error)
+    throw toFormatRejectionError(converter, error)
   }
 }
 
@@ -38,15 +41,73 @@ export const parseAsFormatAsync = async (
   data: AsyncProfileData,
 ): Promise<ParsedInput[]> => {
   try {
-    return converter.type === `json`
-      ? converter.parse(await parseJsonAsync(data))
-      : // Stream the binary data when possible.
-        await converter.parseAsync(guardStreamReads(dataToStream(data)))
+    return classifyLazyParseFailures(
+      converter,
+      converter.type === `json`
+        ? converter.parse(await parseJsonAsync(data))
+        : // Stream the binary data when possible.
+          await converter.parseAsync(guardStreamReads(dataToStream(data))),
+    )
   } catch (error: unknown) {
     rethrowInputReadFailure(error)
-    throw toFormatRejection(converter, error)
+    throw toFormatRejectionError(converter, error)
   }
 }
+
+/**
+ * Wraps each lazily consumed iterable of the parsed inputs, so an error the
+ * parser throws while aggregation consumes it is classified the same way as
+ * one it throws before returning.
+ *
+ * The wrapper is a plain iterator object, because a delegating generator costs
+ * more per item.
+ */
+export const classifyLazyParseFailures = (
+  converter: FormatConverter,
+  parsed: ParsedInput[],
+): ParsedInput[] => {
+  const toError = (error: unknown): FormatRejectionError =>
+    toFormatRejectionError(converter, error)
+  return parsed.map(input => {
+    switch (input.type) {
+      case `call-stack-profile`:
+        return {
+          ...input,
+          observations: classifyIterableFailures(input.observations, toError),
+          ...(input.lineMetrics && {
+            lineMetrics: classifyIterableFailures(input.lineMetrics, toError),
+          }),
+        }
+      case `call-graph`:
+        return input
+      case `heap-snapshot`:
+        return {
+          ...input,
+          nodes: classifyIterableFailures(input.nodes, toError),
+        }
+    }
+  })
+}
+
+const classifyIterableFailures = <Value>(
+  iterable: Iterable<Value>,
+  toError: (error: unknown) => Error,
+): Iterable<Value> => ({
+  [Symbol.iterator]: () => {
+    const iterator = iterable[Symbol.iterator]()
+    return {
+      next: () => {
+        try {
+          return iterator.next()
+        } catch (error: unknown) {
+          throw toError(error)
+        }
+      },
+      return: value =>
+        iterator.return?.(value) ?? { done: true, value: undefined },
+    }
+  },
+})
 
 /**
  * Decodes JSON, wrapping a decoding failure in a {@link FormatParseError}.
@@ -156,22 +217,27 @@ export const dataToBytes = (data: ProfileData): Uint8Array => {
 
 let textEncoder: InstanceType<typeof TextEncoder> | undefined
 
-/**
- * Prefixes a {@link FormatParseError} with the format's title. Any other error
- * passes through, because it reports a bug instead of an unusable input.
- */
-const toFormatRejection = (
+const toFormatRejectionError = (
   converter: FormatConverter,
   error: unknown,
-): unknown =>
-  error instanceof FormatParseError
-    ? new ProfilerMdError(`${converter.title}: ${error.message}`, {
-        cause: error,
-      })
-    : error
+): FormatRejectionError =>
+  new FormatRejectionError(describeParseFailure(converter, error), {
+    cause: error,
+  })
 
-/** A parse's failure as `<title>: <reason>`. */
+/**
+ * A parse's failure as `<title>: <reason>`.
+ *
+ * A {@link FormatParseError}'s message states the violation the parser
+ * identified. The parser did not classify any other error, so its reason is
+ * `failed to parse the input: <message>`.
+ */
 export const describeParseFailure = (
   converter: FormatConverter,
   error: unknown,
-): string => `${converter.title}: ${reasonOf(error)}`
+): string =>
+  `${converter.title}: ${
+    error instanceof FormatParseError
+      ? reasonOf(error)
+      : `failed to parse the input: ${reasonOf(error)}`
+  }`

--- a/src/formats/v8/cpu-profile/testing.ts
+++ b/src/formats/v8/cpu-profile/testing.ts
@@ -18,3 +18,27 @@ export const makeV8CpuProfileRoot = (children: number[]): V8CpuProfileNode => ({
   callFrame: makeV8CallFrame(`(root)`, ``),
   children,
 })
+
+/**
+ * A serialized input that passes the format's `matches` prefilter and crashes
+ * its parse on a shape the parser does not check.
+ */
+export const crashingV8CpuProfile = JSON.stringify({
+  nodes: [{ id: 1, callFrame: null }],
+  timeDeltas: [1],
+})
+
+/**
+ * A serialized input that passes the format's `matches` prefilter and parses,
+ * then crashes the observations its parse returns lazily.
+ */
+export const lazilyCrashingV8CpuProfile = JSON.stringify({
+  nodes: [
+    {
+      id: 1,
+      callFrame: makeV8CallFrame(`a`, ``),
+    },
+  ],
+  samples: null,
+  timeDeltas: [1],
+})


### PR DESCRIPTION
A parser that crashed on a shape it does not check threw a plain Error, so the run printed a stack trace. Because only the input varies on a parser's code path, the pipeline now reports any error escaping parse as `<title>: failed to parse the input: <reason>`, the same way under a specified format and auto-detection, and the same for an error a parsed input's lazy iterable throws while aggregation consumes it. The CLI adds a caveat asking for a bug report when the input opens in its profiler, since that is the evidence that distinguishes an unchecked input from a parser bug.