### PR TITLE
feat(origins): log the resolved origin and its evidence

### DIFF
--- a/src/formats/aggregate.ts
+++ b/src/formats/aggregate.ts
@@ -1,13 +1,16 @@
+import type { DeepReadonly } from '../helpers/types.ts'
+import { sourceReferenceId } from '../location.ts'
 import { CallGraphAggregator } from '../modalities/call-graph/index.ts'
 import { CallStackProfileAggregator } from '../modalities/call-stack-profile/index.ts'
 import { HeapSnapshotAggregator } from '../modalities/heap-snapshot/aggregate.ts'
 import type {
   AggregationProfileToMdOptions,
+  ProfileEntry,
   ProfileToMdContext,
   UnresolvedProfileToMdContext,
 } from '../options.ts'
 import { OriginDetector } from '../origins/index.ts'
-import type { Origin } from '../origins/index.ts'
+import type { Origin, OriginEvidence } from '../origins/index.ts'
 import type { AggregatedInput, ParsedInput } from './converter.ts'
 import type { Format } from './registry.ts'
 
@@ -41,9 +44,52 @@ export const aggregateParsedInputs = (
     format: context.format,
     origin: detector.resolve(),
   }
+  // An input with no profiles has no entries to detect an origin from, and no
+  // functions for the origin to categorize, so the pipeline logs none.
+  if (aggregators.length > 0) {
+    logOrigin(detector, resolvedContext, options)
+  }
   return aggregators.map(aggregator =>
     aggregator.aggregate(options, resolvedContext),
   )
+}
+
+const logOrigin = (
+  detector: OriginDetector,
+  { origin }: ProfileToMdContext,
+  { logger }: AggregationProfileToMdOptions,
+): void => {
+  const { info, debug } = logger
+  if (!info && !debug) {
+    return
+  }
+
+  const { evidence, candidates } = detector
+  if (evidence.type !== `specified`) {
+    debug?.(`origin candidates, in priority order: ${candidates.join(`, `)}`)
+  }
+  info?.(`origin: ${origin} (${describeOriginEvidence(evidence)})`)
+}
+
+const describeOriginEvidence = (evidence: OriginEvidence): string => {
+  switch (evidence.type) {
+    case `specified`:
+      return `specified`
+    case `marker`:
+      return `detected from the entry ${describeEntry(evidence.entry)}`
+    case `hint`:
+      return `detected from the format's metadata`
+    case `fallback`:
+      return `the fallback: no entry marked another origin`
+  }
+}
+
+const describeEntry = ({
+  name,
+  location,
+}: DeepReadonly<ProfileEntry>): string => {
+  const described = name ?? `<anonymous>`
+  return location ? `${described} (${sourceReferenceId(location)})` : described
 }
 
 /**

--- a/src/formats/index.test.ts
+++ b/src/formats/index.test.ts
@@ -57,9 +57,16 @@ const format = injectedFormat()
 
 const SPEEDSCOPE_REJECTION_LOG = `debug: speedscope: recognized the input but rejected it: Cannot read properties of undefined (reading 'map')`
 const V8_CPU_PROFILE_REJECTION_LOG = `debug: v8-cpu-profile: recognized the input but rejected it: Cannot destructure property 'functionName' of 'callFrame' as it is null.`
+const V8_CPU_PROFILE_CANDIDATES_LOG = `debug: origin candidates, in priority order: deno, bun, node, chrome`
+const NODE_ORIGIN_LOG = `info: origin: node (detected from the entry post (node:inspector))`
+const CHROME_ORIGIN_LOG = `info: origin: chrome (the fallback: no entry marked another origin)`
 const V8_CPU_PROFILE_DIFF_LOGS = [
   `info: format: v8-cpu-profile (specified)`,
+  V8_CPU_PROFILE_CANDIDATES_LOG,
+  NODE_ORIGIN_LOG,
   `info: format: v8-cpu-profile (specified)`,
+  V8_CPU_PROFILE_CANDIDATES_LOG,
+  `info: origin: deno (detected from the entry __drainNextTickAndMacrotasks (ext:core/01_core.js))`,
 ]
 
 const inputSets = {
@@ -131,7 +138,7 @@ describe(`profileToMd`, () => {
       const md = profileToMd(readInput(filename), { baseURL: null })
 
       expect(md).toMatch(MARKDOWN_REGEX)
-      expectLogs(detectionLogs(filename))
+      expectLogs(detectionLogs(filename, md))
     })
   }
 
@@ -142,7 +149,7 @@ describe(`profileToMd`, () => {
       })
 
       expect(md).toMatch(MARKDOWN_REGEX)
-      expectLogs(detectionLogs(filename))
+      expectLogs(detectionLogs(filename, md))
     })
   }
 
@@ -158,7 +165,7 @@ describe(`profileToMd`, () => {
         const md = profileToMd(iterable, { baseURL: null })
 
         expect(md).toMatch(MARKDOWN_REGEX)
-        expectLogs(detectionLogs(filename))
+        expectLogs(detectionLogs(filename, md))
       },
     )
   }
@@ -176,7 +183,11 @@ describe(`profileToMd`, () => {
       expect(forced).toBe(auto)
       expectLogs([
         `info: format: v8-cpu-profile (detected)`,
+        V8_CPU_PROFILE_CANDIDATES_LOG,
+        NODE_ORIGIN_LOG,
         `info: format: v8-cpu-profile (specified)`,
+        V8_CPU_PROFILE_CANDIDATES_LOG,
+        NODE_ORIGIN_LOG,
       ])
     })
 
@@ -572,12 +583,22 @@ describe(`profileToMd`, () => {
         scenario: `before parse returns`,
         data: crashingV8CpuProfile,
         // Detection logs the rejection and moves on, so no format is detected.
-        logs: [V8_CPU_PROFILE_REJECTION_LOG],
+        detectedLogs: [V8_CPU_PROFILE_REJECTION_LOG],
+        specifiedLogs: [`info: format: v8-cpu-profile (specified)`],
       },
       {
         scenario: `while aggregation consumes the parse's lazy iterable`,
         data: lazilyCrashingV8CpuProfile,
-        logs: [`info: format: v8-cpu-profile (detected)`],
+        detectedLogs: [
+          `info: format: v8-cpu-profile (detected)`,
+          V8_CPU_PROFILE_CANDIDATES_LOG,
+          CHROME_ORIGIN_LOG,
+        ],
+        specifiedLogs: [
+          `info: format: v8-cpu-profile (specified)`,
+          V8_CPU_PROFILE_CANDIDATES_LOG,
+          CHROME_ORIGIN_LOG,
+        ],
       },
     ]
 
@@ -622,21 +643,21 @@ describe(`profileToMd`, () => {
 
     test.each(unclassifiedInputs)(
       `detection reports an error a parser did not classify the same way a specified format does, thrown $scenario`,
-      ({ data, logs }) => {
+      ({ data, detectedLogs, specifiedLogs }) => {
         let detected
         try {
           profileToMd(data)
         } catch (error: unknown) {
           detected = error
         }
-        expectLogs(logs)
+        expectLogs(detectedLogs)
         let specified
         try {
           profileToMd({ data, format: `v8-cpu-profile` })
         } catch (error: unknown) {
           specified = error
         }
-        expectLogs([`info: format: v8-cpu-profile (specified)`])
+        expectLogs(specifiedLogs)
 
         expect((detected as Error).message).toBe((specified as Error).message)
         expect(mayBeParserBug(detected)).toBe(true)
@@ -791,7 +812,7 @@ describe(`profileToMdAsync`, () => {
         const md = await profileToMdAsync(blob, { baseURL: null })
 
         expect(md).toMatch(MARKDOWN_REGEX)
-        expectLogs(detectionLogs(filename))
+        expectLogs(detectionLogs(filename, md))
       })
 
       test(`from ReadableStream`, async () => {
@@ -805,7 +826,7 @@ describe(`profileToMdAsync`, () => {
         const md = await profileToMdAsync(stream, { baseURL: null })
 
         expect(md).toMatch(MARKDOWN_REGEX)
-        expectLogs(detectionLogs(filename))
+        expectLogs(detectionLogs(filename, md))
       })
     })
   }
@@ -821,7 +842,11 @@ describe(`profileToMdAsync`, () => {
       )
 
       expect(md).toMatch(/^# /u)
-      expectLogs([`info: format: v8-cpu-profile (specified)`])
+      expectLogs([
+        `info: format: v8-cpu-profile (specified)`,
+        V8_CPU_PROFILE_CANDIDATES_LOG,
+        NODE_ORIGIN_LOG,
+      ])
     })
 
     test(`forced binary format streams a ReadableStream through parseAsync`, async () => {
@@ -845,10 +870,12 @@ describe(`profileToMdAsync`, () => {
       expect(md).toBe(
         profileToMd({ data: content, format: `collapsed` }, { baseURL: null }),
       )
-      expectLogs([
+      const logs = [
         `info: format: collapsed (specified)`,
-        `info: format: collapsed (specified)`,
-      ])
+        `debug: origin candidates, in priority order: py-spy, tachyon, async-profiler, eflambe, rbspy, excimer`,
+        `info: origin: py-spy (detected from the entry _run_module_as_main (<frozen runpy>:198))`,
+      ]
+      expectLogs([...logs, ...logs])
     })
 
     test(`throws on unknown data`, async () => {
@@ -1016,6 +1043,10 @@ describe(`origin detection`, () => {
 
     const md = convertJsonToMd(converter, {}, options, `collapsed`)
 
+    expectLogs([
+      `debug: origin candidates, in priority order: py-spy, tachyon, async-profiler, eflambe, rbspy, excimer`,
+      `info: origin: async-profiler (detected from the entry java/util/HashMap.put)`,
+    ])
     expect(selfSamplesTables(md)).toEqual([
       [
         {
@@ -1038,19 +1069,49 @@ describe(`origin detection`, () => {
 })
 
 describe(`logging`, () => {
-  test(`logs the detected format`, () => {
+  test(`logs the detected format and the fallback origin`, () => {
     profileToMd(baseCpuProfile, { baseURL: null })
 
-    expectLogs([`info: format: v8-cpu-profile (detected)`])
+    expectLogs([
+      `info: format: v8-cpu-profile (detected)`,
+      V8_CPU_PROFILE_CANDIDATES_LOG,
+      CHROME_ORIGIN_LOG,
+    ])
   })
 
-  test(`logs the specified format`, () => {
+  test(`logs the specified format and origin`, () => {
     profileToMd(
       { data: baseCpuProfile, format: `v8-cpu-profile`, origin: `deno` },
       { baseURL: null },
     )
 
-    expectLogs([`info: format: v8-cpu-profile (specified)`])
+    expectLogs([
+      `info: format: v8-cpu-profile (specified)`,
+      `info: origin: deno (specified)`,
+    ])
+  })
+
+  test(`logs the entry an origin was detected from`, () => {
+    const cpuProfile = JSON.stringify({
+      nodes: [
+        makeV8CpuProfileRoot([2]),
+        {
+          id: 2,
+          hitCount: 1,
+          callFrame: makeV8CallFrame(`post`, `node:inspector`),
+        },
+      ],
+      samples: [2],
+      timeDeltas: [20],
+    })
+
+    profileToMd(cpuProfile, { baseURL: null })
+
+    expectLogs([
+      `info: format: v8-cpu-profile (detected)`,
+      V8_CPU_PROFILE_CANDIDATES_LOG,
+      NODE_ORIGIN_LOG,
+    ])
   })
 
   test(`logs each format that recognized the input but rejected it`, () => {
@@ -1069,7 +1130,11 @@ describe(`logging`, () => {
     })
 
     expect(received).toStrictEqual([])
-    expectLogs([`info: format: v8-cpu-profile (detected)`])
+    expectLogs([
+      `info: format: v8-cpu-profile (detected)`,
+      V8_CPU_PROFILE_CANDIDATES_LOG,
+      CHROME_ORIGIN_LOG,
+    ])
   })
 
   test(`the logger receives the lines its level enables`, () => {
@@ -1081,8 +1146,15 @@ describe(`logging`, () => {
       logLevel: `info`,
     })
 
-    expect(received).toStrictEqual([`format: v8-cpu-profile (detected)`])
-    expectLogs([`info: format: v8-cpu-profile (detected)`])
+    expect(received).toStrictEqual([
+      `format: v8-cpu-profile (detected)`,
+      `origin: chrome (the fallback: no entry marked another origin)`,
+    ])
+    expectLogs([
+      `info: format: v8-cpu-profile (detected)`,
+      V8_CPU_PROFILE_CANDIDATES_LOG,
+      CHROME_ORIGIN_LOG,
+    ])
   })
 
   test(`throws on an unknown log level`, () => {
@@ -1114,7 +1186,10 @@ describe(`diffProfiles`, () => {
         expect(md).toMatch(MARKDOWN_DIFF_REGEX)
         // No regressions or improvements when diffing an input against itself.
         expect(md).not.toMatch(/Regressions|Improvements/u)
-        expectLogs([...detectionLogs(filename), ...detectionLogs(filename)])
+        expectLogs([
+          ...detectionLogs(filename, md),
+          ...detectionLogs(filename, md),
+        ])
       },
     )
   }
@@ -1424,7 +1499,10 @@ if (smallestAnyInput.length > 0) {
       )
 
       expect(md).toMatch(MARKDOWN_DIFF_REGEX)
-      expectLogs([...detectionLogs(filename), ...detectionLogs(filename)])
+      expectLogs([
+        ...detectionLogs(filename, md),
+        ...detectionLogs(filename, md),
+      ])
     })
   })
 }

--- a/src/formats/testing.ts
+++ b/src/formats/testing.ts
@@ -1,7 +1,7 @@
 import { readFileSync, statSync } from 'node:fs'
 import path from 'node:path'
 import { gunzipSync } from 'node:zlib'
-import { inject } from 'vitest'
+import { expect, inject } from 'vitest'
 import { parseExampleFilename } from '../cli/examples.ts'
 import type { NormalizedProfileToMdOptions } from '../options.ts'
 import { aggregateParsedInputs } from './aggregate.ts'
@@ -52,10 +52,24 @@ export const readInput = (filename: string): Buffer => {
   return data[0] === 0x1f && data[1] === 0x8b ? gunzipSync(data) : data
 }
 
-/** The lines auto-detecting a committed input logs. */
-export const detectionLogs = (filename: string): string[] => [
-  `info: format: ${parseExampleFilename(filename).format} (detected)`,
-]
+/**
+ * The lines auto-detecting a committed input logs, given the Markdown it
+ * converted to. The origin is the one the filename records, and the evidence
+ * for it varies per input. An input with no profiling data logs no origin.
+ */
+export const detectionLogs = (filename: string, md: string): unknown[] => {
+  const { format, origin } = parseExampleFilename(filename)
+  const logs: unknown[] = [`info: format: ${format} (detected)`]
+  if (!md.startsWith(`No profiling data found.`)) {
+    logs.push(
+      expect.stringMatching(/^debug: origin candidates, in priority order: /u),
+      expect.stringMatching(
+        new RegExp(`^info: origin: ${origin} \\(.+\\)$`, `u`),
+      ),
+    )
+  }
+  return logs
+}
 
 /**
  * The smallest of the given inputs, as a single-element array, or an empty

--- a/src/origins/index.ts
+++ b/src/origins/index.ts
@@ -110,35 +110,34 @@ export const normalizeStackFrameForContext = (
 export class OriginDetector {
   readonly #candidates: readonly SpecificOriginSpec[]
   readonly #fallback: SpecificOriginSpec
+  /**
+   * Whether the fallback is unconditional: no candidate, or a single candidate
+   * that is already the fallback (e.g. a single-runtime format), so no entry
+   * can change the outcome.
+   */
+  readonly #fallbackDecided: boolean
 
   /**
-   * Index of the highest-priority (lowest-index) candidate matched so far, or
-   * `Infinity` when none matched. Only higher-priority candidates can change
-   * the outcome, so `add` never evaluates candidates at or below it.
+   * The highest-priority match so far. Only a candidate outranking the matched
+   * one can change the outcome, so `add` never evaluates candidates at or below
+   * its index.
    */
-  #bestMatchIndex = Infinity
-  #decided: Origin | undefined
+  #match: OriginMatch = { type: `fallback` }
 
   public constructor({ format, origin }: UnresolvedProfileToMdContext) {
     this.#fallback = originToSpec.get(formatToConverter[format].fallbackOrigin)!
     if (origin !== null) {
       // A forced origin skips detection; added entries are ignored.
       this.#candidates = []
-      this.#decided = origin
+      this.#fallbackDecided = true
+      this.#match = { type: `specified`, origin }
       return
     }
 
     this.#candidates = formatToOriginSpecs.get(format) ?? []
-
-    // No candidates, or a single candidate that's already the fallback, is
-    // unconditional (e.g. a single-runtime format), so decide without
-    // inspecting any entry.
-    if (
-      this.#candidates.length === 0 ||
-      (this.#candidates.length === 1 && this.#candidates[0] === this.#fallback)
-    ) {
-      this.#decided = this.#fallback.id
-    }
+    this.#fallbackDecided = this.#candidates.every(
+      candidate => candidate === this.#fallback,
+    )
   }
 
   /**
@@ -146,7 +145,17 @@ export class OriginDetector {
    * further entries to add.
    */
   public get decided(): boolean {
-    return this.#decided !== undefined
+    const match = this.#match
+    switch (match.type) {
+      case `specified`:
+        return true
+      case `marker`:
+      case `hint`:
+        // The highest-priority candidate matched; nothing can outrank it.
+        return match.index === 0
+      case `fallback`:
+        return this.#fallbackDecided
+    }
   }
 
   /**
@@ -156,22 +165,20 @@ export class OriginDetector {
    * early; adding further entries is harmless.
    */
   public add(entry: DeepReadonly<ProfileEntry>): boolean {
-    if (this.#decided !== undefined) {
+    if (this.decided) {
       return true
     }
 
-    const endIndex = Math.min(this.#bestMatchIndex, this.#candidates.length)
+    const endIndex = Math.min(
+      matchedIndex(this.#match),
+      this.#candidates.length,
+    )
     for (let index = 0; index < endIndex; index++) {
       if (!this.#candidates[index]!.isMarkerEntry(entry)) {
         continue
       }
-      this.#bestMatchIndex = index
-      // The highest-priority candidate matched; nothing can outrank it.
-      if (index === 0) {
-        this.#decided = this.#candidates[0]!.id
-        return true
-      }
-      break
+      this.#match = { type: `marker`, index, entry }
+      return this.decided
     }
     return false
   }
@@ -188,20 +195,17 @@ export class OriginDetector {
    * isn't a candidate for the format is ignored.
    */
   public hint(origin: string): void {
-    if (this.#decided !== undefined) {
+    if (this.decided) {
       return
     }
 
     const index = this.#candidates.findIndex(
       candidate => candidate.id === origin,
     )
-    if (index === -1 || index >= this.#bestMatchIndex) {
+    if (index === -1 || index >= matchedIndex(this.#match)) {
       return
     }
-    this.#bestMatchIndex = index
-    if (index === 0) {
-      this.#decided = this.#candidates[0]!.id
-    }
+    this.#match = { type: `hint`, index }
   }
 
   /** Adds each entry until decided; adding further entries is harmless. */
@@ -215,17 +219,61 @@ export class OriginDetector {
 
   /** Resolves the detected origin from every entry added so far. */
   public resolve(): Origin {
-    if (this.#decided !== undefined) {
-      return this.#decided
+    const match = this.#match
+    switch (match.type) {
+      case `specified`:
+        return match.origin
+      case `marker`:
+      case `hint`:
+        return this.#candidates[match.index]!.id
+      case `fallback`:
+        return this.#fallback.id
     }
+  }
 
-    return (
-      this.#bestMatchIndex === Infinity
-        ? this.#fallback
-        : this.#candidates[this.#bestMatchIndex]!
-    ).id
+  /** The evidence {@link resolve} selects the origin by. */
+  public get evidence(): OriginEvidence {
+    const match = this.#match
+    switch (match.type) {
+      case `specified`:
+      case `hint`:
+      case `fallback`:
+        return { type: match.type }
+      case `marker`:
+        return { type: match.type, entry: match.entry }
+    }
+  }
+
+  /** The IDs of the origins that can emit the format, in priority order. */
+  public get candidates(): Origin[] {
+    return this.#candidates.map(candidate => candidate.id)
   }
 }
+
+/** The evidence an {@link OriginDetector} resolves its origin by. */
+export type OriginEvidence =
+  | { type: `specified` }
+  | { type: `marker`; entry: DeepReadonly<ProfileEntry> }
+  | { type: `hint` }
+  | { type: `fallback` }
+
+/**
+ * The highest-priority match an {@link OriginDetector} records: its evidence,
+ * with the candidate index a marker entry or hint matched, or the specified
+ * origin.
+ */
+type OriginMatch =
+  | { type: `specified`; origin: Origin }
+  | { type: `marker`; index: number; entry: DeepReadonly<ProfileEntry> }
+  | { type: `hint`; index: number }
+  | { type: `fallback` }
+
+/**
+ * The index of the candidate a match selected, or `Infinity` when no candidate
+ * matched yet, so any candidate outranks it.
+ */
+const matchedIndex = (match: OriginMatch): number =>
+  match.type === `marker` || match.type === `hint` ? match.index : Infinity
 
 /** One of the concrete origin specs, with its literal {@link Origin} ID. */
 type SpecificOriginSpec = (typeof originSpecs)[number]


### PR DESCRIPTION
The origin detector records what it resolved the origin by: the caller's specification, a marker entry, the format's metadata, or the fallback. The library reports it at info, and the candidates it ranked at debug.