### PR TITLE
fix(cli): report an unexpected error as a bug

### DIFF
--- a/src/cli/error.test.ts
+++ b/src/cli/error.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import packageJson from '../../package.json' with { type: 'json' }
+import { ProfilerMdError } from '../error.ts'
+import { CliError, reportError } from './error.ts'
+
+const EXIT = `process.exit`
+
+const exit = vi.spyOn(process, `exit`).mockImplementation(() => {
+  throw new Error(EXIT)
+})
+const stderr: string[] = []
+vi.spyOn(process.stderr, `write`).mockImplementation(chunk => {
+  stderr.push(String(chunk))
+  return true
+})
+
+afterEach(() => {
+  exit.mockClear()
+  stderr.length = 0
+})
+
+test(`reports a plain error as a bug, with its trace`, () => {
+  const error = new Error(`the invariant broke`)
+
+  expect(() => reportError(error)).toThrow(EXIT)
+
+  const [errorLine, ...caveatLines] = stderr.join(``).split(`\n`)
+  expect(errorLine).toBe(`error: the invariant broke`)
+  const traceLines = caveatLines.splice(3)
+  expect(caveatLines).toEqual([
+    `This is a bug in ${packageJson.name}. Report it:`,
+    `${packageJson.bugs.url}/new`,
+    `Include the command you ran, the input if you can share it, and this trace:`,
+  ])
+  expect(traceLines[0]).toBe(`Error: the invariant broke`)
+  expect(
+    traceLines.slice(1, -1).every(line => line.startsWith(`    at `)),
+  ).toBe(true)
+  expect(traceLines.at(-1)).toBe(``)
+  expect(exit).toHaveBeenCalledExactlyOnceWith(1)
+})
+
+test(`reports a thrown non-error as a bug`, () => {
+  expect(() => reportError(`oops`)).toThrow(EXIT)
+
+  expect(stderr.join(``)).toBe(
+    [
+      `error: oops`,
+      `This is a bug in ${packageJson.name}. Report it:`,
+      `${packageJson.bugs.url}/new`,
+      `Include the command you ran, the input if you can share it, and this trace:`,
+      `error: oops`,
+      ``,
+    ].join(`\n`),
+  )
+  expect(exit).toHaveBeenCalledExactlyOnceWith(1)
+})
+
+test.each([
+  { error: new ProfilerMdError(`bad input`), exitCode: 1 },
+  { error: new CliError(`bad flag`, 2), exitCode: 2 },
+])(
+  `reports a $error.name without a bug report, exiting with $exitCode`,
+  ({ error, exitCode }) => {
+    expect(() => reportError(error)).toThrow(EXIT)
+
+    expect(stderr.join(``)).toBe(`error: ${error.message}\n`)
+    expect(exit).toHaveBeenCalledExactlyOnceWith(exitCode)
+  },
+)

--- a/src/cli/error.ts
+++ b/src/cli/error.ts
@@ -1,5 +1,5 @@
 import packageJson from '../../package.json' with { type: 'json' }
-import { ProfilerMdError } from '../error.ts'
+import { ProfilerMdError, reasonOf } from '../error.ts'
 import { unclassifiedParseFailures } from '../formats/error.ts'
 
 export class CliError extends ProfilerMdError {
@@ -19,21 +19,31 @@ export const reportError = (error: unknown): never => {
     const parseFailures = unclassifiedParseFailures(error)
     if (parseFailures.length > 0) {
       process.stderr.write(
-        [
+        bugReport(
           `If the input opens in its profiler, report this as a bug in ${packageJson.name}:`,
-          `${packageJson.bugs.url}/new`,
-          `Include the command you ran, the input if you can share it, and this trace:`,
-          ...parseFailures.map(stackOf),
-          ``,
-        ].join(`\n`),
+          parseFailures,
+        ),
       )
     }
     process.exit(error instanceof CliError ? error.exitCode : 1)
   }
 
-  process.stderr.write(`${stackOf(error)}\n`)
+  process.stderr.write(`error: ${reasonOf(error)}\n`)
+  process.stderr.write(
+    bugReport(`This is a bug in ${packageJson.name}. Report it:`, [error]),
+  )
   process.exit(1)
 }
+
+/** The bug report request that follows an error line, with the given traces. */
+const bugReport = (request: string, errors: readonly unknown[]): string =>
+  [
+    request,
+    `${packageJson.bugs.url}/new`,
+    `Include the command you ran, the input if you can share it, and this trace:`,
+    ...errors.map(stackOf),
+    ``,
+  ].join(`\n`)
 
 /** An error's stack trace, or its description when it has none. */
 const stackOf = (error: unknown): string =>


### PR DESCRIPTION
An error that was not a ProfilerMdError, an invariant violation or a thrown non-error, printed a bare stack trace. Nothing stated that the trace was a bug in this package or where to report it, and the output did not start with the `error:` line every other failure prints.

The CLI now prints the error line, then the same bug report request the unclassified parse failure caveat prints, with the trace after it. Both build the request with one helper, so the two bug reports ask for the same things.