### PR TITLE
fix(cli): treat ENOTCONN as a closed reader when writing the output

### DIFF
--- a/src/cli/error.ts
+++ b/src/cli/error.ts
@@ -50,3 +50,14 @@ const stackOf = (error: unknown): string =>
   error instanceof Error
     ? (error.stack ?? `${error.name}: ${error.message}`)
     : `error: ${String(error)}`
+
+/**
+ * Whether a write failed because the reader closed its end of the pipe.
+ *
+ * The code is `EPIPE` on every platform. On macOS, Node creates a child's
+ * pipes as unix-domain socketpairs, so the kernel returns `ENOTCONN` instead
+ * when the peer closes while the write is between its connection check and its
+ * send.
+ */
+export const isClosedReaderError = (error: NodeJS.ErrnoException): boolean =>
+  error.code === `EPIPE` || error.code === `ENOTCONN`

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -2,7 +2,7 @@ import { createWriteStream } from 'node:fs'
 import { access, constants, stat } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { reasonOf } from '../error.ts'
-import { CliError } from './error.ts'
+import { CliError, isClosedReaderError } from './error.ts'
 import { openPager } from './pager.ts'
 
 export type Output = {
@@ -64,11 +64,10 @@ const openOutput = async (outputPath: string): Promise<Output> => {
       write: text =>
         new Promise((resolve, reject) => {
           // A reader such as `head` can close the pipe before the write
-          // finishes, failing the write with `EPIPE` and emitting an `error`
-          // event that would otherwise go unhandled. A closed pipe is a normal
-          // exit.
+          // finishes, failing the write and emitting an `error` event that
+          // would otherwise go unhandled. A closed pipe is a normal exit.
           const finish = (error?: NodeJS.ErrnoException | null) => {
-            if (!error || error.code === `EPIPE`) {
+            if (!error || isClosedReaderError(error)) {
               resolve()
             } else {
               reject(error)

--- a/src/cli/pager.ts
+++ b/src/cli/pager.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import type { ChildProcessByStdio } from 'node:child_process'
 import type { Writable } from 'node:stream'
+import { isClosedReaderError } from './error.ts'
 import type { Output } from './output.ts'
 
 /**
@@ -102,10 +103,10 @@ const writeStdin = (child: PagerProcess, text: string): Promise<void> =>
   new Promise((resolve, reject) => {
     const finish = (error?: NodeJS.ErrnoException | null) => {
       // Quitting the pager (e.g. `q` in `less`) before the write finishes
-      // fails the write, a normal exit path. The code is `EPIPE` when the
-      // pager closed its stdin first, and `ECANCELED` when Node destroyed the
-      // pipe on the pager's exit first.
-      if (!error || error.code === `EPIPE` || error.code === `ECANCELED`) {
+      // fails the write, a normal exit path. The code is `ECANCELED` when Node
+      // destroyed the pipe on the pager's exit before the pager closed its
+      // stdin.
+      if (!error || isClosedReaderError(error) || error.code === `ECANCELED`) {
         resolve()
       } else {
         reject(error)


### PR DESCRIPTION
A reader such as `head` that closed the pipe failed the write with EPIPE, which the CLI treats as a normal exit. On macOS, Node creates a child's pipes as unix-domain socketpairs, so the kernel returns ENOTCONN instead when the peer closes while the write is between its connection check and its send, and the CLI reported the unhandled error.

The stdout and pager writers now share one check that accepts both codes.