### PR TITLE
feat(format): log the inferred base URL

### DIFF
--- a/src/formats/format.ts
+++ b/src/formats/format.ts
@@ -127,14 +127,30 @@ const makeFormattingProfileToMdOptions = (
   inputs: AggregatedInput[],
 ): FormattingProfileToMdOptions => {
   const { baseURL } = options
-  return baseURL === `auto`
-    ? {
-        ...options,
-        baseURL: commonAncestorDirectoryURL(
-          collectInferableURLs(inputs, { ...options, baseURL: undefined }),
-        ),
-      }
-    : { ...options, baseURL }
+  if (baseURL !== `auto`) {
+    return { ...options, baseURL }
+  }
+
+  const urls = collectInferableURLs(inputs, { ...options, baseURL: undefined })
+  const inferredBaseURL = commonAncestorDirectoryURL(urls)
+  logInferredBaseURL(inferredBaseURL, urls, options)
+  return { ...options, baseURL: inferredBaseURL }
+}
+
+const logInferredBaseURL = (
+  inferredBaseURL: URL | undefined,
+  urls: readonly URL[],
+  { logger }: NormalizedProfileToMdOptions,
+): void => {
+  if (inferredBaseURL) {
+    logger.info?.(
+      `base URL: inferred ${inferredBaseURL.href} from ${urls.length} locations`,
+    )
+  } else {
+    logger.warn?.(
+      `base URL "auto" inferred no directory, so paths stay absolute: no function categorized as ours has an absolute location`,
+    )
+  }
 }
 
 /**

--- a/src/formats/index.test.ts
+++ b/src/formats/index.test.ts
@@ -320,6 +320,12 @@ describe(`profileToMd`, () => {
           },
         ],
       ])
+      expectLogs([
+        `info: format: v8-cpu-profile (specified)`,
+        V8_CPU_PROFILE_CANDIDATES_LOG,
+        `info: origin: node (detected from the entry readFileSync (node:fs))`,
+        `warn: base URL "auto" inferred no directory, so paths stay absolute: no function categorized as ours has an absolute location`,
+      ])
     })
 
     test(`baseURL: 'auto' infers the common ancestor of HTTP locations`, () => {
@@ -1134,6 +1140,26 @@ describe(`logging`, () => {
       `info: format: v8-cpu-profile (detected)`,
       V8_CPU_PROFILE_CANDIDATES_LOG,
       CHROME_ORIGIN_LOG,
+    ])
+  })
+
+  test(`logs the inferred base URL`, () => {
+    profileToMd(baseCpuProfile, { baseURL: `auto` })
+
+    expectLogs([
+      `info: format: v8-cpu-profile (detected)`,
+      V8_CPU_PROFILE_CANDIDATES_LOG,
+      CHROME_ORIGIN_LOG,
+      `info: base URL: inferred file:///project/src/ from 2 locations`,
+    ])
+  })
+
+  test(`warns when no base URL is inferable`, () => {
+    profileToMd(emptyProfile, { baseURL: `auto` })
+
+    expectLogs([
+      `info: format: speedscope (detected)`,
+      `warn: base URL "auto" inferred no directory, so paths stay absolute: no function categorized as ours has an absolute location`,
     ])
   })
 


### PR DESCRIPTION
The library logs at info the directory baseURL "auto" inferred and the number of locations it inferred it from. When no location qualified, it warns that paths stay absolute.