### PR TITLE
feat(cli): color the help in the Kindling theme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ profiler-md
 │   │   ├── output.ts             # Writes Markdown to file or stdout (optionally paged)
 │   │   ├── pager.ts              # Spawns $PAGER or `less` for stdout output
 │   │   ├── highlight-markdown.ts # ANSI Markdown syntax highlighting for stdout
+│   │   ├── highlight-help.ts     # ANSI highlighting of the help text in the Kindling theme
 │   │   ├── theme-kindling.ts     # Custom Shiki theme for syntax highlighting
 │   │   ├── logo.ts               # ASCII art logo printed to stderr by --version
 │   │   ├── ansis.ts              # ANSI color helpers (respects TTY/no-color)

--- a/src/cli/ansis.ts
+++ b/src/cli/ansis.ts
@@ -1,5 +1,14 @@
 import { Ansis } from 'ansis'
 
+export const stdoutSupportsColor = (): boolean =>
+  streamSupportsColor(process.stdout)
+
+export const stderrSupportsColor = (): boolean =>
+  streamSupportsColor(process.stderr)
+
+const streamSupportsColor = (stream: NodeJS.WriteStream): boolean =>
+  makeAnsis({ isTTY: Boolean(stream.isTTY) }).isSupported()
+
 export type MakeAnsisOptions = {
   /** Whether the stream the styled text is written to is a TTY. */
   isTTY: boolean

--- a/src/cli/error.ts
+++ b/src/cli/error.ts
@@ -1,7 +1,9 @@
 import packageJson from '../../package.json' with { type: 'json' }
 import { ProfilerMdError, reasonOf } from '../error.ts'
 import { unclassifiedParseFailures } from '../formats/error.ts'
+import { stderrSupportsColor } from './ansis.ts'
 import { getUsageHint } from './help.ts'
+import { highlightErrorPrefix } from './highlight-help.ts'
 
 export class CliError extends ProfilerMdError {
   public readonly exitCode: 1 | 2
@@ -16,7 +18,10 @@ export class CliError extends ProfilerMdError {
 
 export const reportError = (error: unknown): never => {
   if (error instanceof ProfilerMdError) {
-    process.stderr.write(`error: ${error.message}\n`)
+    const colors = stderrSupportsColor()
+    process.stderr.write(
+      `${highlightErrorPrefix(`error: ${error.message}`, { colors })}\n`,
+    )
     const parseFailures = unclassifiedParseFailures(error)
     if (parseFailures.length > 0) {
       process.stderr.write(
@@ -29,7 +34,7 @@ export const reportError = (error: unknown): never => {
     const exitCode = error instanceof CliError ? error.exitCode : 1
     // Exit code 2 is an invocation error, which the synopsis helps correct
     if (exitCode === 2) {
-      process.stderr.write(getUsageHint())
+      process.stderr.write(getUsageHint({ colors }))
     }
     process.exit(exitCode)
   }

--- a/src/cli/help.test.ts
+++ b/src/cli/help.test.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
+import ansis from 'ansis'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import packageJson from '../../package.json' with { type: 'json' }
 import { formats } from '../formats/index.ts'
@@ -112,6 +113,21 @@ test(`getHelpText lists the flags runParser adds and the project URLs`, () => {
   expect(help).toContain(`\n  --completion SHELL `)
   expect(help).toContain(`\nDocs: ${packageJson.homepage}\n`)
   expect(help).toContain(`\nBugs: ${packageJson.bugs.url}\n`)
+})
+
+test(`getHelpText colors only the styling, leaving the layout intact`, () => {
+  setStdoutColumns(80)
+  const plain = getHelpText()
+
+  vi.stubEnv(`FORCE_COLOR`, `3`)
+  const colored = getHelpText({ colors: true })
+
+  expect(colored).not.toBe(plain)
+
+  expect(ansis.strip(colored)).toBe(
+    // Inline code loses its backticks when colored
+    plain.replaceAll(`\``, ``),
+  )
 })
 
 test(`getSections keeps every option in a titled section`, () => {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -10,8 +10,10 @@ import type { Format } from '../formats/index.ts'
 import { HEAP_SNAPSHOT_NODE_CATEGORIES } from '../modalities/heap-snapshot/type.ts'
 import { FUNCTION_CATEGORIES } from '../options.ts'
 import { origins } from '../origins/index.ts'
+import { stdoutSupportsColor } from './ansis.ts'
 import { helpTopics, inputParser, program } from './cli.ts'
 import { CliError } from './error.ts'
+import { highlightHelp, INDENT } from './highlight-help.ts'
 import { highlightMarkdown } from './highlight-markdown.ts'
 import {
   languageAliasToPrimary,
@@ -30,7 +32,9 @@ export const printHelpTopic = async (
   { pager }: PrintHelpTopicOptions,
 ): Promise<never> => {
   if (topic === undefined) {
-    await writeOutput(getHelpText(), `-`, { pager })
+    await writeOutput(getHelpText({ colors: stdoutSupportsColor() }), `-`, {
+      pager,
+    })
     process.exit(0)
   }
 
@@ -91,14 +95,20 @@ const seeAlsoTopics = (helpTopic: HelpTopic): string[] => {
 }
 
 export const printBriefHelp = (): never => {
-  process.stdout.write(getBriefHelpText())
+  process.stdout.write(getBriefHelpText({ colors: stdoutSupportsColor() }))
   process.exit(0)
 }
 
-export const getHelpText = (): string => {
+export type HelpTextOptions = {
+  colors?: boolean
+}
+
+export const getHelpText = ({
+  colors = false,
+}: HelpTextOptions = {}): string => {
   const maxWidth = getMaxWidth()
   const sections = getSections()
-  return [
+  const text = [
     getHeaderText(maxWidth),
     formatDocPage(
       program.metadata.name,
@@ -108,17 +118,20 @@ export const getHelpText = (): string => {
     ...LISTS.map(([label, items]) => formatList(label, items, maxWidth)),
     `\nDocs: ${packageJson.homepage}\nBugs: ${packageJson.bugs.url}\n`,
   ].join(``)
+  return highlightHelp(text, { colors })
 }
 
 /** The description, the synopsis, the examples, and where the rest of the help is. */
-export const getBriefHelpText = (): string => {
+export const getBriefHelpText = ({
+  colors = false,
+}: HelpTextOptions = {}): string => {
   const maxWidth = getMaxWidth()
   const { name } = program.metadata
   const footer = formatMessage(
     message`Run ${commandLine(`${name} --help`)} for every flag, ${commandLine(`${name} --help <language>`)} for how to profile a language, and ${commandLine(`${name} --help <format>`)} for what a format contains.`,
     { maxWidth },
   )
-  return `${getHeaderText(maxWidth)}\n${footer}\n`
+  return highlightHelp(`${getHeaderText(maxWidth)}\n${footer}\n`, { colors })
 }
 
 /**
@@ -237,7 +250,7 @@ export const formatUsageExamples = (indent = ``): string =>
     .join(`\n`)
 
 /** The synopsis and where the full help is. */
-export const getUsageHint = (): string => {
+export const getUsageHint = ({ colors = false } = {}): string => {
   const { name } = program.metadata
   const text = formatDocPage(
     name,
@@ -248,7 +261,7 @@ export const getUsageHint = (): string => {
     },
     { maxWidth: getMaxWidth() },
   )
-  return `\n${text}\n`
+  return highlightHelp(`\n${text}\n`, { colors })
 }
 
 export const getMaxWidth = (): number =>
@@ -260,9 +273,6 @@ export const getMaxWidth = (): number =>
 
 // Optique throws below the width its narrowest layout requires
 const MIN_WIDTH = 40
-
-/** The indentation of Optique's doc page entries. */
-const INDENT = `  `
 
 const LISTS: readonly (readonly [string, readonly string[]])[] = [
   [`Formats`, formats],

--- a/src/cli/highlight-help.ts
+++ b/src/cli/highlight-help.ts
@@ -1,0 +1,191 @@
+import type { Ansis } from 'ansis'
+import { makeAnsis } from './ansis.ts'
+import { kindlingColors } from './theme-kindling.ts'
+
+export type HighlightOptions = {
+  /** Whether to color the text. The text is returned as is otherwise. */
+  colors: boolean
+}
+
+/**
+ * Colors the plain help text in the Kindling theme by re-parsing its layout.
+ * Styling after layout keeps the columns aligned.
+ */
+export const highlightHelp = (
+  text: string,
+  { colors }: HighlightOptions,
+): string => {
+  if (!colors) {
+    return text
+  }
+
+  const palette = makePalette(makeAnsis({ isTTY: true }))
+  let section: Section = `entries`
+  return text
+    .split(`\n`)
+    .map(line => {
+      if (line === ``) {
+        return line
+      }
+
+      const label = /^(?<label>[A-Z][A-Za-z ]*):(?<rest>.*)$/u.exec(line)
+      if (label) {
+        const name = label.groups!.label!
+        const rest = label.groups!.rest!
+        section = sectionOf(name, rest)
+        return highlightLabelLine(name, rest, section, palette)
+      }
+
+      switch (section) {
+        case `usage`:
+          return highlightUsage(line, palette)
+        case `examples`:
+          return highlightExample(line, palette)
+        case `entries`:
+          return highlightEntry(line, palette)
+      }
+    })
+    .join(`\n`)
+}
+
+const highlightLabelLine = (
+  name: string,
+  rest: string,
+  section: Section,
+  palette: Palette,
+): string => {
+  const styledLabel = palette.label(`${name}:`)
+  if (rest === ``) {
+    return styledLabel
+  }
+  const content = rest.slice(1)
+  return `${styledLabel} ${section === `usage` ? highlightSyntax(content, palette) : palette.url(content)}`
+}
+
+type Section = `usage` | `examples` | `entries`
+
+const sectionOf = (label: string, rest: string): Section => {
+  if (label === `Examples`) {
+    return `examples`
+  }
+  if (rest === `` || /^ https?:/u.test(rest)) {
+    return `entries`
+  }
+  return `usage`
+}
+
+/** The indentation of Optique's doc page entries. */
+export const INDENT = `  `
+
+/** Styles a synopsis line wrapped under the label's content, or the prose after it. */
+const highlightUsage = (line: string, palette: Palette): string =>
+  /^ +\S/u.test(line)
+    ? highlightSyntax(line, palette)
+    : highlightProse(line, palette)
+
+const highlightExample = (line: string, palette: Palette): string => {
+  const comment = /^(?<indent> *)(?<comment>#.*)$/u.exec(line)
+  if (comment) {
+    return `${comment.groups!.indent}${palette.comment(comment.groups!.comment!)}`
+  }
+
+  const command = /^(?<indent> *)\$ (?<command>.*)$/u.exec(line)
+  if (command) {
+    return `${command.groups!.indent}${palette.punctuation(`$`)} ${highlightCommand(command.groups!.command!, palette)}`
+  }
+
+  return highlightProse(line, palette)
+}
+
+const highlightCommand = (command: string, palette: Palette): string =>
+  command.replaceAll(
+    /(?<option>(?<![\w.])--?[a-z][\w-]*)|(?:^|(?<=[|&] ))[\w-]+/gu,
+    (match, option?: string) =>
+      option ? palette.option(option) : palette.program(match),
+  )
+
+/**
+ * Styles a flag or argument entry, a list line, a wrapped description, or the
+ * prose between them, told apart by their indentation.
+ */
+const highlightEntry = (line: string, palette: Palette): string => {
+  const body = line.slice(INDENT.length)
+  if (line.startsWith(INDENT) && /^[-A-Z]/u.test(body)) {
+    return `${INDENT}${highlightTermLine(body, palette)}`
+  }
+
+  if (/^ {3,}/u.test(line)) {
+    return highlightProse(line, palette)
+  }
+
+  if (line.startsWith(INDENT)) {
+    return line.replaceAll(`,`, palette.punctuation(`,`))
+  }
+
+  return highlightProse(line, palette)
+}
+
+/** Styles an entry's term and, after the two-space gap, its description. */
+const highlightTermLine = (body: string, palette: Palette): string => {
+  const gapIndex = body.search(/ {2}/u)
+  const term = gapIndex === -1 ? body : body.slice(0, gapIndex)
+  const description = gapIndex === -1 ? `` : body.slice(gapIndex)
+  return `${highlightSyntax(term, palette)}${highlightProse(description, palette)}`
+}
+
+/** Styles a usage or term's program, options, metavars, and punctuation. */
+const highlightSyntax = (line: string, palette: Palette): string => {
+  const program = /^(?<indent> *)(?<program>[a-z][\w-]*) /u.exec(line)
+  const prefix = program
+    ? `${program.groups!.indent}${palette.program(program.groups!.program!)} `
+    : ``
+  return `${prefix}${line
+    .slice(program?.[0].length ?? 0)
+    .replaceAll(
+      /(?<option>(?<![\w.])--?[a-z][\w-]*)|(?<metavar>\b[A-Z][A-Z-]*\b)|[[\]|=,]/gu,
+      (match, option?: string, metavar?: string) => {
+        if (option) {
+          return palette.option(option)
+        }
+        if (metavar) {
+          return palette.metavar(metavar)
+        }
+        return palette.punctuation(match)
+      },
+    )}`
+}
+
+const highlightProse = (line: string, palette: Palette): string =>
+  line.replaceAll(/(?<quoted>"[^"]*")|`[^`]*`/gu, (match, quoted?: string) =>
+    quoted ? palette.quoted(quoted) : palette.code(match.slice(1, -1)),
+  )
+
+export const highlightErrorPrefix = (
+  text: string,
+  { colors }: HighlightOptions,
+): string => {
+  if (!colors) {
+    return text
+  }
+  const { error } = makePalette(makeAnsis({ isTTY: true }))
+  return text.replace(/^error:/u, error(`error:`))
+}
+
+type Palette = ReturnType<typeof makePalette>
+
+const makePalette = (ansis: Ansis) => {
+  const { mutedSage, amberBrown, goldenAmber, richOrange, softRed } =
+    kindlingColors
+  return {
+    label: ansis.hex(goldenAmber).bold,
+    option: ansis.hex(softRed),
+    metavar: ansis.hex(amberBrown).italic,
+    punctuation: ansis.hex(mutedSage),
+    comment: ansis.hex(mutedSage).italic,
+    program: ansis.bold,
+    quoted: ansis.hex(richOrange),
+    code: ansis.hex(amberBrown),
+    url: ansis.hex(amberBrown).underline,
+    error: ansis.hex(softRed).bold,
+  }
+}

--- a/src/cli/theme-kindling.ts
+++ b/src/cli/theme-kindling.ts
@@ -14,6 +14,14 @@ const warmOrange = `#e69875`
 const terracotta = `#c4907a`
 const softRed = `#ca6e63`
 
+export const kindlingColors = {
+  mutedSage,
+  amberBrown,
+  goldenAmber,
+  richOrange,
+  softRed,
+}
+
 const kindlingTheme: ThemeInput = {
   name: `kindling`,
   displayName: `Kindling`,


### PR DESCRIPTION
On a terminal the CLI colors the help, the usage hint, and the error: prefix in the Kindling theme. It colors after layout by re-parsing the plain text, so the columns stay aligned.