### PR TITLE
refactor(intern): replace HashSink with pure HASH_SEED and mixHash

### DIFF
--- a/src/formats/jfr/parse.ts
+++ b/src/formats/jfr/parse.ts
@@ -1,5 +1,5 @@
 import { ByteQueue } from '../../helpers/bytes.ts'
-import { HashInterner } from '../../helpers/intern.ts'
+import { HASH_SEED, HashInterner, mixHash } from '../../helpers/intern.ts'
 import type {
   CallStackProfile,
   Observation,
@@ -502,12 +502,13 @@ class JfrParser {
   // keys, keyed by the resolved frames so the result is exact. Owns the stack
   // list; events reference its entries by the index `intern` returns.
   readonly #stackInterner = new HashInterner<JfrStackTrace, JfrStackTrace>(
-    ({ methodIds, leafLine }, sink) => {
+    ({ methodIds, leafLine }) => {
+      let hash = HASH_SEED
       for (const methodId of methodIds) {
-        sink.add(methodId)
+        hash = mixHash(hash, methodId)
       }
       // A missing line uses a sentinel that no valid 1-based line can take.
-      sink.add(leafLine ?? -1)
+      return mixHash(hash, leafLine ?? -1)
     },
     (stack, key) =>
       stack.leafLine === key.leafLine &&

--- a/src/formats/memray/parse.ts
+++ b/src/formats/memray/parse.ts
@@ -1,4 +1,4 @@
-import { HashInterner } from '../../helpers/intern.ts'
+import { HASH_SEED, HashInterner, mixHash } from '../../helpers/intern.ts'
 import { decompressLz4Frame, isLz4Frame } from '../../helpers/lz4.ts'
 import type {
   CallStackProfile,
@@ -793,7 +793,8 @@ class StackTree {
    */
   readonly #frames: CaptureFrame[] = []
   readonly #frameIndices = new HashInterner<CaptureFrame, CaptureFrame>(
-    (frame, sink) => sink.add(frame.codeObjectId).add(frame.instructionOffset),
+    frame =>
+      mixHash(mixHash(HASH_SEED, frame.codeObjectId), frame.instructionOffset),
     (item, frame) =>
       item.codeObjectId === frame.codeObjectId &&
       item.instructionOffset === frame.instructionOffset,
@@ -805,7 +806,7 @@ class StackTree {
     { parent: number; frame: number },
     { parent: number; frame: number }
   >(
-    (key, sink) => sink.add(key.parent).add(key.frame),
+    key => mixHash(mixHash(HASH_SEED, key.parent), key.frame),
     (item, key) => item.parent === key.parent && item.frame === key.frame,
   )
 

--- a/src/helpers/intern.test.ts
+++ b/src/helpers/intern.test.ts
@@ -1,52 +1,27 @@
 import { fc, test } from '@fast-check/vitest'
 import { describe, expect } from 'vitest'
-import { HashInterner, HashSink } from './intern.ts'
+import { HASH_SEED, HashInterner, mixHash } from './intern.ts'
 
-describe(`HashSink`, () => {
+describe(`mixHash`, () => {
+  const hash = (values: number[]) =>
+    values.reduce((hash, value) => mixHash(hash, value), HASH_SEED) >>> 0
+
   test(`accumulates the same value for the same sequence`, () => {
-    const hash = (values: number[]) => {
-      const sink = new HashSink()
-      for (const value of values) {
-        sink.add(value)
-      }
-      return sink.value
-    }
-
     expect(hash([1, 2, 3])).toBe(hash([1, 2, 3]))
   })
 
   test(`distinguishes order and content`, () => {
-    const hash = (values: number[]) => {
-      const sink = new HashSink()
-      for (const value of values) {
-        sink.add(value)
-      }
-      return sink.value
-    }
-
     expect(hash([1, 2])).not.toBe(hash([2, 1]))
     expect(hash([1, 2])).not.toBe(hash([1, 3]))
     expect(hash([1, 2])).not.toBe(hash([1, 2, 0]))
   })
 
-  test(`reset returns to the seed so a sink can be reused`, () => {
-    const sink = new HashSink()
-    const seed = sink.value
+  test(`is a 32-bit integer`, () => {
+    const value = mixHash(mixHash(HASH_SEED, -1), 0xff_ff_ff_ff)
 
-    sink.add(42).add(7)
-    expect(sink.value).not.toBe(seed)
-
-    sink.reset()
-    expect(sink.value).toBe(seed)
-  })
-
-  test(`is an unsigned 32-bit integer`, () => {
-    const sink = new HashSink()
-    sink.add(-1).add(0xff_ff_ff_ff)
-
-    expect(sink.value).toBeGreaterThanOrEqual(0)
-    expect(sink.value).toBeLessThanOrEqual(0xff_ff_ff_ff)
-    expect(Number.isInteger(sink.value)).toBe(true)
+    expect(value).toBeGreaterThanOrEqual(-0x80_00_00_00)
+    expect(value).toBeLessThanOrEqual(0x7f_ff_ff_ff)
+    expect(Number.isInteger(value)).toBe(true)
   })
 })
 
@@ -57,7 +32,7 @@ describe(`HashSink`, () => {
 const lengthHashedInterner = () => {
   let creates = 0
   const interner = new HashInterner<number[], { key: number[] }>(
-    (key, sink) => sink.add(key.length),
+    key => key.length,
     (item, key) =>
       item.key.length === key.length &&
       item.key.every((value, i) => value === key[i]),
@@ -156,8 +131,8 @@ const keysArb = fc.array(fc.array(fc.nat({ max: 3 }), { maxLength: 4 }), {
 const hashArb = fc
   .integer({ min: 1, max: 8 })
   .map(
-    buckets => (key: number[], sink: HashSink) =>
-      sink.add(key.reduce((sum, value) => sum + value, 0) % buckets),
+    buckets => (key: number[]) =>
+      key.reduce((sum, value) => sum + value, 0) % buckets,
   )
 
 test.prop([keysArb, hashArb])(

--- a/src/helpers/intern.ts
+++ b/src/helpers/intern.ts
@@ -1,31 +1,19 @@
+const FNV_OFFSET_BASIS = 0x81_1c_9d_c5
+const FNV_PRIME = 0x01_00_01_93
+
 /**
- * Accumulates integers into a single 32-bit FNV-1a hash. Callers {@link add}
- * each component of a structural key in order and read the combined hash from
- * {@link value}; the seed and mixing constants live here so callers declare only
- * what to hash, not how.
+ * The seed a structural key's hash starts from. Callers fold each component of
+ * the key into it in order with {@link mixHash}.
  */
-export class HashSink {
-  static readonly #OFFSET_BASIS = 0x81_1c_9d_c5
-  static readonly #PRIME = 0x01_00_01_93
+export const HASH_SEED: number = FNV_OFFSET_BASIS
 
-  #hash = HashSink.#OFFSET_BASIS
-
-  /** Folds {@link value} into the running hash, returning `this` to chain. */
-  public add(value: number): this {
-    this.#hash = Math.imul(this.#hash ^ value, HashSink.#PRIME)
-    return this
-  }
-
-  /** Clears the running hash back to the seed for reuse across keys. */
-  public reset(): void {
-    this.#hash = HashSink.#OFFSET_BASIS
-  }
-
-  /** The accumulated hash as an unsigned 32-bit integer. */
-  public get value(): number {
-    return this.#hash >>> 0
-  }
-}
+/**
+ * Folds {@link value} into the running 32-bit FNV-1a {@link hash} and returns
+ * the new hash. Pure, so a loop over a key's components keeps the running hash
+ * in a local instead of a heap field, and the call inlines.
+ */
+export const mixHash = (hash: number, value: number): number =>
+  Math.imul(hash ^ value, FNV_PRIME)
 
 /**
  * A deduplicating collection: appends one canonical {@link Value} per distinct
@@ -37,8 +25,8 @@ export class HashSink {
  * lookup. That string is allocated and then hashed over its full length, since
  * a freshly built string carries no cached hash; both costs scale with key
  * size, and the allocation feeds GC. This instead folds the key's components
- * into a number directly via a {@link HashSink}, with no string or allocation,
- * and the `Map<number, …>` it indexes by hashes just that one number. The
+ * into a number directly via {@link mixHash}, with no string or allocation, and
+ * the `Map<number, …>` it indexes by hashes just that one number. The
  * caller's {@link matches} check runs only on a hash collision, which is rare,
  * so distinct keys that hash alike still stay distinct.
  *
@@ -55,15 +43,15 @@ export class HashInterner<Key, Value> {
   readonly #values: Value[] = []
   readonly #indicesByHash = new Map<number, number | number[]>()
 
-  // Reused across `intern` calls so hashing a key allocates nothing; safe
-  // because `intern` is synchronous and never reentrant.
-  readonly #sink = new HashSink()
-
-  readonly #hash: (key: Key, sink: HashSink) => void
+  readonly #hash: (key: Key) => number
   readonly #matches: (item: Value, key: Key) => boolean
 
   public constructor(
-    hash: (key: Key, sink: HashSink) => void,
+    /**
+     * Folds the key's components into a hash, starting from {@link HASH_SEED}
+     * and mixing each with {@link mixHash}.
+     */
+    hash: (key: Key) => number,
     matches: (item: Value, key: Key) => boolean,
   ) {
     this.#hash = hash
@@ -83,9 +71,7 @@ export class HashInterner<Key, Value> {
    * a fresh one from {@link create} and returns its index when none matches.
    */
   public intern(key: Key, create: () => Value): number {
-    this.#sink.reset()
-    this.#hash(key, this.#sink)
-    const hash = this.#sink.value
+    const hash = this.#hash(key) >>> 0
     const bucket = this.#indicesByHash.get(hash)
     if (bucket === undefined) {
       const index = this.#add(create)

--- a/src/modalities/call-stack-profile/aggregate.ts
+++ b/src/modalities/call-stack-profile/aggregate.ts
@@ -1,4 +1,4 @@
-import { HashInterner } from '../../helpers/intern.ts'
+import { HASH_SEED, HashInterner, mixHash } from '../../helpers/intern.ts'
 import type { SourceLocation } from '../../location.ts'
 import type {
   AggregationProfileToMdOptions,
@@ -88,10 +88,12 @@ class ObservationsAggregator {
     AggregatedCallStackProfileFunction[],
     AggregatedCallStackProfileCallStack
   >(
-    (frames, sink) => {
+    frames => {
+      let hash = HASH_SEED
       for (const frame of frames) {
-        sink.add(frame.id)
+        hash = mixHash(hash, frame.id)
       }
+      return hash
     },
     (callStack, frames) => sameStackFrameIds(callStack.frames, frames),
   )

--- a/src/modalities/call-stack-profile/format.ts
+++ b/src/modalities/call-stack-profile/format.ts
@@ -9,7 +9,7 @@ import {
   formatMicroseconds,
 } from '../../helpers/format.ts'
 import { selectTopN } from '../../helpers/heap.ts'
-import { HashInterner } from '../../helpers/intern.ts'
+import { HASH_SEED, HashInterner, mixHash } from '../../helpers/intern.ts'
 import {
   formatSectionGroup,
   heading,
@@ -756,10 +756,12 @@ const newShownCallStackInterner = (): HashInterner<
   ShownCallStack
 > =>
   new HashInterner(
-    (frames, sink) => {
+    frames => {
+      let hash = HASH_SEED
       for (const frame of frames) {
-        sink.add(frame.type === `hidden` ? -1 : frame.id)
+        hash = mixHash(hash, frame.type === `hidden` ? -1 : frame.id)
       }
+      return hash
     },
     (callStack, frames) =>
       callStack.frames.length === frames.length &&


### PR DESCRIPTION
A key's hash accumulates in a local instead of a heap field on a reused sink, and the per-component call inlines.