### PR TITLE
feat(options): add a logger and log the format detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,8 @@ profiler-md
 │   ├── options.ts                # API option types and normalization logic
 │   ├── location.ts               # URL, file path, and line:column location logic
 │   ├── source-map.ts             # Source map resolution logic
-│   ├── testing.ts                # Test-only option resolution and cross-modality Markdown assertion helpers
+│   ├── testing.ts                # Test-only option resolution, log assertion, and cross-modality Markdown assertion helpers
+│   ├── test-setup.ts             # Vitest setup: records every logged line and fails a test that leaves one unasserted
 │   │
 │   └── helpers/                  # Truly generic (non-profiling) utility functions
 │       ├── array.ts
@@ -287,6 +288,43 @@ pnpm generate-inputs go ruby   # Limit to named workload scripts
   maintainer reads it
 - Derive a format or origin name from the registry (e.g. `FormatMeta.title`),
   never a string literal
+
+### Logging
+
+- The library logs only through `ProfileToMdOptions.logger`, filtered to
+  `logLevel`, never through `console` or another global channel. The CLI passes
+  a logger writing to stderr, so stdout stays the Markdown
+- Throw an error, never log one. `error` is the CLI's level for reporting the
+  thrown error
+- `warn` when the run succeeded but something the caller supplied had no effect,
+  or an option would change the outcome (e.g. a source map that matched no
+  generated file). The test: the caller changes an option or an input after
+  reading it
+- Assert every logged line, at every level, with `expectLogs()` in
+  `src/testing.ts`. `src/test-setup.ts` records every line a conversion logs,
+  whatever logger options the test passed, and fails a test that ends with a
+  line `expectLogs()` did not consume. A new log line fails every test whose
+  conversion emits it until they assert it. Call `ignoreLogs()` in a test whose
+  subject is unrelated to what the conversion logs (e.g. a format's diff
+  output), and `expectLogs()` in one whose subject is what the pipeline decided
+  (e.g. the format it detected)
+- `info` for one line per decision the pipeline made on the caller's behalf
+  (e.g. the detected format). At most a few lines per input
+- `debug` for the reasoning behind an info line, and for detail keyed by a
+  distinct file, format, or record type, such as each format that rejected the
+  input and why. Count per key in a `Map` and log once at the end. NEVER log per
+  entry, observation, frame, or node
+- NEVER log what the outcome states. A failure's reason must be in the thrown
+  error's message, and a fact the detected format implies (e.g. that a JSON
+  lines input failed to decode as one JSON document) adds nothing to the info
+  line. The test for a line: a caller reading the output and the other lines
+  learns something from it
+- Call a level's method only if it is defined (`logger.debug?.(...)`), and build
+  an expensive message or per-key detail only inside `if (logger.debug)`. Write
+  the message like an error message: `<what happened>: <detail>`, values last
+  after `got: `, naming what the caller controls.
+  `eslint-rules/error-message.js` checks the wording conventions of a
+  `logger.<level>(...)` call's message too
 
 ### Performance
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -102,6 +102,13 @@ const options = {
   // Make paths relative to a custom base URL or directory, or pass `auto` to
   // infer the profiled files' common ancestor directory.
   baseURL: `/path/to/project`,
+  // Receive the conversion's diagnostics: at `warn`, an option or input that
+  // had no effect; at `info`, each decision made on your behalf; and at
+  // `debug`, the reasoning behind each decision. Only defined methods are
+  // called, so `console` qualifies. Set `logLevel`, which defaults to `none`,
+  // to receive any message.
+  logger: console,
+  logLevel: `info`,
   matchEntry: (entry, context) => {
     if (entry.location?.url?.pathname.includes(`/bundle.`)) {
       // Match bundled entries when diffing by name only, ignoring

--- a/eslint-rules/error-message.js
+++ b/eslint-rules/error-message.js
@@ -1,7 +1,4 @@
-/**
- * Enforces the error message conventions in `CLAUDE.md`: one line, no trailing
- * period, no semicolon, and a lowercase opener.
- */
+/** Enforces the message conventions in `CLAUDE.md` on error and logger messages. */
 
 /**
  * Stands in for an interpolated value, so a check distinguishes an
@@ -44,29 +41,39 @@ const checks = [
   },
 ]
 
+const LOGGER_METHODS = new Set([`error`, `warn`, `info`, `debug`])
+
+/**
+ * Holds for `logger.<level>?.(...)` too, because optional chaining leaves the
+ * callee a member expression.
+ */
+const isLoggerCall = ({ callee }) =>
+  callee.type === `MemberExpression` &&
+  !callee.computed &&
+  callee.object.type === `Identifier` &&
+  callee.object.name === `logger` &&
+  LOGGER_METHODS.has(callee.property.name)
+
+const isErrorConstruction = ({ callee }) =>
+  callee.type === `Identifier` && callee.name.endsWith(`Error`)
+
 export const errorMessage = {
   meta: {
     type: `problem`,
-    docs: { description: `enforce the project's error message conventions` },
+    docs: {
+      description: `enforce the project's error and logger message conventions`,
+    },
     schema: [],
     messages: {
-      multiLine: `Write the error message on one line.`,
-      trailingPeriod: `Drop the error message's trailing period.`,
-      semicolon: `Replace the error message's semicolon with a comma or a second clause.`,
-      capitalized: `Start the error message lowercase, unless it opens with an identifier, a proper noun, or a format title.`,
+      multiLine: `Write the message on one line.`,
+      trailingPeriod: `Drop the message's trailing period.`,
+      semicolon: `Replace the message's semicolon with a comma or a second clause.`,
+      capitalized: `Start the message lowercase, unless it opens with an identifier, a proper noun, or a format title.`,
     },
   },
 
-  create: context => ({
-    NewExpression: node => {
-      if (
-        node.callee.type !== `Identifier` ||
-        !node.callee.name.endsWith(`Error`)
-      ) {
-        return
-      }
-
-      const [message] = node.arguments
+  create: context => {
+    const checkMessage = ([message]) => {
       const text = message && messageText(message)
       if (text === undefined) {
         return
@@ -77,6 +84,19 @@ export const errorMessage = {
           context.report({ node: message, messageId })
         }
       }
-    },
-  }),
+    }
+
+    return {
+      NewExpression: node => {
+        if (isErrorConstruction(node)) {
+          checkMessage(node.arguments)
+        }
+      },
+      CallExpression: node => {
+        if (isLoggerCall(node)) {
+          checkMessage(node.arguments)
+        }
+      },
+    }
+  },
 }

--- a/src/formats/callgrind/index.test.ts
+++ b/src/formats/callgrind/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { beforeAll, describe, expect, test } from 'vitest'
 import {
   allTablesAfterHeading,
   chunk,
@@ -18,6 +18,7 @@ import {
   categorySectionTables,
   categoryTables,
   diffRankingTable,
+  ignoreLogs,
   linesTables,
   profileTitles,
   rankingTable,
@@ -1053,6 +1054,7 @@ describe(`convert`, () => {
   })
 
   test(`diffs base and current call graphs into regressions and improvements`, () => {
+    ignoreLogs()
     const graph = (mainSelf: number, compressSelf: number) => [
       `events: Ir`,
       `fl=(1) /src/main.c`,
@@ -1217,11 +1219,17 @@ describe(`category subsections`, () => {
         `1 10`,
       ])
 
-    const diffMd = diffProfiles(
-      { data: graph(600, 390), format: `callgrind` },
-      { data: graph(300, 700), format: `callgrind` },
-      { baseURL: `/app`, showEntry: () => true },
-    )
+    // Converted in a hook rather than at collection time, so the log
+    // exemption reaches the first test's log check.
+    let diffMd: string
+    beforeAll(() => {
+      ignoreLogs()
+      diffMd = diffProfiles(
+        { data: graph(600, 390), format: `callgrind` },
+        { data: graph(300, 700), format: `callgrind` },
+        { baseURL: `/app`, showEntry: () => true },
+      )
+    })
 
     test(`splits each ranking into a subsection per covered category`, () => {
       expect(
@@ -1255,6 +1263,7 @@ describe(`category subsections`, () => {
     })
 
     test(`splits a ranking whose functions all fall in one category`, () => {
+      ignoreLogs()
       const singleCategoryMd = diffProfiles(
         {
           data: makeCallgrind([

--- a/src/formats/detect.ts
+++ b/src/formats/detect.ts
@@ -1,4 +1,5 @@
 import { reasonOf } from '../error.ts'
+import type { AggregationProfileToMdOptions } from '../options.ts'
 import type {
   BinaryFormatConverter,
   Detect,
@@ -26,9 +27,10 @@ export type FormatRejection = { converter: FormatConverter; error: unknown }
 export const detectJsonFormat = (
   json: unknown,
   rejections: FormatRejection[],
+  options: AggregationProfileToMdOptions,
 ): DetectedInput | undefined => {
   for (const converter of jsonFormatConverters) {
-    const parsed = detectWithConverter(converter, json, rejections)
+    const parsed = detectWithConverter(converter, json, rejections, options)
     if (parsed) {
       return { format: converter.format, parsed }
     }
@@ -39,9 +41,10 @@ export const detectJsonFormat = (
 export const detectBinaryFormat = (
   bytes: Uint8Array,
   rejections: FormatRejection[],
+  options: AggregationProfileToMdOptions,
 ): DetectedInput | undefined => {
   for (const converter of binaryFormatConverters) {
-    const parsed = detectWithConverter(converter, bytes, rejections)
+    const parsed = detectWithConverter(converter, bytes, rejections, options)
     if (parsed) {
       return { format: converter.format, parsed }
     }
@@ -74,18 +77,25 @@ const detectWithConverter = <Input>(
   converter: FormatConverter & Detect<Input> & Parse<Input>,
   input: Input,
   rejections: FormatRejection[],
+  { logger }: AggregationProfileToMdOptions,
 ): ParsedInput[] | undefined => {
   try {
     if (!converter.matches(input)) {
       return undefined
     }
-  } catch {
+  } catch (error: unknown) {
+    logger.debug?.(
+      `${converter.format}: skipped because detection threw: ${reasonOf(error)}`,
+    )
     return undefined
   }
 
   try {
     return classifyLazyParseFailures(converter, converter.parse(input))
   } catch (error: unknown) {
+    logger.debug?.(
+      `${converter.format}: recognized the input but rejected it: ${reasonOf(error)}`,
+    )
     rejections.push({ converter, error })
     return undefined
   }

--- a/src/formats/escaping.test.ts
+++ b/src/formats/escaping.test.ts
@@ -6,7 +6,7 @@ import {
   selfTimeTables,
   totalTimeTables,
 } from '../modalities/call-stack-profile/testing.ts'
-import { categoryTables } from '../testing.ts'
+import { categoryTables, ignoreLogs } from '../testing.ts'
 
 /**
  * A speedscope profile whose single sampled function has the given untrusted
@@ -62,6 +62,7 @@ const frameName = fc
 test.prop([frameName])(
   `function names round-trip through Markdown exactly`,
   name => {
+    ignoreLogs()
     const md = profileToMd({
       data: makeProfileData(name),
       format: `speedscope`,
@@ -83,12 +84,14 @@ test.each([
   `[link](x)`,
   `<img src=x>`,
 ])(`adversarial function name round-trips exactly: %s`, name => {
+  ignoreLogs()
   const md = profileToMd({ data: makeProfileData(name), format: `speedscope` })
 
   expect(inlineCodeValues(md)).toContain(name)
 })
 
 test(`a newline in a function name normalizes to a space without breaking structure`, () => {
+  ignoreLogs()
   const md = profileToMd({
     data: makeProfileData(`evil\nname`),
     format: `speedscope`,
@@ -110,6 +113,7 @@ test(`a newline in a function name normalizes to a space without breaking struct
 })
 
 test(`a backslash-pipe in a function name normalizes with a space without breaking structure`, () => {
+  ignoreLogs()
   const md = profileToMd({
     data: makeProfileData(`RegExp: a\\|b`),
     format: `speedscope`,
@@ -128,6 +132,7 @@ test(`a backslash-pipe in a function name normalizes with a space without breaki
 })
 
 test(`file paths with Markdown syntax round-trip exactly in locations`, () => {
+  ignoreLogs()
   const md = profileToMd({
     data: makeProfileData(`main`, `path/with_underscores*and*stars.py`),
     format: `speedscope`,

--- a/src/formats/index.test.ts
+++ b/src/formats/index.test.ts
@@ -11,7 +11,13 @@ import {
 } from '../modalities/call-stack-profile/testing.ts'
 import { SAMPLES } from '../modalities/metrics.ts'
 import { normalizeProfileToMdOptions } from '../options.ts'
-import { categoryTables, profileTitles, rankingTables } from '../testing.ts'
+import {
+  categoryTables,
+  expectLogs,
+  ignoreLogs,
+  profileTitles,
+  rankingTables,
+} from '../testing.ts'
 import type { JsonFormatConverter } from './converter.ts'
 import { FormatDetectError, mayBeParserBug } from './error.ts'
 import {
@@ -24,6 +30,7 @@ import {
 } from './index.ts'
 import {
   convertJsonToMd,
+  detectionLogs,
   injectedFormat,
   injectedInputs,
   inputPath,
@@ -48,6 +55,13 @@ import {
 vi.setConfig({ testTimeout: 125_000 })
 
 const format = injectedFormat()
+
+const SPEEDSCOPE_REJECTION_LOG = `debug: speedscope: recognized the input but rejected it: Cannot read properties of undefined (reading 'map')`
+const V8_CPU_PROFILE_REJECTION_LOG = `debug: v8-cpu-profile: recognized the input but rejected it: Cannot destructure property 'functionName' of 'callFrame' as it is null.`
+const V8_CPU_PROFILE_DIFF_LOGS = [
+  `info: format: v8-cpu-profile (specified)`,
+  `info: format: v8-cpu-profile (specified)`,
+]
 
 const inputSets = {
   json: new Set<string>(),
@@ -118,6 +132,7 @@ describe(`profileToMd`, () => {
       const md = profileToMd(readInput(filename), { baseURL: null })
 
       expect(md).toMatch(MARKDOWN_REGEX)
+      expectLogs(detectionLogs(filename))
     })
   }
 
@@ -128,6 +143,7 @@ describe(`profileToMd`, () => {
       })
 
       expect(md).toMatch(MARKDOWN_REGEX)
+      expectLogs(detectionLogs(filename))
     })
   }
 
@@ -143,6 +159,7 @@ describe(`profileToMd`, () => {
         const md = profileToMd(iterable, { baseURL: null })
 
         expect(md).toMatch(MARKDOWN_REGEX)
+        expectLogs(detectionLogs(filename))
       },
     )
   }
@@ -158,9 +175,14 @@ describe(`profileToMd`, () => {
       )
 
       expect(forced).toBe(auto)
+      expectLogs([
+        `info: format: v8-cpu-profile (detected)`,
+        `info: format: v8-cpu-profile (specified)`,
+      ])
     })
 
     test(`baseURL: 'auto' infers the common ancestor of ours locations`, () => {
+      ignoreLogs()
       // `funcA` and `funcB` span the project; the dependency and builtin frames
       // are not `ours`, so they don't move the inferred base up towards the
       // root.
@@ -245,6 +267,7 @@ describe(`profileToMd`, () => {
     })
 
     test(`baseURL: 'auto' falls back to absolute paths when no location qualifies`, () => {
+      ignoreLogs()
       // The only `ours` location is a relative path and the builtin's `node:`
       // URL has no hierarchical path, so nothing qualifies for inference.
       const cpuProfile = JSON.stringify({
@@ -292,6 +315,7 @@ describe(`profileToMd`, () => {
     })
 
     test(`baseURL: 'auto' infers the common ancestor of HTTP locations`, () => {
+      ignoreLogs()
       // Both scripts live on one HTTPS origin and differ only by query string,
       // so the inferred base relativizes them while keeping the queries.
       const cpuProfile = JSON.stringify({
@@ -344,6 +368,7 @@ describe(`profileToMd`, () => {
     })
 
     test(`baseURL: 'auto' infers the dominant file: base despite a lone HTTP location`, () => {
+      ignoreLogs()
       // Two of the three absolute locations are file: URLs, so the file: group
       // dominates and the lone HTTP location renders absolute.
       const cpuProfile = JSON.stringify({
@@ -411,6 +436,7 @@ describe(`profileToMd`, () => {
     })
 
     test(`baseURL: 'auto' infers the common ancestor from source-mapped locations`, () => {
+      ignoreLogs()
       // The only `ours` location is a generated bundle whose source map points
       // into src/. Inference must follow the map like formatting does: a base
       // inferred from the raw dist/ path would show the mapped source as
@@ -459,6 +485,7 @@ describe(`profileToMd`, () => {
     })
 
     test(`reports when there is no profiling data`, () => {
+      ignoreLogs()
       const md = profileToMd(emptyProfile, { baseURL: null })
 
       expect(md).toBe(`No profiling data found.\n`)
@@ -485,15 +512,18 @@ describe(`profileToMd`, () => {
       })
 
       expect(() => profileToMd(almostSpeedscope)).toThrow(/^Speedscope: /u)
+      expectLogs([SPEEDSCOPE_REJECTION_LOG])
     })
 
     test(`a specified format reports its rejection as that format's`, () => {
+      ignoreLogs()
       expect(() =>
         profileToMd({ data: `funcA;funcB`, format: `collapsed` }),
       ).toThrow(`Collapsed stacks: missing sample count`)
     })
 
     test(`a specified format reports its rejection as that format's when async`, async () => {
+      ignoreLogs()
       await expect(
         profileToMdAsync({
           data: new Blob([`funcA;funcB`]),
@@ -516,6 +546,7 @@ describe(`profileToMd`, () => {
       expect(() => profileToMd(almostBoth)).toThrow(
         /could not detect the profile format, rejected by: Speedscope: .*, V8 CPU profile: /u,
       )
+      expectLogs([SPEEDSCOPE_REJECTION_LOG, V8_CPU_PROFILE_REJECTION_LOG])
     })
 
     test(`detection reports a malformed JSON document as invalid JSON`, () => {
@@ -525,12 +556,14 @@ describe(`profileToMd`, () => {
     })
 
     test(`a specified JSON format reports invalid JSON as its rejection`, () => {
+      ignoreLogs()
       expect(() =>
         profileToMd({ data: `garbage\n`, format: `v8-cpu-profile` }),
       ).toThrow(/^V8 CPU profile: invalid JSON: /u)
     })
 
     test(`a specified JSON format reports invalid JSON as its rejection when async`, async () => {
+      ignoreLogs()
       await expect(
         profileToMdAsync({
           data: new Blob([`garbage\n`]),
@@ -540,22 +573,30 @@ describe(`profileToMd`, () => {
     })
 
     test(`a specified binary format reports its decoder's failure as its rejection`, () => {
+      ignoreLogs()
       expect(() => profileToMd({ data: `garbage\n`, format: `pprof` })).toThrow(
         /^pprof: invalid protobuf encoding: /u,
       )
     })
 
     const unclassifiedInputs = [
-      { scenario: `before parse returns`, data: crashingV8CpuProfile },
+      {
+        scenario: `before parse returns`,
+        data: crashingV8CpuProfile,
+        // Detection logs the rejection and moves on, so no format is detected.
+        logs: [V8_CPU_PROFILE_REJECTION_LOG],
+      },
       {
         scenario: `while aggregation consumes the parse's lazy iterable`,
         data: lazilyCrashingV8CpuProfile,
+        logs: [`info: format: v8-cpu-profile (detected)`],
       },
     ]
 
     test.each(unclassifiedInputs)(
       `a specified format reports an error its parser did not classify as a failure to parse, thrown $scenario`,
       ({ data }) => {
+        ignoreLogs()
         let thrown
         try {
           profileToMd({ data, format: `v8-cpu-profile` })
@@ -574,6 +615,7 @@ describe(`profileToMd`, () => {
     test.each(unclassifiedInputs)(
       `a specified format reports an error its parser did not classify as a failure to parse when async, thrown $scenario`,
       async ({ data }) => {
+        ignoreLogs()
         let thrown
         try {
           await profileToMdAsync({
@@ -594,19 +636,21 @@ describe(`profileToMd`, () => {
 
     test.each(unclassifiedInputs)(
       `detection reports an error a parser did not classify the same way a specified format does, thrown $scenario`,
-      ({ data }) => {
+      ({ data, logs }) => {
         let detected
         try {
           profileToMd(data)
         } catch (error: unknown) {
           detected = error
         }
+        expectLogs(logs)
         let specified
         try {
           profileToMd({ data, format: `v8-cpu-profile` })
         } catch (error: unknown) {
           specified = error
         }
+        expectLogs([`info: format: v8-cpu-profile (specified)`])
 
         expect((detected as Error).message).toBe((specified as Error).message)
         expect(mayBeParserBug(detected)).toBe(true)
@@ -614,6 +658,7 @@ describe(`profileToMd`, () => {
     )
 
     test(`a rejection the parser classified is not a possible bug`, () => {
+      ignoreLogs()
       let thrown
       try {
         profileToMd({ data: `funcA;funcB`, format: `collapsed` })
@@ -630,6 +675,7 @@ describe(`profileToMd`, () => {
     ])(
       `a rejection's message collapses the whitespace of the value it reports, $scenario`,
       ({ format }) => {
+        ignoreLogs()
         const data = new TextEncoder().encode(
           `JAVA PROFILE \nfoo\n  1.0\tbar\0${`\0`.repeat(20)}`,
         )
@@ -641,6 +687,7 @@ describe(`profileToMd`, () => {
     )
 
     test(`a specified format's rejection wraps the parser's error as its cause`, () => {
+      ignoreLogs()
       let thrown
       try {
         profileToMd({ data: crashingV8CpuProfile, format: `v8-cpu-profile` })
@@ -664,11 +711,14 @@ describe(`profileToMd`, () => {
           },
         })
 
-      test.each([
+      const scenarios = [
         { scenario: `under a specified JSON format`, format: `v8-cpu-profile` },
         { scenario: `under a specified binary format`, format: `pprof` },
         { scenario: `under auto-detection`, format: undefined },
-      ] as const)(`from an iterable $scenario`, ({ format }) => {
+      ] as const
+
+      test.each(scenarios)(`from an iterable $scenario`, ({ format }) => {
+        ignoreLogs()
         let thrown
         try {
           profileToMd({ data: failingIterable(), format })
@@ -679,11 +729,8 @@ describe(`profileToMd`, () => {
         expect(thrown).toBe(readError)
       })
 
-      test.each([
-        { scenario: `under a specified JSON format`, format: `v8-cpu-profile` },
-        { scenario: `under a specified binary format`, format: `pprof` },
-        { scenario: `under auto-detection`, format: undefined },
-      ] as const)(`from a stream $scenario`, async ({ format }) => {
+      test.each(scenarios)(`from a stream $scenario`, async ({ format }) => {
+        ignoreLogs()
         let thrown
         try {
           await profileToMdAsync({ data: failingStream(), format })
@@ -711,6 +758,7 @@ describe(`profileToMd`, () => {
 
       expect(thrown).toBeInstanceOf(FormatDetectError)
       expect((thrown as FormatDetectError).errors).toHaveLength(1)
+      expectLogs([SPEEDSCOPE_REJECTION_LOG])
     })
 
     test.each([
@@ -719,6 +767,7 @@ describe(`profileToMd`, () => {
     ])(
       `auto-detection of %s propagates a throwing categorizeFunctions`,
       filename => {
+        ignoreLogs()
         // Errors raised after a format is detected are real errors, not
         // detection misses, so they must surface, not be swallowed into an
         // unknown-format error.
@@ -736,6 +785,7 @@ describe(`profileToMd`, () => {
     )
 
     test(`throws when categorizeFunctions returns a misaligned array`, () => {
+      ignoreLogs()
       expect(() =>
         profileToMd(
           { data: baseCpuProfile, format: `v8-cpu-profile` },
@@ -762,6 +812,7 @@ describe(`profileToMdAsync`, () => {
         const md = await profileToMdAsync(blob, { baseURL: null })
 
         expect(md).toMatch(MARKDOWN_REGEX)
+        expectLogs(detectionLogs(filename))
       })
 
       test(`from ReadableStream`, async () => {
@@ -775,6 +826,7 @@ describe(`profileToMdAsync`, () => {
         const md = await profileToMdAsync(stream, { baseURL: null })
 
         expect(md).toMatch(MARKDOWN_REGEX)
+        expectLogs(detectionLogs(filename))
       })
     })
   }
@@ -790,6 +842,7 @@ describe(`profileToMdAsync`, () => {
       )
 
       expect(md).toMatch(/^# /u)
+      expectLogs([`info: format: v8-cpu-profile (specified)`])
     })
 
     test(`forced binary format streams a ReadableStream through parseAsync`, async () => {
@@ -813,6 +866,10 @@ describe(`profileToMdAsync`, () => {
       expect(md).toBe(
         profileToMd({ data: content, format: `collapsed` }, { baseURL: null }),
       )
+      expectLogs([
+        `info: format: collapsed (specified)`,
+        `info: format: collapsed (specified)`,
+      ])
     })
 
     test(`throws on unknown data`, async () => {
@@ -1001,6 +1058,71 @@ describe(`origin detection`, () => {
   })
 })
 
+describe(`logging`, () => {
+  test(`logs the detected format`, () => {
+    profileToMd(baseCpuProfile, { baseURL: null })
+
+    expectLogs([`info: format: v8-cpu-profile (detected)`])
+  })
+
+  test(`logs the specified format`, () => {
+    profileToMd(
+      { data: baseCpuProfile, format: `v8-cpu-profile`, origin: `deno` },
+      { baseURL: null },
+    )
+
+    expectLogs([`info: format: v8-cpu-profile (specified)`])
+  })
+
+  test(`logs each format that recognized the input but rejected it`, () => {
+    expect(() => profileToMd(`a;b 1\nc;d x\n`)).toThrow(/invalid sample count/u)
+    expectLogs([
+      `debug: collapsed: recognized the input but rejected it: invalid sample count`,
+    ])
+  })
+
+  test(`the logger receives nothing at the default level`, () => {
+    const received: string[] = []
+
+    profileToMd(baseCpuProfile, {
+      baseURL: null,
+      logger: { info: message => received.push(message) },
+    })
+
+    expect(received).toStrictEqual([])
+    expectLogs([`info: format: v8-cpu-profile (detected)`])
+  })
+
+  test(`the logger receives the lines its level enables`, () => {
+    const received: string[] = []
+
+    profileToMd(baseCpuProfile, {
+      baseURL: null,
+      logger: { info: message => received.push(message) },
+      logLevel: `info`,
+    })
+
+    expect(received).toStrictEqual([`format: v8-cpu-profile (detected)`])
+    expectLogs([`info: format: v8-cpu-profile (detected)`])
+  })
+
+  test(`throws on an unknown log level`, () => {
+    expect(() =>
+      profileToMd(baseCpuProfile, {
+        logLevel: `loud` as `debug`,
+      }),
+    ).toThrow(
+      `logLevel must be one of none, error, warn, info, debug, got: loud`,
+    )
+  })
+
+  test(`expectLogs fails on lines the expectation omits`, () => {
+    profileToMd(baseCpuProfile, { baseURL: null })
+
+    expect(() => expectLogs([])).toThrow()
+  })
+})
+
 describe(`diffProfiles`, () => {
   if (allInputs.length > 0) {
     test.each(allInputs)(
@@ -1013,6 +1135,7 @@ describe(`diffProfiles`, () => {
         expect(md).toMatch(MARKDOWN_DIFF_REGEX)
         // No regressions or improvements when diffing an input against itself.
         expect(md).not.toMatch(/Regressions|Improvements/u)
+        expectLogs([...detectionLogs(filename), ...detectionLogs(filename)])
       },
     )
   }
@@ -1035,9 +1158,11 @@ describe(`diffProfiles`, () => {
       )
 
       expect(md).toMatch(/^# .*diff/iu)
+      expectLogs(V8_CPU_PROFILE_DIFF_LOGS)
     })
 
     test(`diffs two CPU profiles end-to-end`, () => {
+      ignoreLogs()
       const md = diffProfiles(
         { data: baseCpuProfile, format: `v8-cpu-profile` },
         { data: currentCpuProfile, format: `v8-cpu-profile` },
@@ -1097,6 +1222,7 @@ describe(`diffProfiles`, () => {
     })
 
     test(`baseURL: 'auto' infers one common ancestor across both diff sides`, () => {
+      ignoreLogs()
       // The function moved from src/ to lib/ between the two profiles. A
       // per-side base would render both as a bare `a.ts`; the shared base keeps
       // the two locations distinguishable.
@@ -1151,6 +1277,7 @@ describe(`diffProfiles`, () => {
     })
 
     test(`diffs two heap snapshots end-to-end`, () => {
+      ignoreLogs()
       const md = diffProfiles(
         { data: baseHeapSnapshot, format: `v8-heap-snapshot` },
         { data: currentHeapSnapshot, format: `v8-heap-snapshot` },
@@ -1224,6 +1351,7 @@ describe(`diffProfiles`, () => {
     // exhibits a differing build hash.
 
     test(`matchEntry matches functions whose locations differ across profiles`, () => {
+      ignoreLogs()
       // `funcA`'s file carries a per-build suffix, so by default the two sides
       // don't match. The `matchEntry` hook equates the locations; the matched
       // row displays the current profile's real path.
@@ -1286,12 +1414,14 @@ describe(`diffProfiles`, () => {
     })
 
     test(`reports when there is no profiling data`, () => {
+      ignoreLogs()
       const md = diffProfiles(emptyProfile, emptyProfile, { baseURL: null })
 
       expect(md).toBe(`No profiling data found.\n`)
     })
 
     test(`throws on diffing a profile against a snapshot`, () => {
+      ignoreLogs()
       const profileContent = readFileSync(
         inputPath(`javascript.node.base.cpuprofile`),
       )
@@ -1321,6 +1451,7 @@ if (smallestAnyInput.length > 0) {
       )
 
       expect(md).toMatch(MARKDOWN_DIFF_REGEX)
+      expectLogs([...detectionLogs(filename), ...detectionLogs(filename)])
     })
   })
 }

--- a/src/formats/index.ts
+++ b/src/formats/index.ts
@@ -34,6 +34,7 @@ import {
   rethrowInputReadFailure,
 } from './parse.ts'
 import { formatToConverter } from './registry.ts'
+import type { Format } from './registry.ts'
 
 export { formatToConverter, formats } from './registry.ts'
 export type { Format } from './registry.ts'
@@ -121,6 +122,8 @@ export const aggregateInput = (
   const { data, format, origin } = normalizeProfileInput(input)
 
   if (format) {
+    logFormat(format, `specified`, options)
+
     const parsed = parseAsFormat(formatToConverter[format], data)
     return aggregateParsedInputs(parsed, options, makeContext(format, origin))
   }
@@ -146,11 +149,15 @@ export const aggregateInput = (
 
   const rejections: FormatRejection[] = []
   const detected =
-    (json === undefined ? undefined : detectJsonFormat(json, rejections)) ??
-    detectBinaryFormat(dataToBytes(buffered), rejections)
+    (json === undefined
+      ? undefined
+      : detectJsonFormat(json, rejections, options)) ??
+    detectBinaryFormat(dataToBytes(buffered), rejections, options)
   if (!detected) {
     throw toUndetectedFormatError(rejections, jsonError)
   }
+  logFormat(detected.format, `detected`, options)
+
   return aggregateParsedInputs(
     detected.parsed,
     options,
@@ -165,6 +172,8 @@ const aggregateInputAsync = async (
   const { data, format, origin } = normalizeProfileInput(input)
 
   if (format) {
+    logFormat(format, `specified`, options)
+
     const parsed = await parseAsFormatAsync(formatToConverter[format], data)
     return aggregateParsedInputs(parsed, options, makeContext(format, origin))
   }
@@ -202,17 +211,30 @@ const aggregateInputAsync = async (
 
   const rejections: FormatRejection[] = []
   const detected =
-    (json === undefined ? undefined : detectJsonFormat(json, rejections)) ??
+    (json === undefined
+      ? undefined
+      : detectJsonFormat(json, rejections, options)) ??
     detectBinaryFormat(
       buffered instanceof Blob ? await buffered.bytes() : buffered,
       rejections,
+      options,
     )
   if (!detected) {
     throw toUndetectedFormatError(rejections, jsonError)
   }
+  logFormat(detected.format, `detected`, options)
+
   return aggregateParsedInputs(
     detected.parsed,
     options,
     makeContext(detected.format, origin),
   )
+}
+
+const logFormat = (
+  format: Format,
+  evidence: `specified` | `detected`,
+  { logger }: AggregationProfileToMdOptions,
+): void => {
+  logger.info?.(`format: ${format} (${evidence})`)
 }

--- a/src/formats/memray/index.test.ts
+++ b/src/formats/memray/index.test.ts
@@ -8,6 +8,7 @@ import {
 import { normalizeProfileToMdOptions } from '../../options.ts'
 import {
   categoryTables,
+  ignoreLogs,
   linesTables,
   profileTitles,
   rankingTables,
@@ -797,6 +798,7 @@ describe(`convert`, () => {
   })
 
   test(`diffs sides holding the same bytes over different allocation counts`, () => {
+    ignoreLogs()
     // A stack's bytes are reported as measured rather than divided across its
     // allocations, which would multiply back to a total off by an ulp and read
     // as a change here.

--- a/src/formats/systing/index.test.ts
+++ b/src/formats/systing/index.test.ts
@@ -11,6 +11,7 @@ import { normalizeProfileToMdOptions } from '../../options.ts'
 import {
   calleesTables,
   categoryTables,
+  ignoreLogs,
   linesTables,
   profileTitles,
   summaryLines,
@@ -465,6 +466,7 @@ describe(`convert`, () => {
   })
 
   test(`a sleep diff names the sleeps it counts`, () => {
+    ignoreLogs()
     const sleeps = (count: number) => [
       [`f`, 0, `do_nanosleep ([kernel]) <0xffff2>`],
       [`s`, 0, [0]],
@@ -484,6 +486,7 @@ describe(`convert`, () => {
   })
 
   test(`rejects a diff of the two sleep kinds, naming both`, () => {
+    ignoreLogs()
     const sleeps = (eventType: number) => [
       [`f`, 0, `do_nanosleep ([kernel]) <0xffff2>`],
       [`s`, 0, [0]],

--- a/src/formats/testing.ts
+++ b/src/formats/testing.ts
@@ -2,6 +2,7 @@ import { readFileSync, statSync } from 'node:fs'
 import path from 'node:path'
 import { gunzipSync } from 'node:zlib'
 import { inject } from 'vitest'
+import { parseExampleFilename } from '../cli/examples.ts'
 import type { NormalizedProfileToMdOptions } from '../options.ts'
 import { aggregateParsedInputs } from './aggregate.ts'
 import type {
@@ -50,6 +51,11 @@ export const readInput = (filename: string): Buffer => {
   const data = readFileSync(inputPath(filename))
   return data[0] === 0x1f && data[1] === 0x8b ? gunzipSync(data) : data
 }
+
+/** The lines auto-detecting a committed input logs. */
+export const detectionLogs = (filename: string): string[] => [
+  `info: format: ${parseExampleFilename(filename).format} (detected)`,
+]
 
 /**
  * The smallest of the given inputs, as a single-element array, or an empty

--- a/src/formats/v8/heap-snapshot/index.test.ts
+++ b/src/formats/v8/heap-snapshot/index.test.ts
@@ -7,7 +7,7 @@ import {
   selfSizeTables,
 } from '../../../modalities/heap-snapshot/testing.ts'
 import { normalizeProfileToMdOptions } from '../../../options.ts'
-import { categoryTables, rankingTables } from '../../../testing.ts'
+import { categoryTables, ignoreLogs, rankingTables } from '../../../testing.ts'
 import { diffProfiles } from '../../index.ts'
 import { convertJsonToMd } from '../../testing.ts'
 import { v8HeapSnapshotConverter } from './index.ts'
@@ -486,6 +486,7 @@ describe(`convert`, () => {
   })
 
   test(`matchEntry matches functions whose locations differ across snapshots`, () => {
+    ignoreLogs()
     // The function's script path carries a per-build suffix, so by default the
     // two sides don't match and the function shows as a removed/new pair.
     const base = JSON.stringify(

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,5 +29,6 @@ export type {
   SourceLocation,
   SourceReference,
 } from './location.ts'
+export type { Logger, LogLevel } from './logger.ts'
 export type { Origin } from './origins/index.ts'
 export type { SourceMap } from './source-map.ts'

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,0 +1,50 @@
+import { expect, test, vi } from 'vitest'
+import type * as logger from './logger.ts'
+import type { LogLevel } from './logger.ts'
+
+// The test setup mocks `normalizeLogger` to record every line, so these tests
+// import the real one.
+const { LOG_LEVELS, normalizeLogger } =
+  await vi.importActual<typeof logger>(`./logger.ts`)
+
+const LEVEL_METHODS = LOG_LEVELS.filter(level => level !== `none`)
+
+test.each(LOG_LEVELS)(
+  `normalizeLogger keeps the methods at or before %s`,
+  logLevel => {
+    const logger = Object.fromEntries(
+      LEVEL_METHODS.map(level => [level, () => {}]),
+    )
+
+    const normalized = normalizeLogger(logger, logLevel)
+
+    expect(Object.keys(normalized)).toStrictEqual(
+      LEVEL_METHODS.filter(
+        level => LOG_LEVELS.indexOf(level) <= LOG_LEVELS.indexOf(logLevel),
+      ),
+    )
+  },
+)
+
+test(`normalizeLogger omits the methods the logger lacks`, () => {
+  const normalized = normalizeLogger({ warn: () => {} }, `debug`)
+
+  expect(Object.keys(normalized)).toStrictEqual([`warn`])
+})
+
+test(`normalizeLogger returns no methods without a logger`, () => {
+  expect(normalizeLogger(undefined, `debug`)).toStrictEqual({})
+})
+
+test(`normalizeLogger calls the logger's methods on the logger`, () => {
+  const logger = {
+    messages: [] as string[],
+    info(message: string) {
+      this.messages.push(`info: ${message}`)
+    },
+  }
+
+  normalizeLogger(logger, `info` satisfies LogLevel).info!(`hello`)
+
+  expect(logger.messages).toStrictEqual([`info: hello`])
+})

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,45 @@
+/**
+ * The verbosity of a conversion's diagnostics, from `none` (the default) to
+ * `debug`. A level enables its own messages and every level before it.
+ */
+export type LogLevel = (typeof LOG_LEVELS)[number]
+
+/** Every {@link LogLevel}, least to most verbose. */
+export const LOG_LEVELS = [`none`, `error`, `warn`, `info`, `debug`] as const
+
+/**
+ * Receives a conversion's diagnostics, one message per call.
+ *
+ * Only defined methods are called, so `console` qualifies as a logger, and so
+ * does `{ warn: console.warn }`.
+ */
+export type Logger = Partial<
+  Record<Exclude<LogLevel, `none`>, (message: string) => void>
+>
+
+/**
+ * Filters a {@link Logger} to a {@link LogLevel}: a method is defined only if
+ * the logger defines it and the level enables it. Test for the method before
+ * building an expensive message.
+ */
+export const normalizeLogger = (
+  logger: Logger | undefined,
+  logLevel: LogLevel,
+): Logger => {
+  if (!logger) {
+    return {}
+  }
+
+  const threshold = LOG_LEVELS.indexOf(logLevel)
+  const normalized: Logger = {}
+  for (const level of LOG_LEVELS) {
+    if (level === `none`) {
+      continue
+    }
+    const log = logger[level]
+    if (log && LOG_LEVELS.indexOf(level) <= threshold) {
+      normalized[level] = message => log.call(logger, message)
+    }
+  }
+  return normalized
+}

--- a/src/options.ts
+++ b/src/options.ts
@@ -7,6 +7,8 @@ import {
   sourceReferenceKind,
 } from './location.ts'
 import type { SourceLocation } from './location.ts'
+import { LOG_LEVELS, normalizeLogger } from './logger.ts'
+import type { Logger, LogLevel } from './logger.ts'
 import type { AggregatedCallGraphFunction } from './modalities/call-graph/aggregate.ts'
 import type { AggregatedCallStackProfileFunction } from './modalities/call-stack-profile/aggregate.ts'
 import type { AggregatedHeapSnapshotNode } from './modalities/heap-snapshot/aggregate.ts'
@@ -227,6 +229,23 @@ export type ProfileToMdOptions = {
   sourceMaps?: SourceMap[] | Record<string, SourceMap>
 
   /**
+   * Receive the conversion's diagnostics: at `warn`, an option or input that
+   * had no effect; at `info`, each decision made on your behalf; and at
+   * `debug`, the reasoning behind each decision.
+   *
+   * Only defined methods are called, so `console` qualifies. The logger
+   * receives only the levels {@link logLevel} enables.
+   */
+  logger?: Logger
+
+  /**
+   * The most verbose level {@link logger} receives.
+   *
+   * Defaults to `none`.
+   */
+  logLevel?: LogLevel
+
+  /**
    * Returns a normalized name and location to match this entry by across
    * diffed profiles, or `undefined` to match by the entry's own name and
    * location.
@@ -290,6 +309,7 @@ export type NormalizedProfileToMdOptions = {
   minCategoryShare: number
   baseURL: URL | `auto` | undefined
   sourceMaps: NormalizedSourceMaps
+  logger: Logger
   entryMatchKeys: (
     entry: ProfileEntry,
     context: ProfileToMdContext,
@@ -331,6 +351,8 @@ export const normalizeProfileToMdOptions = ({
   minCategoryShare = 0.01,
   baseURL,
   sourceMaps = [],
+  logger,
+  logLevel = `none`,
   matchEntry = defaultMatchEntry,
   categorizeFunctions = defaultCategorizeFunctions,
   showEntry = defaultShowEntry,
@@ -339,6 +361,7 @@ export const normalizeProfileToMdOptions = ({
   minCategoryShare: normalizeMinCategoryShare(minCategoryShare),
   baseURL: normalizeBaseURL(baseURL),
   sourceMaps: normalizeSourceMaps(sourceMaps),
+  logger: normalizeLogger(logger, normalizeLogLevel(logLevel)),
   entryMatchKeys: cacheEntryFunction((entry, context) =>
     entryMatchKeys(entry, context, matchEntry),
   ),
@@ -362,6 +385,15 @@ const normalizeTopN = (topN: number): number => {
     )
   }
   return topN
+}
+
+const normalizeLogLevel = (logLevel: LogLevel): LogLevel => {
+  if (!LOG_LEVELS.includes(logLevel)) {
+    throw new ProfilerMdError(
+      `logLevel must be one of ${LOG_LEVELS.join(`, `)}, got: ${String(logLevel)}`,
+    )
+  }
+  return logLevel
 }
 
 const normalizeMinCategoryShare = (minCategoryShare: number): number => {

--- a/src/origins/index.test.ts
+++ b/src/origins/index.test.ts
@@ -9,6 +9,7 @@ import {
 import { HEAP_SNAPSHOT_NODE_CATEGORIES } from '../modalities/heap-snapshot/type.ts'
 import { FUNCTION_CATEGORIES, normalizeProfileToMdOptions } from '../options.ts'
 import type { NormalizedProfileToMdOptions } from '../options.ts'
+import { ignoreLogs } from '../testing.ts'
 import {
   categorizeHeapSnapshotConstructorForOrigin,
   OriginDetector,
@@ -41,6 +42,7 @@ if (inputFilenames.length > 0) {
     test.each(inputFilenames)(
       `%s resolves to its profiler's origin and categorizes canonically`,
       filename => {
+        ignoreLogs()
         const inputs = aggregateInput(
           readInput(filename),
           normalizeProfileToMdOptions(),
@@ -107,6 +109,7 @@ if (format === undefined) {
       readInput(`javascript.node.base.cpuprofile`)
 
     test(`an explicit origin overrides detection and reaches categorizeFunctions`, () => {
+      ignoreLogs()
       const detectedOrigins: Origin[] = []
       aggregateInput(nodeInput(), recordOriginOptions(detectedOrigins))
       expect(detectedOrigins).toEqual([`node`])

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, vi } from 'vitest'
+import { recordLog, takeUnassertedLogs } from './testing.ts'
+
+// Every conversion resolves its logger through `normalizeLogger`, so wrapping
+// it records every line the library logs, at every level and whatever
+// `logger` and `logLevel` the test passed. The caller's logger still receives
+// only what its options enable.
+vi.mock(import(`./logger.ts`), async importOriginal => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    normalizeLogger: (logger, logLevel) => {
+      const normalized = actual.normalizeLogger(logger, logLevel)
+      const recording: typeof normalized = {}
+      for (const level of actual.LOG_LEVELS) {
+        if (level === `none`) {
+          continue
+        }
+        recording[level] = message => {
+          // Called at call time: its module is mid-import while this factory
+          // runs.
+          recordLog(level, message)
+          normalized[level]?.(message)
+        }
+      }
+      return recording
+    },
+  }
+})
+
+const failOnUnassertedLogs = (message: string) => () => {
+  const lines = takeUnassertedLogs()
+  if (lines.length > 0) {
+    throw new Error(`${message}, got: ${lines.join(`, `)}`)
+  }
+}
+
+beforeEach(failOnUnassertedLogs(`a conversion logged lines outside a test`))
+afterEach(
+  failOnUnassertedLogs(
+    `the test did not pass every line a conversion logged to expectLogs`,
+  ),
+)

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,4 +1,5 @@
 import type { Node } from 'mdast'
+import { expect } from 'vitest'
 import { nodeText } from './helpers/markdown.ts'
 import {
   allTablesAfterHeadingContaining,
@@ -30,6 +31,38 @@ export const resolveProfileToMdOptions = (
     )
   }
   return { ...rest, baseURL }
+}
+
+const emittedLogs: string[] = []
+let logsIgnored = false
+
+/** Records a line the library logged, for {@link expectLogs} to assert. */
+export const recordLog = (level: string, message: string): void => {
+  emittedLogs.push(`${level}: ${message}`)
+}
+
+/** Asserts the lines logged since the previous call, and consumes them. */
+export const expectLogs = (expected: unknown[]): void => {
+  expect(emittedLogs.splice(0)).toStrictEqual(expected)
+}
+
+/**
+ * Exempts the current test from asserting the lines its conversions log, for
+ * a test whose subject is unrelated to them.
+ */
+export const ignoreLogs = (): void => {
+  logsIgnored = true
+}
+
+/**
+ * Consumes the logged lines a test left unasserted, and the test's exemption.
+ * Returns the lines unless the test ignored them.
+ */
+export const takeUnassertedLogs = (): string[] => {
+  const lines = emittedLogs.splice(0)
+  const ignored = logsIgnored
+  logsIgnored = false
+  return ignored ? [] : lines
 }
 
 export const profileTitles = (md: string): string[] =>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -145,16 +145,17 @@ export const projects = [
 export default defineConfig({
   test: {
     environment: `node`,
-    // Threads over the default forks pool, without per-file isolation. No test
-    // mutates module or global state, so a fresh worker and module graph per
-    // test file would only slow the run.
+    // Threads over the default forks pool, without per-file isolation. A test
+    // mutates only the log buffer, which the setup file resets per test, so a
+    // fresh worker and module graph per test file would only slow the run.
     pool: `threads`,
     isolate: false,
+    setupFiles: [`src/test-setup.ts`],
     exclude: [...configDefaults.exclude, `.claude/worktrees/**`],
     projects,
     coverage: {
       include: [`src`],
-      exclude: [`**/testing.ts`, `*.bench.ts`],
+      exclude: [`**/testing.ts`, `src/test-setup.ts`, `*.bench.ts`],
     },
   },
 })


### PR DESCRIPTION
The library reports the format it detected or was given, and at debug each format that recognized the input but rejected it, through the caller's logger filtered to logLevel.