### PR TITLE
feat(source-map): report what the source maps mapped per generated file

### DIFF
--- a/eslint-rules/error-message.js
+++ b/eslint-rules/error-message.js
@@ -43,16 +43,67 @@ const checks = [
 
 const LOGGER_METHODS = new Set([`error`, `warn`, `info`, `debug`])
 
+/** Matches a variable or property holding a logger: `logger`, `normalizedLogger`, `#logger`. */
+const LOGGER_NAME = /logger$/iu
+
+const isLoggerExpression = node =>
+  (node.type === `Identifier` && LOGGER_NAME.test(node.name)) ||
+  (node.type === `MemberExpression` &&
+    !node.computed &&
+    LOGGER_NAME.test(node.property.name))
+
 /**
- * Holds for `logger.<level>?.(...)` too, because optional chaining leaves the
- * callee a member expression.
+ * Whether {@link callee} is a logger method accessed on the logger, as in
+ * `logger.warn(...)`. Holds for `logger.warn?.(...)` too, because optional
+ * chaining leaves the callee a member expression.
  */
-const isLoggerCall = ({ callee }) =>
+const isLoggerMethodAccess = callee =>
   callee.type === `MemberExpression` &&
   !callee.computed &&
-  callee.object.type === `Identifier` &&
-  callee.object.name === `logger` &&
-  LOGGER_METHODS.has(callee.property.name)
+  LOGGER_METHODS.has(callee.property.name) &&
+  isLoggerExpression(callee.object)
+
+const findVariable = (scope, name) => {
+  for (let current = scope; current; current = current.upper) {
+    const variable = current.set.get(name)
+    if (variable) {
+      return variable
+    }
+  }
+  return undefined
+}
+
+/**
+ * Whether {@link callee} is a logger method destructured from the logger, as
+ * in `const { warn } = logger` followed by `warn(...)`.
+ */
+const isDestructuredLoggerMethod = (callee, sourceCode) => {
+  if (callee.type !== `Identifier`) {
+    return false
+  }
+  const variable = findVariable(sourceCode.getScope(callee), callee.name)
+  return (variable?.defs ?? []).some(({ type, node }) => {
+    if (
+      type !== `Variable` ||
+      node.id.type !== `ObjectPattern` ||
+      !node.init ||
+      !isLoggerExpression(node.init)
+    ) {
+      return false
+    }
+    return node.id.properties.some(
+      property =>
+        property.type === `Property` &&
+        !property.computed &&
+        LOGGER_METHODS.has(property.key.name) &&
+        property.value.type === `Identifier` &&
+        property.value.name === callee.name,
+    )
+  })
+}
+
+const isLoggerCall = ({ callee }, sourceCode) =>
+  isLoggerMethodAccess(callee) || isDestructuredLoggerMethod(callee, sourceCode)
 
 const isErrorConstruction = ({ callee }) =>
   callee.type === `Identifier` && callee.name.endsWith(`Error`)
@@ -93,7 +144,7 @@ export const errorMessage = {
         }
       },
       CallExpression: node => {
-        if (isLoggerCall(node)) {
+        if (isLoggerCall(node, context.sourceCode)) {
           checkMessage(node.arguments)
         }
       },

--- a/src/formats/format.ts
+++ b/src/formats/format.ts
@@ -26,7 +26,7 @@ import type {
   FormattingProfileToMdOptions,
   NormalizedProfileToMdOptions,
 } from '../options.ts'
-import { sourceMapSourceLocation } from '../source-map.ts'
+import { SourceMapResolver } from '../source-map.ts'
 import type { AggregatedInput, ParsedInput } from './converter.ts'
 
 export const formatAggregatedInputs = (
@@ -44,6 +44,7 @@ export const formatAggregatedInputs = (
         return formatHeapSnapshot(input, formattingOptions)
     }
   })
+  formattingOptions.sourceMaps.report(formattingOptions.baseURL)
   return toMarkdown(contents)
 }
 
@@ -105,6 +106,7 @@ export const formatAggregatedDiff = (
       `cannot diff a ${modalityName(baseInput.type)} against a ${modalityName(currentInput.type)}`,
     )
   })
+  formattingOptions.sourceMaps.report(formattingOptions.baseURL)
   return toMarkdown(contents)
 }
 
@@ -117,24 +119,40 @@ const toMarkdown = (contents: RootContent[]): string =>
   )
 
 /**
- * Resolves a `baseURL` of `'auto'` to the common ancestor directory of the
- * aggregated {@link inputs}.
- *
- * Any other `baseURL` passes through unchanged.
+ * Wraps the source maps in a resolver for this conversion, and records in it
+ * every generated file the aggregated {@link inputs} reference. Resolves a
+ * `baseURL` of `'auto'` to the common ancestor directory of the inputs, and
+ * passes any other `baseURL` through unchanged.
  */
 const makeFormattingProfileToMdOptions = (
   options: NormalizedProfileToMdOptions,
   inputs: AggregatedInput[],
 ): FormattingProfileToMdOptions => {
+  const sourceMaps = new SourceMapResolver(options.sourceMaps, options.logger)
   const { baseURL } = options
   if (baseURL !== `auto`) {
-    return { ...options, baseURL }
+    for (const { location } of locations(inputs)) {
+      sourceMaps.addGeneratedFile(location)
+    }
+    return { ...options, baseURL, sourceMaps }
   }
 
-  const urls = collectInferableURLs(inputs, { ...options, baseURL: undefined })
+  // The resolver maps each location first, so the base is inferred from the
+  // locations formatting will show. A relative source cannot contribute,
+  // because it resolves only against the base being inferred.
+  const urls: URL[] = []
+  for (const { location, inferable } of locations(inputs)) {
+    sourceMaps.addGeneratedFile(location)
+    if (inferable) {
+      const mappedLocation = sourceMaps.resolve(location, undefined)
+      if (isBaseURLInferableLocation(mappedLocation)) {
+        urls.push(mappedLocation.url)
+      }
+    }
+  }
   const inferredBaseURL = commonAncestorDirectoryURL(urls)
   logInferredBaseURL(inferredBaseURL, urls, options)
-  return { ...options, baseURL: inferredBaseURL }
+  return { ...options, baseURL: inferredBaseURL, sourceMaps }
 }
 
 const logInferredBaseURL = (
@@ -154,45 +172,41 @@ const logInferredBaseURL = (
 }
 
 /**
- * Collects the base-URL-inferable absolute URLs of {@link inputs}' entries.
+ * Yields the location of each entity in {@link inputs}, and whether the
+ * location may contribute to base URL inference.
  *
- * Applies source maps first so the base is inferred from the locations
- * formatting will show.
+ * Only a function categorized `ours` contributes, because a dependency's
+ * install path can be far outside the source tree. Including it would move the
+ * inferred base up to an ancestor the install path shares with the tree. Every
+ * heap snapshot entity contributes.
  */
-const collectInferableURLs = (
+function* locations(
   inputs: AggregatedInput[],
-  options: FormattingProfileToMdOptions,
-): URL[] => {
-  const urls: URL[] = []
-  const collect = (location: SourceLocation | undefined) => {
-    if (!location) {
-      return
-    }
-    const mappedLocation = sourceMapSourceLocation(location, options)
-    if (isBaseURLInferableLocation(mappedLocation)) {
-      urls.push(mappedLocation.url)
-    }
-  }
-
+): Iterable<{ location: SourceLocation; inferable: boolean }> {
   for (const input of inputs) {
     switch (input.type) {
       case `call-stack-profile`:
       case `call-graph`:
         for (const func of input.functions) {
-          // Only `ours`-categorized functions contribute, because a
-          // dependency's install path can be far outside the source tree and
-          // would raise the base to a shared root.
-          if (func.category === `ours`) {
-            collect(func.location)
+          if (func.location) {
+            yield {
+              location: func.location,
+              // Only `ours`-categorized functions contribute, because a
+              // dependency's install path can be far outside the source tree
+              // and would raise the base to a shared root.
+              inferable: func.category === `ours`,
+            }
           }
         }
         break
       case `heap-snapshot`:
         for (const entity of [...input.constructors, ...input.functions]) {
-          collect(entityLocation(entity))
+          const location = entityLocation(entity)
+          if (location) {
+            yield { location, inferable: true }
+          }
         }
         break
     }
   }
-  return urls
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -19,7 +19,11 @@ import {
 } from './origins/index.ts'
 import type { Origin } from './origins/index.ts'
 import { normalizeSourceMaps } from './source-map.ts'
-import type { NormalizedSourceMaps, SourceMap } from './source-map.ts'
+import type {
+  NormalizedSourceMaps,
+  SourceMap,
+  SourceMapResolver,
+} from './source-map.ts'
 
 /** Profile data that can be synchronously parsed and converted to Markdown. */
 export type ProfileData = string | Uint8Array | Iterable<Uint8Array>
@@ -130,7 +134,7 @@ export type EntryMatch = {
  * The keys an entry is paired by across a diff's two sides, derived from its
  * {@link EntryMatch}.
  */
-export type EntryMatchKeys = {
+type EntryMatchKeys = {
   /**
    * The key pairing entries by normalized name alone, for entities whose
    * location varies between profiles of the same program.
@@ -327,23 +331,26 @@ export type NormalizedProfileToMdOptions = {
 /**
  * The options aggregation code receives.
  *
- * Everything except `baseURL`, which only affects formatting and, for `'auto'`,
- * is resolvable only after aggregation (from the aggregated entries). The
- * omission keeps aggregation logic from depending on it.
+ * Everything except `baseURL` and `sourceMaps`, which only affect formatting.
+ * `baseURL: 'auto'` is resolvable only after aggregation (from the aggregated
+ * entries), and source maps apply to the locations formatting shows. The
+ * omission keeps aggregation logic from depending on them.
  */
 export type AggregationProfileToMdOptions = Omit<
   NormalizedProfileToMdOptions,
-  `baseURL`
+  `baseURL` | `sourceMaps`
 >
 
 /**
  * The options formatting code receives.
  *
  * {@link NormalizedProfileToMdOptions} with `'auto'` resolved to a concrete
- * base URL (or `undefined` when nothing qualified for inference).
+ * base URL (or `undefined` when nothing qualified for inference), and the
+ * source maps wrapped in a resolver that records one conversion's outcomes.
  */
 export type FormattingProfileToMdOptions = AggregationProfileToMdOptions & {
   baseURL: URL | undefined
+  sourceMaps: SourceMapResolver
 }
 
 export const normalizeProfileToMdOptions = ({
@@ -356,27 +363,30 @@ export const normalizeProfileToMdOptions = ({
   matchEntry = defaultMatchEntry,
   categorizeFunctions = defaultCategorizeFunctions,
   showEntry = defaultShowEntry,
-}: ProfileToMdOptions = {}): NormalizedProfileToMdOptions => ({
-  topN: normalizeTopN(topN),
-  minCategoryShare: normalizeMinCategoryShare(minCategoryShare),
-  baseURL: normalizeBaseURL(baseURL),
-  sourceMaps: normalizeSourceMaps(sourceMaps),
-  logger: normalizeLogger(logger, normalizeLogLevel(logLevel)),
-  entryMatchKeys: cacheEntryFunction((entry, context) =>
-    entryMatchKeys(entry, context, matchEntry),
-  ),
-  categorizeFunctions: (entries, context) => {
-    const categories = categorizeFunctions(entries, context)
-    if (categories.length !== entries.length) {
-      throw new ProfilerMdError(
-        `categorizeFunctions must return one category per entry, aligned by ` +
-          `index, got: ${categories.length} categories for ${entries.length} entries`,
-      )
-    }
-    return categories
-  },
-  showEntry: cacheEntryFunction(showEntry),
-})
+}: ProfileToMdOptions = {}): NormalizedProfileToMdOptions => {
+  const normalizedLogger = normalizeLogger(logger, normalizeLogLevel(logLevel))
+  return {
+    topN: normalizeTopN(topN),
+    minCategoryShare: normalizeMinCategoryShare(minCategoryShare),
+    baseURL: normalizeBaseURL(baseURL),
+    sourceMaps: normalizeSourceMaps(sourceMaps, normalizedLogger),
+    logger: normalizedLogger,
+    entryMatchKeys: cacheEntryFunction((entry, context) =>
+      entryMatchKeys(entry, context, matchEntry),
+    ),
+    categorizeFunctions: (entries, context) => {
+      const categories = categorizeFunctions(entries, context)
+      if (categories.length !== entries.length) {
+        throw new ProfilerMdError(
+          `categorizeFunctions must return one category per entry, aligned by ` +
+            `index, got: ${categories.length} categories for ${entries.length} entries`,
+        )
+      }
+      return categories
+    },
+    showEntry: cacheEntryFunction(showEntry),
+  }
+}
 
 const normalizeTopN = (topN: number): number => {
   if (!(Number.isSafeInteger(topN) && topN >= 0)) {

--- a/src/source-map.test.ts
+++ b/src/source-map.test.ts
@@ -1,11 +1,16 @@
 import { expect, test } from 'vitest'
+import {
+  makeV8CallFrame,
+  makeV8CpuProfileRoot,
+} from './formats/v8/cpu-profile/testing.ts'
+import { profileToMd } from './index.ts'
 import type {
   FormattingProfileToMdOptions,
   ProfileToMdOptions,
 } from './options.ts'
-import { normalizeSourceMaps, sourceMapSourceLocation } from './source-map.ts'
+import { sourceMapSourceLocation } from './source-map.ts'
 import type { SourceMap } from './source-map.ts'
-import { resolveProfileToMdOptions } from './testing.ts'
+import { expectLogs, resolveProfileToMdOptions } from './testing.ts'
 
 // Maps generated line 1 col 0 -> sources[0] line 1 col 0 (0-based).
 const L1_C0_TO_SOURCE_0_L1_C0 = `AAAA`
@@ -27,133 +32,154 @@ const makeNormalizedOptions = ({
 >): FormattingProfileToMdOptions =>
   resolveProfileToMdOptions({ baseURL, sourceMaps })
 
-test(`normalizeSourceMaps drops entries with no file field`, () => {
-  const sourceMaps = normalizeSourceMaps([makeSourceMap()])
+const LOCATION = {
+  type: `absolute`,
+  url: new URL(`file:///project/dist/app.js`),
+  line: 1,
+  column: 1,
+} as const
 
-  expect(sourceMaps).toHaveLength(0)
+const MAPPED_LOCATION = {
+  type: `absolute`,
+  url: new URL(`file:///project/src/original.ts`),
+  line: 1,
+  column: 1,
+} as const
+
+const mapping = (sourceMap: Partial<SourceMap> = {}): SourceMap =>
+  makeSourceMap({
+    sources: [`/project/src/original.ts`],
+    mappings: L1_C0_TO_SOURCE_0_L1_C0,
+    ...sourceMap,
+  })
+
+test(`sourceMaps drops and warns about a list entry with no file field`, () => {
+  const mappedLocation = sourceMapSourceLocation(
+    LOCATION,
+    resolveProfileToMdOptions({ sourceMaps: [mapping()] }),
+  )
+
+  expect(mappedLocation).toStrictEqual(LOCATION)
+  expectLogs([
+    `warn: source map ignored: the entry at index 0 has no "file" field naming the generated file it maps`,
+  ])
 })
 
-test(`normalizeSourceMaps drops entries with the placeholder unknown file field`, () => {
-  const sourceMaps = normalizeSourceMaps([makeSourceMap({ file: `unknown` })])
+test(`sourceMaps drops and warns about a record entry with the placeholder unknown key`, () => {
+  const mappedLocation = sourceMapSourceLocation(
+    LOCATION,
+    resolveProfileToMdOptions({ sourceMaps: { unknown: mapping() } }),
+  )
 
-  expect(sourceMaps).toHaveLength(0)
+  expect(mappedLocation).toStrictEqual(LOCATION)
+  expectLogs([
+    `warn: source map ignored: its key is the placeholder a compiler writes when given no file name, got: unknown`,
+  ])
 })
 
-test(`normalizeSourceMaps throws for an invalid source map`, () => {
+test(`sourceMaps drops and warns about a list entry with the placeholder unknown file field`, () => {
+  const mappedLocation = sourceMapSourceLocation(
+    LOCATION,
+    resolveProfileToMdOptions({ sourceMaps: [mapping({ file: `unknown` })] }),
+  )
+
+  expect(mappedLocation).toStrictEqual(LOCATION)
+  expectLogs([
+    `warn: source map ignored: the "file" field of the entry at index 0 is the placeholder a compiler writes when given no file name, got: unknown`,
+  ])
+})
+
+test(`sourceMaps drops and warns about a list entry whose file field names the same generated file as an earlier entry`, () => {
+  const mappedLocation = sourceMapSourceLocation(
+    LOCATION,
+    makeNormalizedOptions({
+      sourceMaps: [
+        mapping({ file: `/project/dist/app.js` }),
+        mapping({
+          file: `file:///project/dist/app.js`,
+          sources: [`/project/src/other.ts`],
+        }),
+      ],
+    }),
+  )
+
+  expect(mappedLocation).toStrictEqual(MAPPED_LOCATION)
+  expectLogs([
+    `warn: source map ignored: the "file" field of the entry at index 1 names the same generated file as an earlier entry, got: file:///project/dist/app.js`,
+  ])
+})
+
+test(`sourceMaps drops and warns about a record entry whose key names the same generated file as an earlier entry`, () => {
+  const mappedLocation = sourceMapSourceLocation(
+    LOCATION,
+    makeNormalizedOptions({
+      sourceMaps: {
+        '/project/dist/app.js': mapping(),
+        'file:///project/dist/app.js': mapping({
+          sources: [`/project/src/other.ts`],
+        }),
+      },
+    }),
+  )
+
+  expect(mappedLocation).toStrictEqual(MAPPED_LOCATION)
+  expectLogs([
+    `warn: source map ignored: its key names the same generated file as an earlier entry, got: file:///project/dist/app.js`,
+  ])
+})
+
+test(`sourceMaps throws for an invalid source map`, () => {
   expect(() =>
-    normalizeSourceMaps([makeSourceMap({ file: `/app.js`, version: `2` })]),
+    resolveProfileToMdOptions({
+      sourceMaps: [mapping({ file: `/app.js`, version: `2` })],
+    }),
   ).toThrow(
     `sourceMaps entry for /app.js is an invalid source map: Unsupported version: 2`,
   )
 })
 
-test(`normalizeSourceMaps infers absolute location from absolute file path`, () => {
-  const sourceMaps = normalizeSourceMaps([
-    makeSourceMap({
-      file: `/project/dist/app.js`,
-    }),
-  ])
+test.each([
+  [`absolute file path`, `/project/dist/app.js`],
+  [`file URL`, `file:///project/dist/app.js`],
+  [`relative file`, `dist/app.js`],
+])(`sourceMaps matches a list entry's %s file field`, (_, file) => {
+  const mappedLocation = sourceMapSourceLocation(
+    LOCATION,
+    makeNormalizedOptions({ sourceMaps: [mapping({ file })] }),
+  )
 
-  expect(sourceMaps).toMatchObject([
-    {
-      fileReference: {
-        type: `absolute`,
-        url: new URL(`file:///project/dist/app.js`),
-      },
-    },
-  ])
+  expect(mappedLocation).toStrictEqual(MAPPED_LOCATION)
 })
 
-test(`normalizeSourceMaps infers absolute location from file URL`, () => {
-  const sourceMaps = normalizeSourceMaps([
-    makeSourceMap({ file: `file:///project/dist/app.js` }),
-  ])
-
-  expect(sourceMaps).toMatchObject([
-    {
-      fileReference: {
-        type: `absolute`,
-        url: new URL(`file:///project/dist/app.js`),
-      },
-    },
-  ])
-})
-
-test(`normalizeSourceMaps infers relative location from relative file`, () => {
-  const sourceMaps = normalizeSourceMaps([
-    makeSourceMap({ file: `dist/app.js` }),
-  ])
-
-  expect(sourceMaps).toMatchObject([
-    {
-      fileReference: {
-        type: `relative`,
-        path: `dist/app.js`,
-      },
-    },
-  ])
-})
-
-test(`normalizeSourceMaps does not use sourceRoot to resolve the file field`, () => {
+test(`sourceMaps ignores sourceRoot when resolving the file field`, () => {
   // `sourceRoot` applies to `sources` (original), not to `file` (generated).
-  const sourceMaps = normalizeSourceMaps([
-    makeSourceMap({
-      file: `app.js`,
-      sourceRoot: `file:///project/src/`,
+  const mappedLocation = sourceMapSourceLocation(
+    LOCATION,
+    makeNormalizedOptions({
+      sourceMaps: [
+        mapping({
+          file: `app.js`,
+          sourceRoot: `file:///project/src/`,
+          sources: [`original.ts`],
+        }),
+      ],
     }),
-  ])
+  )
 
-  expect(sourceMaps).toMatchObject([
-    {
-      fileReference: {
-        type: `relative`,
-        path: `app.js`,
-      },
-    },
-  ])
+  expect(mappedLocation).toStrictEqual(MAPPED_LOCATION)
 })
 
-test(`normalizeSourceMaps converts absolute path key to absolute location`, () => {
-  const sourceMaps = normalizeSourceMaps({
-    '/project/dist/app.js': makeSourceMap(),
-  })
+test.each([
+  [`absolute path`, `/project/dist/app.js`],
+  [`URL`, `file:///project/dist/app.js`],
+  [`relative path`, `dist/app.js`],
+])(`sourceMaps matches a record entry's %s key`, (_, key) => {
+  const mappedLocation = sourceMapSourceLocation(
+    LOCATION,
+    makeNormalizedOptions({ sourceMaps: { [key]: mapping() } }),
+  )
 
-  expect(sourceMaps).toMatchObject([
-    {
-      fileReference: {
-        type: `absolute`,
-        url: new URL(`file:///project/dist/app.js`),
-      },
-    },
-  ])
-})
-
-test(`normalizeSourceMaps converts URL key to absolute location`, () => {
-  const sourceMaps = normalizeSourceMaps({
-    'file:///project/dist/app.js': makeSourceMap(),
-  })
-
-  expect(sourceMaps).toMatchObject([
-    {
-      fileReference: {
-        type: `absolute`,
-        url: new URL(`file:///project/dist/app.js`),
-      },
-    },
-  ])
-})
-
-test(`normalizeSourceMaps converts relative path key to relative location`, () => {
-  const sourceMaps = normalizeSourceMaps({ 'dist/app.js': makeSourceMap() })
-
-  expect(sourceMaps).toMatchObject([
-    {
-      fileReference: {
-        type: `relative`,
-        path: `dist/app.js`,
-      },
-    },
-  ])
+  expect(mappedLocation).toStrictEqual(MAPPED_LOCATION)
 })
 
 test(`sourceMapSourceLocation matches by absolute location`, () => {
@@ -426,4 +452,151 @@ test(`sourceMapSourceLocation converts result column from 0-based to 1-based`, (
     line: 1,
     column: 1,
   })
+})
+
+const cpuProfile = JSON.stringify({
+  nodes: [
+    makeV8CpuProfileRoot([2, 3]),
+    {
+      id: 2,
+      hitCount: 5,
+      callFrame: makeV8CallFrame(`funcA`, `file:///project/dist/a.js`),
+    },
+    {
+      id: 3,
+      hitCount: 3,
+      callFrame: makeV8CallFrame(`funcB`, `file:///project/dist/b.js`),
+    },
+  ],
+  samples: [2, 2, 2, 2, 2, 3, 3, 3],
+  timeDeltas: Array.from({ length: 8 }, () => 20),
+})
+
+const DETECTION_LOGS = [
+  `info: format: v8-cpu-profile (detected)`,
+  `debug: origin candidates, in priority order: deno, bun, node, chrome`,
+  `info: origin: chrome (the fallback: no entry marked another origin)`,
+]
+
+test(`sourceMaps reports each generated file and warns about a map matching none`, () => {
+  profileToMd(cpuProfile, {
+    baseURL: null,
+    sourceMaps: {
+      'file:///project/dist/a.js': mapping(),
+      'file:///project/dist/c.js': mapping(),
+    },
+  })
+
+  expectLogs([
+    ...DETECTION_LOGS,
+    `info: source maps: 1 of 2 generated files have a source map`,
+    `warn: source map for file:///project/dist/c.js matched no generated file in the profile, whose generated files are: file:///project/dist/a.js, file:///project/dist/b.js`,
+    `debug: file:///project/dist/a.js: mapped by the source map for file:///project/dist/a.js`,
+    `debug: file:///project/dist/b.js: no source map`,
+  ])
+})
+
+test(`sourceMaps warns about relative sources with no base URL`, () => {
+  profileToMd(cpuProfile, {
+    baseURL: null,
+    sourceMaps: {
+      'file:///project/dist/a.js': mapping({ sources: [`../src/a.ts`] }),
+    },
+  })
+
+  expectLogs([
+    ...DETECTION_LOGS,
+    `info: source maps: 1 of 2 generated files have a source map`,
+    `warn: source map sources are relative paths, so their locations stay unmapped until baseURL is set`,
+    `debug: file:///project/dist/a.js: mapped by the source map for file:///project/dist/a.js, whose sources are relative paths and stay unmapped without a base URL`,
+    `debug: file:///project/dist/b.js: no source map`,
+  ])
+})
+
+test(`sourceMaps resolves relative sources against an inferred base URL without warning`, () => {
+  const markdown = profileToMd(cpuProfile, {
+    baseURL: `auto`,
+    sourceMaps: {
+      'file:///project/dist/a.js': mapping({ sources: [`../src/a.ts`] }),
+    },
+  })
+
+  expect(markdown).toContain(`../src/a.ts:1:1`)
+  expectLogs([
+    ...DETECTION_LOGS,
+    `info: base URL: inferred file:///project/dist/ from 2 locations`,
+    `info: source maps: 1 of 2 generated files have a source map`,
+    `debug: file:///project/dist/a.js: mapped by the source map for file:///project/dist/a.js`,
+    `debug: file:///project/dist/b.js: no source map`,
+  ])
+})
+
+test(`sourceMaps counts and matches generated files formatting does not show`, () => {
+  profileToMd(cpuProfile, {
+    baseURL: null,
+    // Shows only the hotter function, in `a.js`.
+    topN: 1,
+    sourceMaps: { 'file:///project/dist/b.js': mapping() },
+  })
+
+  expectLogs([
+    ...DETECTION_LOGS,
+    `info: source maps: 1 of 2 generated files have a source map`,
+    `debug: file:///project/dist/a.js: no source map`,
+    `debug: file:///project/dist/b.js: mapped by the source map for file:///project/dist/b.js`,
+  ])
+})
+
+test(`sourceMaps reports each conversion's generated files when options are shared`, () => {
+  const options: ProfileToMdOptions = {
+    baseURL: null,
+    sourceMaps: { 'file:///project/dist/a.js': mapping() },
+  }
+  const otherCpuProfile = JSON.stringify({
+    nodes: [
+      makeV8CpuProfileRoot([2]),
+      {
+        id: 2,
+        hitCount: 1,
+        callFrame: makeV8CallFrame(`funcC`, `file:///project/dist/c.js`),
+      },
+    ],
+    samples: [2],
+    timeDeltas: [20],
+  })
+
+  profileToMd(cpuProfile, options)
+  profileToMd(otherCpuProfile, options)
+
+  expectLogs([
+    ...DETECTION_LOGS,
+    `info: source maps: 1 of 2 generated files have a source map`,
+    `debug: file:///project/dist/a.js: mapped by the source map for file:///project/dist/a.js`,
+    `debug: file:///project/dist/b.js: no source map`,
+    ...DETECTION_LOGS,
+    `info: source maps: 0 of 1 generated files have a source map`,
+    `warn: source map for file:///project/dist/a.js matched no generated file in the profile, whose generated files are: file:///project/dist/c.js`,
+    `debug: file:///project/dist/c.js: no source map`,
+  ])
+})
+
+test(`sourceMaps reports the positions a source map has no mapping for`, () => {
+  profileToMd(cpuProfile, {
+    baseURL: null,
+    // Maps only generated line 2, so line 1 has no mapping.
+    sourceMaps: { 'file:///project/dist/a.js': mapping({ mappings: `;AAAA` }) },
+  })
+
+  expectLogs([
+    ...DETECTION_LOGS,
+    `info: source maps: 1 of 2 generated files have a source map`,
+    `debug: file:///project/dist/a.js: mapped by the source map for file:///project/dist/a.js, which has no mapping for 1 position (e.g. 1:1)`,
+    `debug: file:///project/dist/b.js: no source map`,
+  ])
+})
+
+test(`sourceMaps logs nothing without source maps`, () => {
+  profileToMd(cpuProfile, { baseURL: null })
+
+  expectLogs(DETECTION_LOGS)
 })

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -1,8 +1,10 @@
 import { SourceMapConsumer } from 'source-map-js'
 import type { MappedPosition, RawSourceMap as SourceMap } from 'source-map-js'
 import { ProfilerMdError, reasonOf } from './error.ts'
-import { makeFileReference } from './location.ts'
+import { formatCount } from './helpers/format.ts'
+import { makeFileReference, sourceReferenceId } from './location.ts'
 import type { FileReference, SourceLocation } from './location.ts'
+import type { Logger } from './logger.ts'
 import type { FormattingProfileToMdOptions } from './options.ts'
 
 type NormalizedSourceMap = {
@@ -10,115 +12,359 @@ type NormalizedSourceMap = {
   fileReference: FileReference
 }
 
-export type NormalizedSourceMaps = NormalizedSourceMap[]
+/** The caller's source maps, each keyed by the generated file it maps. */
+export type NormalizedSourceMaps = readonly NormalizedSourceMap[]
 
-export const normalizeSourceMaps = (
-  sourceMaps: SourceMap[] | Record<string, SourceMap>,
-): NormalizedSourceMaps => {
-  if (Array.isArray(sourceMaps)) {
-    sourceMaps = Object.fromEntries(
-      sourceMaps.flatMap(sourceMap =>
-        sourceMap.file ? [[sourceMap.file, sourceMap]] : [],
-      ),
+type GeneratedFileOutcome = UnmappedGeneratedFile | MappedGeneratedFile
+
+/** A generated file no source map matched. */
+type UnmappedGeneratedFile = { type: `unmapped` }
+
+/** A generated file a source map matched, and what the map did to its locations. */
+type MappedGeneratedFile = {
+  type: `mapped`
+  sourceMap: NormalizedSourceMap
+  /** `line:column` positions the source map had no mapping for. */
+  unmappedPositions: Set<string>
+  /** Whether the source map mapped a location to a relative source path. */
+  relativeSource: boolean
+}
+
+const UNMAPPED_GENERATED_FILE: UnmappedGeneratedFile = { type: `unmapped` }
+
+/**
+ * Applies the caller's source maps to one conversion's locations, and records
+ * each generated file's outcome for {@link SourceMapResolver.report}.
+ */
+export class SourceMapResolver {
+  readonly #sourceMaps: NormalizedSourceMaps
+  readonly #logger: Logger
+  readonly #generatedFiles = new Map<string, GeneratedFileOutcome>()
+
+  public constructor(sourceMaps: NormalizedSourceMaps, logger: Logger) {
+    this.#sourceMaps = sourceMaps
+    this.#logger = logger
+  }
+
+  /**
+   * Records {@link location}'s generated file, so {@link report} counts it
+   * whether or not formatting resolves a location in it.
+   */
+  public addGeneratedFile(location: SourceLocation): void {
+    if (this.#sourceMaps.length > 0 && location.type === `absolute`) {
+      this.#outcomeFor(location.url)
+    }
+  }
+
+  /**
+   * Applies the matching source map, if any, to {@link location}.
+   *
+   * A mapped source that is a relative path resolves against the resolved
+   * `baseURL`, including one inferred by `baseURL: 'auto'`. The resolved source
+   * may then be outside the inferred directory and format with `../`
+   * segments. Without a base URL the location stays unmapped.
+   */
+  public resolve(
+    location: SourceLocation,
+    baseURL: URL | undefined,
+  ): SourceLocation {
+    if (this.#sourceMaps.length === 0 || location.type !== `absolute`) {
+      // A source map never applies to a relative path, whose target is
+      // unknown, or to a logical location, which is not a file.
+      return location
+    }
+
+    const outcome = this.#outcomeFor(location.url)
+    if (outcome.type === `unmapped`) {
+      return location
+    }
+
+    const mappedPosition = originalPositionOf(
+      outcome.sourceMap.consumer,
+      location,
+    )
+    if (!mappedPosition) {
+      return this.#unmapped(outcome, location)
+    }
+
+    const mappedFileReference = makeSourceMapFileReference(
+      mappedPosition.source,
+    )
+    if (!mappedFileReference) {
+      return this.#unmapped(outcome, location)
+    }
+
+    if (mappedFileReference.type === `absolute`) {
+      return mappedLocation(mappedFileReference.url, mappedPosition)
+    }
+
+    outcome.relativeSource = true
+    return baseURL
+      ? mappedLocation(
+          new URL(mappedFileReference.path, baseURL),
+          mappedPosition,
+        )
+      : location
+  }
+
+  #outcomeFor(url: URL): GeneratedFileOutcome {
+    let outcome = this.#generatedFiles.get(url.href)
+    if (!outcome) {
+      const sourceMap = this.#findSourceMap(url)
+      outcome = sourceMap
+        ? {
+            type: `mapped`,
+            sourceMap,
+            unmappedPositions: new Set(),
+            relativeSource: false,
+          }
+        : UNMAPPED_GENERATED_FILE
+      this.#generatedFiles.set(url.href, outcome)
+    }
+    return outcome
+  }
+
+  #findSourceMap(url: URL): NormalizedSourceMap | undefined {
+    return (
+      this.#sourceMaps.find(
+        sourceMap =>
+          sourceMap.fileReference.type === `absolute` &&
+          sourceMap.fileReference.url.href === url.href,
+      ) ??
+      this.#sourceMaps.find(
+        sourceMap =>
+          sourceMap.fileReference.type === `relative` &&
+          url.pathname.endsWith(`/${sourceMap.fileReference.path}`),
+      )
     )
   }
 
-  return Object.entries(sourceMaps).flatMap(([urlOrPath, sourceMap]) => {
-    const fileReference = makeSourceMapFileReference(urlOrPath)
-    if (!fileReference) {
-      return []
-    }
-    let consumer: SourceMapConsumer
-    try {
-      consumer = new SourceMapConsumer(sourceMap)
-    } catch (error) {
-      throw new ProfilerMdError(
-        `sourceMaps entry for ${urlOrPath} is an invalid source map: ${reasonOf(
-          error,
-        )}`,
-        { cause: error },
+  #unmapped(
+    outcome: MappedGeneratedFile,
+    location: SourceLocation & { type: `absolute` },
+  ): SourceLocation {
+    if (this.#logger.debug) {
+      outcome.unmappedPositions.add(
+        `${location.line ?? 1}:${location.column ?? 1}`,
       )
     }
-    return { consumer, fileReference }
-  })
+    return location
+  }
+
+  /**
+   * Logs what the source maps did across the generated files recorded so far:
+   * a summary of the generated files at `info`, each supplied map that matched
+   * no generated file at `warn`, and each generated file's outcome at `debug`.
+   *
+   * {@link baseURL} is the base URL formatting resolved relative sources
+   * against, so the report states which relative sources stayed unmapped.
+   */
+  public report(baseURL: URL | undefined): void {
+    const logger = this.#logger
+    if (this.#sourceMaps.length === 0) {
+      return
+    }
+
+    const mappedFiles = this.#mappedFiles()
+
+    logger.info?.(
+      `source maps: ${mappedFiles.length} of ${this.#generatedFiles.size} generated files have a source map`,
+    )
+
+    if (logger.warn) {
+      const matched = new Set(mappedFiles.map(({ sourceMap }) => sourceMap))
+      for (const sourceMap of this.#sourceMaps) {
+        if (!matched.has(sourceMap)) {
+          logger.warn(
+            `source map for ${sourceReferenceId(sourceMap.fileReference)} matched no generated file in the profile, whose generated files are: ${describeGeneratedFiles(this.#generatedFiles.keys())}`,
+          )
+        }
+      }
+      if (
+        !baseURL &&
+        mappedFiles.some(({ relativeSource }) => relativeSource)
+      ) {
+        logger.warn(
+          `source map sources are relative paths, so their locations stay unmapped until baseURL is set`,
+        )
+      }
+    }
+
+    if (logger.debug) {
+      for (const [href, outcome] of this.#generatedFiles) {
+        logger.debug(`${href}: ${describeGeneratedFile(outcome, baseURL)}`)
+      }
+    }
+  }
+
+  #mappedFiles(): MappedGeneratedFile[] {
+    const mappedFiles: MappedGeneratedFile[] = []
+    for (const outcome of this.#generatedFiles.values()) {
+      if (outcome.type === `mapped`) {
+        mappedFiles.push(outcome)
+      }
+    }
+    return mappedFiles
+  }
 }
 
 /**
- * Applies the matching source map, if any, to {@link location}.
- *
- * A mapped source that is a relative path resolves against the resolved
- * `baseURL`, including one inferred by `baseURL: 'auto'`; the resolved source
- * may then fall outside the inferred directory and format with `../` segments.
+ * Keys each of the caller's source maps by the generated file it maps, warning
+ * about and dropping each map that identifies no generated file or names the
+ * same generated file as an earlier map.
  */
-export const sourceMapSourceLocation = (
-  location: SourceLocation,
-  { baseURL, sourceMaps }: FormattingProfileToMdOptions,
-): SourceLocation => {
-  if (location.type !== `absolute`) {
-    // A source map never applies to a relative path, whose target is unknown,
-    // or to a logical location, which is not a file.
-    return location
+export const normalizeSourceMaps = (
+  sourceMaps: SourceMap[] | Record<string, SourceMap>,
+  logger: Logger,
+): NormalizedSourceMaps => {
+  const normalized = new Map<string, NormalizedSourceMap>()
+
+  const add = (
+    urlOrPath: string,
+    sourceMap: SourceMap,
+    describeKey: (rejection: string) => string,
+  ): void => {
+    const fileReference = makeSourceMapFileReference(urlOrPath)
+    if (!fileReference) {
+      logger.warn?.(
+        `source map ignored: ${describeKey(rejectionReason(urlOrPath))}, got: ${urlOrPath}`,
+      )
+      return
+    }
+
+    const generatedFileId = sourceReferenceId(fileReference)
+    if (normalized.has(generatedFileId)) {
+      logger.warn?.(
+        `source map ignored: ${describeKey(`names the same generated file as an earlier entry`)}, got: ${urlOrPath}`,
+      )
+      return
+    }
+
+    normalized.set(generatedFileId, {
+      consumer: makeSourceMapConsumer(urlOrPath, sourceMap),
+      fileReference,
+    })
   }
 
-  const sourceMap =
-    sourceMaps.find(
-      sourceMap =>
-        sourceMap.fileReference.type === `absolute` &&
-        sourceMap.fileReference.url.href === location.url.href,
-    ) ??
-    sourceMaps.find(
-      sourceMap =>
-        sourceMap.fileReference.type === `relative` &&
-        location.url.pathname.endsWith(`/${sourceMap.fileReference.path}`),
+  if (Array.isArray(sourceMaps)) {
+    for (const [index, sourceMap] of sourceMaps.entries()) {
+      if (!sourceMap.file) {
+        logger.warn?.(
+          `source map ignored: the entry at index ${index} has no "file" field naming the generated file it maps`,
+        )
+        continue
+      }
+      add(
+        sourceMap.file,
+        sourceMap,
+        rejection =>
+          `the "file" field of the entry at index ${index} ${rejection}`,
+      )
+    }
+  } else {
+    for (const [key, sourceMap] of Object.entries(sourceMaps)) {
+      add(key, sourceMap, rejection => `its key ${rejection}`)
+    }
+  }
+
+  return [...normalized.values()]
+}
+
+/** Why {@link makeSourceMapFileReference} rejected {@link urlOrPath}. */
+const rejectionReason = (urlOrPath: string): string =>
+  urlOrPath === UNKNOWN_FILE
+    ? `is the placeholder a compiler writes when given no file name`
+    : `is not a URL or file path`
+
+const makeSourceMapConsumer = (
+  urlOrPath: string,
+  sourceMap: SourceMap,
+): SourceMapConsumer => {
+  try {
+    return new SourceMapConsumer(sourceMap)
+  } catch (error) {
+    throw new ProfilerMdError(
+      `sourceMaps entry for ${urlOrPath} is an invalid source map: ${reasonOf(
+        error,
+      )}`,
+      { cause: error },
     )
-  if (!sourceMap) {
-    // No source map is applicable to this location.
-    return location
   }
+}
 
+const originalPositionOf = (
+  consumer: SourceMapConsumer,
+  location: SourceLocation & { type: `absolute` },
+): MappedPosition | undefined => {
   let mappedPosition: MappedPosition
   try {
-    mappedPosition = sourceMap.consumer.originalPositionFor({
+    mappedPosition = consumer.originalPositionFor({
       line: location.line ?? 1,
-      // Our columns are 1-based, but source map columns are 0-based,
+      // A SourceLocation's columns are 1-based, but source map columns are 0-based.
       column: (location.column ?? 1) - 1,
     })
   } catch {
     // `source-map-js` throws when a line has mappings, but none at or before
     // the queried column (no greatest lower bound).
-    return location
+    return undefined
   }
-  if (!mappedPosition.source) {
-    return location
-  }
-
-  const mappedFileReference = makeSourceMapFileReference(mappedPosition.source)
-  if (!mappedFileReference) {
-    return location
-  }
-
-  if (mappedFileReference.type === `absolute`) {
-    return {
-      type: `absolute`,
-      url: mappedFileReference.url,
-      line: mappedPosition.line,
-      // Source map columns are 0-based, but ours are 1-based.
-      column: mappedPosition.column + 1,
-    }
-  }
-
-  if (!baseURL) {
-    return location
-  }
-
-  return {
-    type: `absolute`,
-    url: new URL(mappedFileReference.path, baseURL),
-    line: mappedPosition.line,
-    // Source map columns are 0-based, but ours are 1-based.
-    column: mappedPosition.column + 1,
-  }
+  // `source-map-js` types `source` as a string, but returns null for an
+  // unmapped position.
+  return mappedPosition.source ? mappedPosition : undefined
 }
+
+const mappedLocation = (
+  url: URL,
+  mappedPosition: MappedPosition,
+): SourceLocation => ({
+  type: `absolute`,
+  url,
+  line: mappedPosition.line,
+  // Source map columns are 0-based, but a SourceLocation's are 1-based.
+  column: mappedPosition.column + 1,
+})
+
+const describeGeneratedFiles = (hrefs: Iterable<string>): string => {
+  const listed = [...hrefs]
+  if (listed.length === 0) {
+    return `none`
+  }
+  const shown = listed.slice(0, MAX_LISTED_GENERATED_FILES).join(`, `)
+  const rest = listed.length - MAX_LISTED_GENERATED_FILES
+  return rest > 0 ? `${shown}, and ${rest} more` : shown
+}
+
+const MAX_LISTED_GENERATED_FILES = 5
+
+const describeGeneratedFile = (
+  outcome: GeneratedFileOutcome,
+  baseURL: URL | undefined,
+): string => {
+  if (outcome.type === `unmapped`) {
+    return `no source map`
+  }
+  const { sourceMap, unmappedPositions, relativeSource } = outcome
+  const described = `mapped by the source map for ${sourceReferenceId(sourceMap.fileReference)}`
+  if (relativeSource && !baseURL) {
+    return `${described}, whose sources are relative paths and stay unmapped without a base URL`
+  }
+  if (unmappedPositions.size > 0) {
+    return `${described}, which has no mapping for ${formatCount(unmappedPositions.size, `position`)} (e.g. ${[...unmappedPositions].slice(0, MAX_LISTED_POSITIONS).join(`, `)})`
+  }
+  return described
+}
+
+const MAX_LISTED_POSITIONS = 3
+
+/**
+ * Applies the matching source map, if any, to {@link location}.
+ *
+ * @see {@link SourceMapResolver.resolve}
+ */
+export const sourceMapSourceLocation = (
+  location: SourceLocation,
+  { baseURL, sourceMaps }: FormattingProfileToMdOptions,
+): SourceLocation => sourceMaps.resolve(location, baseURL)
 
 const makeSourceMapFileReference = (
   urlOrPath: string,

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -15,6 +15,7 @@ import type {
   FormattingProfileToMdOptions,
   ProfileToMdOptions,
 } from './options.ts'
+import { SourceMapResolver } from './source-map.ts'
 
 /**
  * Normalizes options for tests that call aggregation, diffing, or formatting
@@ -24,13 +25,17 @@ import type {
 export const resolveProfileToMdOptions = (
   options?: ProfileToMdOptions,
 ): FormattingProfileToMdOptions => {
-  const { baseURL, ...rest } = normalizeProfileToMdOptions(options)
+  const { baseURL, sourceMaps, ...rest } = normalizeProfileToMdOptions(options)
   if (baseURL === `auto`) {
     throw new Error(
       `baseURL 'auto' is resolved by the conversion pipeline, so pass a concrete base URL here`,
     )
   }
-  return { ...rest, baseURL }
+  return {
+    ...rest,
+    baseURL,
+    sourceMaps: new SourceMapResolver(sourceMaps, rest.logger),
+  }
 }
 
 const emittedLogs: { level: string; line: string }[] = []


### PR DESCRIPTION
The resolver records each generated file's outcome while resolving locations and reports them once at the end: a summary, the supplied maps that matched no generated file, and each file's detail.