### PR TITLE
perf(cli): stop spreading globalThis into the non-TTY Ansis options

### DIFF
--- a/src/cli/ansis.ts
+++ b/src/cli/ansis.ts
@@ -22,7 +22,6 @@ export const makeAnsis = ({ isTTY }: MakeAnsisOptions): Ansis => {
   // If this is a non-TTY output, then start off the default level as no color.
   // CLI flags and `FORCE_COLOR` can still override this.
   return new Ansis({
-    ...globalThis,
     process: {
       ...process,
       env: {


### PR DESCRIPTION
Ansis reads only `process` (and `window`) from its options, but spreading `globalThis` evaluates every lazy global getter Node defines, loading undici for `fetch`, the MIME parser, and more. That cost 17ms of a 120ms `--help` on the built CLI, and runs on every non-TTY stdout or stderr.