### PR TITLE
feat(api): strip gzip, brotli, and LZ4 compression in the library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,9 @@ profiler-md
 │   │   ├── registry.ts           # Format converter registry
 │   │   ├── error.ts              # Parse, rejection, and detection error classes, and the bug report caveat check
 │   │   ├── parse.ts              # JSON decode and specified-format parse wrappers that classify a parse failure
+│   │   ├── compression.ts        # Strips gzip and LZ4 by magic, and tries brotli as a last resort, through the runtime's decoders
+│   │   ├── compression.node.ts   # The `#compression` runtime a Node bundle resolves to (node:zlib)
+│   │   ├── compression.web.ts    # The `#compression` runtime every other bundle resolves to (DecompressionStream)
 │   │   ├── detect.ts             # Format auto-detection and its undetected-format error
 │   │   ├── aggregate.ts          # Parsed input to aggregated input dispatch across modalities, with origin detection
 │   │   ├── format.ts             # Aggregated input and diff to Markdown dispatch across modalities

--- a/docs/api.md
+++ b/docs/api.md
@@ -143,3 +143,23 @@ console.log(
   ),
 )
 ```
+
+## Compressed inputs
+
+The API strips the compression an input is wrapped in before detecting its
+format, so a profile converts as its profiler wrote it: a gzipped `.pb.gz` pprof
+profile, an LZ4 memray capture, or a profile a user compressed.
+
+Gzip and LZ4 are identified by their magic bytes. Brotli has none, so the API
+tries it only after the input converts to nothing as it is, and reports the
+original failure when that fails too.
+
+Which codecs decode depends on the runtime the package resolves to:
+
+| Runtime     | Sync API                    | Async API                                                                  |
+| ----------- | --------------------------- | -------------------------------------------------------------------------- |
+| Node.js     | gzip, brotli, LZ4           | gzip, brotli, LZ4                                                          |
+| Other (web) | LZ4 (gzip and brotli throw) | gzip, LZ4, and brotli where the runtime's `DecompressionStream` accepts it |
+
+The async API streams a gzipped `Blob` or `ReadableStream` through the decoder
+rather than reading it into memory first. LZ4 is decoded whole.

--- a/package.json
+++ b/package.json
@@ -58,9 +58,16 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",
+      "node": "./dist/node/index.mjs",
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
+  },
+  "imports": {
+    "#compression": {
+      "node": "./src/formats/compression.node.ts",
+      "default": "./src/formats/compression.web.ts"
+    }
   },
   "scripts": {
     "format:base": "prettier --cache --write",

--- a/scripts/update-examples-worker.ts
+++ b/scripts/update-examples-worker.ts
@@ -2,7 +2,6 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import { enableCompileCache } from 'node:module'
 import { join } from 'node:path'
 import { parentPort, workerData } from 'node:worker_threads'
-import { brotliDecompressSync, gunzipSync } from 'node:zlib'
 import type { ProfileToMdOptions } from '../src/options.ts'
 
 // Reuse compiled bytecode across the worker threads and runs, roughly halving
@@ -30,23 +29,8 @@ const { check } = workerData as { check: boolean }
 
 const options: ProfileToMdOptions = { baseURL: `auto` }
 
-// The CLI's decompression rule (`src/cli/input.ts`): brotli by file suffix,
-// gzip by magic bytes. Reading and decompressing synchronously keeps the work
-// on this thread instead of the process-wide libuv pool the threads would
-// contend on.
-const readInput = (inputPath: string): Uint8Array => {
-  const bytes = readFileSync(inputPath)
-  if (inputPath.endsWith(`.br`)) {
-    return brotliDecompressSync(bytes)
-  }
-  if (bytes[0] === 0x1f && bytes[1] === 0x8b) {
-    return gunzipSync(bytes)
-  }
-  return bytes
-}
-
 const convertInputs = (inputPaths: string[]): string => {
-  const inputs = inputPaths.map(readInput)
+  const inputs = inputPaths.map(path => readFileSync(path))
   return inputs.length === 1
     ? profileToMd(inputs[0]!, options)
     : diffProfiles(inputs[0]!, inputs[1]!, options)

--- a/src/cli/input.ts
+++ b/src/cli/input.ts
@@ -1,17 +1,10 @@
 import { createReadStream, openAsBlob } from 'node:fs'
 import { access, constants, stat } from 'node:fs/promises'
-import type { Transform } from 'node:stream'
 import { blob } from 'node:stream/consumers'
-import { pipeline } from 'node:stream/promises'
-import { createBrotliDecompress, createGunzip } from 'node:zlib'
 import { reasonOf } from '../error.ts'
 import { CliError } from './error.ts'
 
 export const openInputAsBlob = async (
-  filePath: string | undefined,
-): Promise<Blob> => decompressBlob(await openRawInputAsBlob(filePath), filePath)
-
-const openRawInputAsBlob = async (
   filePath: string | undefined,
 ): Promise<Blob> => {
   if (!filePath || STDIN_PATHS.has(filePath)) {
@@ -81,49 +74,4 @@ const readStreamAsBlob = async (
       cause: error,
     })
   }
-}
-
-const decompressBlob = async (
-  data: Blob,
-  filePath: string | undefined,
-): Promise<Blob> => {
-  try {
-    if (filePath?.endsWith(`.br`)) {
-      return await decompressStream(
-        data,
-        createBrotliDecompress({ chunkSize: DECOMPRESS_CHUNK_SIZE }),
-      )
-    }
-    const header = new Uint8Array(await data.slice(0, 2).arrayBuffer())
-    if (header[0] === 0x1f && header[1] === 0x8b) {
-      return await decompressStream(
-        data,
-        createGunzip({ chunkSize: DECOMPRESS_CHUNK_SIZE }),
-      )
-    }
-    return data
-  } catch (error) {
-    throw new CliError(
-      `cannot decompress ${filePath ?? `stdin`}: ${reasonOf(error)}`,
-      1,
-      { cause: error },
-    )
-  }
-}
-
-/**
- * The output buffer size for the decompression transforms. With zlib's 16 KiB
- * default, a transform emits a large decompressed input as thousands of
- * chunks, each a separate event-loop hop. A larger buffer keeps the hop count
- * small for the cost of one buffer's memory.
- */
-const DECOMPRESS_CHUNK_SIZE = 4 * 1024 * 1024
-
-const decompressStream = async (
-  data: Blob,
-  transform: Transform,
-): Promise<Blob> => {
-  const decompressedData = blob(transform)
-  await pipeline(data.stream(), transform)
-  return decompressedData
 }

--- a/src/formats/compression.node.ts
+++ b/src/formats/compression.node.ts
@@ -1,0 +1,57 @@
+import { Duplex } from 'node:stream'
+import {
+  brotliDecompressSync,
+  createBrotliDecompress,
+  createGunzip,
+  gunzipSync,
+} from 'node:zlib'
+import { ProfilerMdError, reasonOf } from '../error.ts'
+import type { CompressionRuntime } from './compression.ts'
+
+/**
+ * The Node implementation of {@link CompressionRuntime}, decoding with
+ * `node:zlib`, which decodes gzip and brotli both synchronously and as a
+ * stream.
+ */
+
+/**
+ * The output buffer size for the decompression transforms. With zlib's 16 KiB
+ * default, a transform emits a large decompressed input as thousands of
+ * chunks, each a separate event-loop hop. A larger buffer keeps the hop count
+ * small for the cost of one buffer's memory.
+ */
+const CHUNK_SIZE = 4 * 1024 * 1024
+
+export const gunzip: CompressionRuntime[`gunzip`] = bytes => {
+  try {
+    return toUint8Array(gunzipSync(bytes))
+  } catch (error) {
+    throw new ProfilerMdError(
+      `cannot decompress the gzip input: ${reasonOf(error)}`,
+      { cause: error },
+    )
+  }
+}
+
+export const gunzipStream: CompressionRuntime[`gunzipStream`] = stream =>
+  pipeThrough(stream, createGunzip({ chunkSize: CHUNK_SIZE }))
+
+export const tryBrotli: CompressionRuntime[`tryBrotli`] = bytes => {
+  try {
+    return toUint8Array(brotliDecompressSync(bytes))
+  } catch {
+    return undefined
+  }
+}
+
+export const brotliStream: CompressionRuntime[`brotliStream`] = stream =>
+  pipeThrough(stream, createBrotliDecompress({ chunkSize: CHUNK_SIZE }))
+
+/** A plain view of a `Buffer`'s bytes, so callers see the type they passed. */
+const toUint8Array = (buffer: Buffer): Uint8Array =>
+  new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+
+const pipeThrough = (
+  stream: ReadableStream<Uint8Array>,
+  transform: Duplex,
+): ReadableStream<Uint8Array> => stream.pipeThrough(Duplex.toWeb(transform))

--- a/src/formats/compression.test.ts
+++ b/src/formats/compression.test.ts
@@ -1,0 +1,183 @@
+import { brotliCompressSync, gzipSync } from 'node:zlib'
+import { describe, expect, test } from 'vitest'
+import { ProfilerMdError } from '../error.ts'
+import { chunk, streamOf } from '../helpers/testing.ts'
+import * as node from './compression.node.ts'
+import type { CompressionRuntime } from './compression.ts'
+import {
+  decompressIdentified,
+  decompressIdentifiedAsync,
+  isGzip,
+  tryDecompressBrotli,
+  tryDecompressBrotliAsync,
+} from './compression.ts'
+import * as web from './compression.web.ts'
+import { asLz4Frame } from './memray/testing.ts'
+
+const text = new TextEncoder().encode(`{"profile": "${`x`.repeat(1000)}"}`)
+const gzipped = new Uint8Array(gzipSync(text))
+const brotlied = new Uint8Array(brotliCompressSync(text))
+const lz4ed = asLz4Frame(text)
+
+const bytesOf = async (data: Blob | ReadableStream<Uint8Array>) =>
+  new Uint8Array(await new Response(data).arrayBuffer())
+
+describe(`isGzip`, () => {
+  test(`recognizes the gzip magic`, () => {
+    expect(isGzip(gzipped)).toBe(true)
+    expect(isGzip(text)).toBe(false)
+    expect(isGzip(Uint8Array.from([0x1f]))).toBe(false)
+  })
+})
+
+// Vitest runs on Node, so `#compression` resolves to the Node runtime here.
+describe(`decompressIdentified`, () => {
+  test(`passes uncompressed bytes through`, () => {
+    expect(decompressIdentified(text)).toBe(text)
+  })
+
+  test(`strips gzip`, () => {
+    expect(decompressIdentified(gzipped)).toEqual(text)
+  })
+
+  test(`strips an LZ4 frame`, () => {
+    expect(decompressIdentified(lz4ed)).toEqual(text)
+  })
+
+  test(`reports a corrupt gzip input as the caller's`, () => {
+    const corrupt = gzipped.slice(0, 20)
+
+    expect(() => decompressIdentified(corrupt)).toThrow(ProfilerMdError)
+    expect(() => decompressIdentified(corrupt)).toThrow(
+      /^cannot decompress the gzip input: /u,
+    )
+  })
+
+  test(`reports a corrupt LZ4 input as the caller's`, () => {
+    const corrupt = lz4ed.slice(0, 12)
+
+    expect(() => decompressIdentified(corrupt)).toThrow(ProfilerMdError)
+    expect(() => decompressIdentified(corrupt)).toThrow(
+      /^cannot decompress the LZ4 input: /u,
+    )
+  })
+})
+
+describe(`decompressIdentifiedAsync`, () => {
+  test(`passes an uncompressed blob through`, async () => {
+    const blob = new Blob([text])
+
+    expect(await decompressIdentifiedAsync(blob)).toBe(blob)
+  })
+
+  test(`passes an uncompressed stream through, with the peeked bytes`, async () => {
+    const decompressed = await decompressIdentifiedAsync(
+      streamOf(...chunk(text, 3)),
+    )
+
+    expect(decompressed).toBeInstanceOf(ReadableStream)
+    expect(await bytesOf(decompressed)).toEqual(text)
+  })
+
+  test(`streams gzip`, async () => {
+    expect(
+      await bytesOf(await decompressIdentifiedAsync(new Blob([gzipped]))),
+    ).toEqual(text)
+    expect(
+      await bytesOf(
+        await decompressIdentifiedAsync(streamOf(...chunk(gzipped, 5))),
+      ),
+    ).toEqual(text)
+  })
+
+  test(`strips an LZ4 frame`, async () => {
+    expect(
+      await bytesOf(await decompressIdentifiedAsync(new Blob([lz4ed]))),
+    ).toEqual(text)
+    expect(
+      await bytesOf(
+        await decompressIdentifiedAsync(streamOf(...chunk(lz4ed, 5))),
+      ),
+    ).toEqual(text)
+  })
+
+  test(`reports a corrupt gzip input as the caller's`, async () => {
+    const corrupt = gzipped.slice(0, 20)
+
+    await expect(
+      decompressIdentifiedAsync(new Blob([corrupt])),
+    ).rejects.toThrow(/^cannot decompress the gzip input: /u)
+    await expect(
+      bytesOf(await decompressIdentifiedAsync(streamOf(corrupt))),
+    ).rejects.toThrow(ProfilerMdError)
+  })
+})
+
+describe(`tryDecompressBrotli`, () => {
+  test(`decodes brotli`, async () => {
+    expect(tryDecompressBrotli(brotlied)).toEqual(text)
+    expect(
+      await bytesOf((await tryDecompressBrotliAsync(new Blob([brotlied])))!),
+    ).toEqual(text)
+  })
+
+  test(`returns undefined for bytes that are not brotli`, async () => {
+    expect(tryDecompressBrotli(text)).toBeUndefined()
+    expect(await tryDecompressBrotliAsync(new Blob([text]))).toBeUndefined()
+  })
+
+  // An uncompressed pprof profile begins with a byte a brotli decoder reads as
+  // an empty stream.
+  test(`returns undefined for bytes that decode to nothing`, async () => {
+    const pprofLike = Uint8Array.from([0x0a, 0x05, 0x01, 0x02])
+
+    expect(tryDecompressBrotli(pprofLike)).toBeUndefined()
+    expect(
+      await tryDecompressBrotliAsync(new Blob([pprofLike])),
+    ).toBeUndefined()
+  })
+})
+
+describe.each<[string, CompressionRuntime]>([
+  [`node`, node],
+  [`web`, web],
+])(`%s runtime`, (name, runtime) => {
+  test(`decompresses a gzip stream`, async () => {
+    expect(
+      await bytesOf(runtime.gunzipStream(streamOf(...chunk(gzipped, 7)))),
+    ).toEqual(text)
+  })
+
+  test(`fails a corrupt gzip stream`, async () => {
+    await expect(
+      bytesOf(runtime.gunzipStream(streamOf(gzipped.slice(0, 20)))),
+    ).rejects.toThrow()
+  })
+
+  test(`decodes brotli as a stream where supported`, async () => {
+    if (runtime.brotliStream === undefined) {
+      return
+    }
+    expect(
+      await bytesOf(runtime.brotliStream(streamOf(...chunk(brotlied, 7)))),
+    ).toEqual(text)
+    await expect(
+      bytesOf(runtime.brotliStream(streamOf(text))),
+    ).rejects.toThrow()
+  })
+
+  if (name === `node`) {
+    test(`decodes synchronously`, () => {
+      expect(runtime.gunzip(gzipped)).toEqual(text)
+      expect(runtime.tryBrotli(brotlied)).toEqual(text)
+      expect(runtime.tryBrotli(text)).toBeUndefined()
+    })
+  } else {
+    test(`cannot decode synchronously`, () => {
+      expect(() => runtime.gunzip(gzipped)).toThrow(
+        /^cannot decompress a gzip input synchronously in this runtime: /u,
+      )
+      expect(runtime.tryBrotli(brotlied)).toBeUndefined()
+    })
+  }
+})

--- a/src/formats/compression.ts
+++ b/src/formats/compression.ts
@@ -1,0 +1,230 @@
+import { ProfilerMdError, reasonOf } from '../error.ts'
+import { concatUint8Arrays, streamToUint8Array } from '../helpers/bytes.ts'
+import { decompressLz4Frame, isLz4Frame } from '../helpers/lz4.ts'
+import type { AsyncProfileData } from '../options.ts'
+import * as runtime from '#compression'
+
+/**
+ * The decoders a runtime provides for the codecs this package does not
+ * implement itself.
+ *
+ * `#compression` resolves to the Node implementation, which decodes with
+ * `node:zlib`, in a Node bundle, and to the web implementation, which decodes
+ * with `DecompressionStream`, everywhere else. Both implement this type.
+ *
+ * The sync decoders take and return bytes, because the sync API reads its
+ * input whole. The async decoders transform a stream, so a compressed input
+ * streams through them instead of being read into memory first. A sync decoder
+ * throws a `ProfilerMdError` where the runtime decodes only asynchronously.
+ *
+ * Brotli has no magic bytes to identify it by, so it is only ever tried: the
+ * sync decoder returns `undefined` for bytes that are not brotli, or where the
+ * runtime has no brotli decoder, and the async decoder is `undefined` where the
+ * runtime has none. A failure part way through the async decoder's stream is
+ * the stream's error.
+ */
+export type CompressionRuntime = {
+  gunzip: (bytes: Uint8Array) => Uint8Array
+  gunzipStream: (
+    stream: ReadableStream<Uint8Array>,
+  ) => ReadableStream<Uint8Array>
+  tryBrotli: (bytes: Uint8Array) => Uint8Array | undefined
+  brotliStream:
+    | ((stream: ReadableStream<Uint8Array>) => ReadableStream<Uint8Array>)
+    | undefined
+}
+
+/** Returns whether {@link bytes} begin with the gzip magic. */
+export const isGzip = (bytes: Uint8Array): boolean =>
+  bytes.length >= 2 && bytes[0] === 0x1f && bytes[1] === 0x8b
+
+/** The most bytes a codec's magic needs. */
+const MAGIC_LENGTH = 4
+
+/**
+ * Strips the compression the bytes identify themselves as: a gzip member,
+ * which tools and users wrap a profile in, or an LZ4 frame, which memray
+ * writes every capture as.
+ *
+ * Brotli is not identifiable and is tried only where the bytes convert to
+ * nothing otherwise ({@link tryDecompressBrotli}).
+ */
+export const decompressIdentified = (bytes: Uint8Array): Uint8Array => {
+  if (isGzip(bytes)) {
+    return runtime.gunzip(bytes)
+  }
+  if (isLz4Frame(bytes)) {
+    return decompressLz4(bytes)
+  }
+  return bytes
+}
+
+/**
+ * The async analogue of {@link decompressIdentified}.
+ *
+ * A gzip input streams through the decoder: a `Blob` into a decompressed
+ * `Blob`, and a stream into a decompressed stream. An LZ4 input is read whole,
+ * because the decoder works on a buffer. An uncompressed stream is returned
+ * with the bytes read to identify it put back.
+ */
+export const decompressIdentifiedAsync = async (
+  data: AsyncProfileData,
+): Promise<AsyncProfileData> => {
+  if (data instanceof Blob) {
+    const head = new Uint8Array(await data.slice(0, MAGIC_LENGTH).arrayBuffer())
+    if (isGzip(head)) {
+      return await collectBlob(gunzipStream(data.stream()))
+    }
+    if (isLz4Frame(head)) {
+      return new Blob([decompressLz4(await data.bytes())])
+    }
+    return data
+  }
+
+  const { head, chunks } = await peekStream(data, MAGIC_LENGTH)
+  const stream = prependChunks(chunks, data)
+  if (isGzip(head)) {
+    return gunzipStream(stream)
+  }
+  if (isLz4Frame(head)) {
+    return new Blob([decompressLz4(await streamToUint8Array(stream))])
+  }
+  return stream
+}
+
+const gunzipStream = (
+  stream: ReadableStream<Uint8Array>,
+): ReadableStream<Uint8Array> =>
+  mapStreamErrors(
+    runtime.gunzipStream(stream),
+    error =>
+      new ProfilerMdError(
+        `cannot decompress the gzip input: ${reasonOf(error)}`,
+        { cause: error },
+      ),
+  )
+
+/**
+ * Decodes {@link bytes} as brotli, or returns `undefined` when they are not a
+ * brotli stream or the runtime cannot decode one.
+ *
+ * A decoder accepts some bytes that are not brotli: an uncompressed pprof
+ * profile decodes to nothing, because its first byte reads as an empty
+ * stream. An empty result is therefore not a decoding.
+ */
+export const tryDecompressBrotli = (
+  bytes: Uint8Array,
+): Uint8Array | undefined => nonEmpty(runtime.tryBrotli(bytes))
+
+/**
+ * The async analogue of {@link tryDecompressBrotli}, decoding a `Blob` into a
+ * decompressed `Blob`. A failure anywhere in the stream means the bytes are not
+ * brotli.
+ */
+export const tryDecompressBrotliAsync = async (
+  data: Blob,
+): Promise<Blob | undefined> => {
+  if (runtime.brotliStream === undefined) {
+    return undefined
+  }
+  let decompressed
+  try {
+    decompressed = await collectBlob(runtime.brotliStream(data.stream()))
+  } catch {
+    return undefined
+  }
+  return decompressed.size > 0 ? decompressed : undefined
+}
+
+const nonEmpty = (bytes: Uint8Array | undefined): Uint8Array | undefined =>
+  bytes && bytes.length > 0 ? bytes : undefined
+
+const decompressLz4 = (bytes: Uint8Array): Uint8Array => {
+  try {
+    return decompressLz4Frame(bytes)
+  } catch (error) {
+    throw new ProfilerMdError(
+      `cannot decompress the LZ4 input: ${reasonOf(error)}`,
+      { cause: error },
+    )
+  }
+}
+
+/** Reads a whole stream into a `Blob`. */
+const collectBlob = (stream: ReadableStream<Uint8Array>): Promise<Blob> =>
+  new Response(stream).blob()
+
+/** A stream yielding {@link stream}'s chunks, with its errors mapped. */
+const mapStreamErrors = (
+  stream: ReadableStream<Uint8Array>,
+  toError: (error: unknown) => Error,
+): ReadableStream<Uint8Array> => {
+  const reader = stream.getReader()
+  return new ReadableStream<Uint8Array>({
+    pull: async controller => {
+      let result
+      try {
+        result = await reader.read()
+      } catch (error: unknown) {
+        throw toError(error)
+      }
+      if (result.done) {
+        controller.close()
+      } else {
+        controller.enqueue(result.value)
+      }
+    },
+    cancel: reason => reader.cancel(reason),
+  })
+}
+
+/**
+ * Reads chunks from {@link stream} until at least {@link length} bytes are
+ * read or it ends. The reader is released, so the stream's remaining chunks
+ * can still be read.
+ */
+const peekStream = async (
+  stream: ReadableStream<Uint8Array>,
+  length: number,
+): Promise<{ head: Uint8Array; chunks: Uint8Array[] }> => {
+  const chunks: Uint8Array[] = []
+  let read = 0
+  const reader = stream.getReader()
+  try {
+    while (read < length) {
+      const { done, value } = await reader.read()
+      if (done) {
+        break
+      }
+      chunks.push(value)
+      read += value.length
+    }
+  } finally {
+    reader.releaseLock()
+  }
+  return { head: concatUint8Arrays(chunks).subarray(0, length), chunks }
+}
+
+/** A stream yielding {@link chunks} and then the rest of {@link stream}. */
+const prependChunks = (
+  chunks: Uint8Array[],
+  stream: ReadableStream<Uint8Array>,
+): ReadableStream<Uint8Array> => {
+  const reader = stream.getReader()
+  let index = 0
+  return new ReadableStream<Uint8Array>({
+    pull: async controller => {
+      if (index < chunks.length) {
+        controller.enqueue(chunks[index++]!)
+        return
+      }
+      const { done, value } = await reader.read()
+      if (done) {
+        controller.close()
+      } else {
+        controller.enqueue(value)
+      }
+    },
+    cancel: reason => reader.cancel(reason),
+  })
+}

--- a/src/formats/compression.web.ts
+++ b/src/formats/compression.web.ts
@@ -1,0 +1,37 @@
+import { ProfilerMdError } from '../error.ts'
+import type { CompressionRuntime } from './compression.ts'
+
+/**
+ * The web implementation of {@link CompressionRuntime}, decoding with the
+ * `DecompressionStream` every modern runtime provides. It decodes only as a
+ * stream, so the sync decoders cannot decompress, and it decodes brotli only
+ * where the runtime names it as a format.
+ */
+
+export const gunzip: CompressionRuntime[`gunzip`] = () => {
+  throw new ProfilerMdError(
+    `cannot decompress a gzip input synchronously in this runtime: use the async API, or decompress the input first`,
+  )
+}
+
+export const gunzipStream: CompressionRuntime[`gunzipStream`] = stream =>
+  stream.pipeThrough(new DecompressionStream(`gzip`))
+
+export const tryBrotli: CompressionRuntime[`tryBrotli`] = () => undefined
+
+/**
+ * A brotli decoder, or `undefined` where the runtime's `DecompressionStream`
+ * rejects the format.
+ */
+const makeBrotliDecoder = (): DecompressionStream | undefined => {
+  try {
+    return new DecompressionStream(`brotli`)
+  } catch {
+    return undefined
+  }
+}
+
+export const brotliStream: CompressionRuntime[`brotliStream`] =
+  makeBrotliDecoder() === undefined
+    ? undefined
+    : stream => stream.pipeThrough(makeBrotliDecoder()!)

--- a/src/formats/index.test.ts
+++ b/src/formats/index.test.ts
@@ -1,4 +1,5 @@
 import { readdirSync, readFileSync } from 'node:fs'
+import { brotliCompressSync, gzipSync } from 'node:zlib'
 import { describe, expect, test, vi } from 'vitest'
 import { projects } from '../../vitest.config.ts'
 import { parseExampleFilename } from '../cli/examples.ts'
@@ -27,6 +28,7 @@ import {
   profileToMd,
   profileToMdAsync,
 } from './index.ts'
+import { asLz4Frame } from './memray/testing.ts'
 import {
   convertJsonToMd,
   detectionLogs,
@@ -127,6 +129,107 @@ if (format === undefined) {
       )
 
       expect(projectInputs.sort()).toEqual(readdirSync(inputPath()).sort())
+    })
+  })
+}
+
+if (format === undefined) {
+  // The pipeline strips an input's compression before detection, so these run
+  // on a profile of no particular format: a speedscope file with no profiles,
+  // which converts to the no-data message.
+  describe(`compressed inputs`, () => {
+    const bytes = new TextEncoder().encode(emptyProfile)
+    const gzipped = new Uint8Array(gzipSync(bytes))
+    const brotlied = new Uint8Array(brotliCompressSync(bytes))
+    const lz4ed = asLz4Frame(bytes)
+    const NO_DATA = `No profiling data found.\n`
+
+    test.each([
+      [`gzip`, gzipped],
+      [`brotli`, brotlied],
+      [`LZ4`, lz4ed],
+    ])(`profileToMd detects a %s input`, (_, compressed) => {
+      expect(profileToMd(compressed)).toBe(NO_DATA)
+      expect(
+        profileToMd([compressed.subarray(0, 9), compressed.subarray(9)]),
+      ).toBe(NO_DATA)
+    })
+
+    test.each([
+      [`gzip`, gzipped],
+      [`brotli`, brotlied],
+      [`LZ4`, lz4ed],
+    ])(
+      `profileToMd converts a %s input of a specified format`,
+      (_, compressed) => {
+        expect(profileToMd({ data: compressed, format: `speedscope` })).toBe(
+          NO_DATA,
+        )
+      },
+    )
+
+    test.each([
+      [`gzip`, gzipped],
+      [`brotli`, brotlied],
+      [`LZ4`, lz4ed],
+    ])(`profileToMdAsync detects a %s input`, async (_, compressed) => {
+      expect(await profileToMdAsync(new Blob([compressed]))).toBe(NO_DATA)
+      expect(await profileToMdAsync(new Blob([compressed]).stream())).toBe(
+        NO_DATA,
+      )
+    })
+
+    test.each([
+      [`gzip`, gzipped],
+      [`LZ4`, lz4ed],
+    ])(
+      `profileToMdAsync converts a %s input of a specified format`,
+      async (_, compressed) => {
+        expect(
+          await profileToMdAsync({
+            data: new Blob([compressed]),
+            format: `speedscope`,
+          }),
+        ).toBe(NO_DATA)
+        expect(
+          await profileToMdAsync({
+            data: new Blob([compressed]).stream(),
+            format: `speedscope`,
+          }),
+        ).toBe(NO_DATA)
+      },
+    )
+
+    // Brotli has no magic bytes, so it is tried only once the bytes fail as
+    // they are. A stream is consumed by that first attempt.
+    test(`profileToMdAsync tries brotli on a blob of a specified format, not a stream`, async () => {
+      expect(
+        await profileToMdAsync({
+          data: new Blob([brotlied]),
+          format: `speedscope`,
+        }),
+      ).toBe(NO_DATA)
+      await expect(
+        profileToMdAsync({
+          data: new Blob([brotlied]).stream(),
+          format: `speedscope`,
+        }),
+      ).rejects.toThrow(`Speedscope: invalid JSON`)
+    })
+
+    test(`reports the original failure when brotli is not the answer either`, () => {
+      expect(() =>
+        profileToMd(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])),
+      ).toThrow(FormatDetectError)
+    })
+
+    test(`reports a corrupt compressed input as the caller's`, () => {
+      expect(() => profileToMd(gzipped.subarray(0, 20))).toThrow(
+        `cannot decompress the gzip input`,
+      )
+      expect(() => profileToMd(lz4ed.subarray(0, 12))).toThrow(
+        `cannot decompress the LZ4 input`,
+      )
     })
   })
 }

--- a/src/formats/index.ts
+++ b/src/formats/index.ts
@@ -1,4 +1,4 @@
-import { concatUint8Arrays, streamToUint8Array } from '../helpers/bytes.ts'
+import { streamToUint8Array } from '../helpers/bytes.ts'
 import {
   maybeJson,
   maybeJsonAsync,
@@ -17,13 +17,19 @@ import {
   normalizeProfileToMdOptions,
 } from '../options.ts'
 import { aggregateParsedInputs, makeContext } from './aggregate.ts'
+import {
+  decompressIdentified,
+  decompressIdentifiedAsync,
+  tryDecompressBrotli,
+  tryDecompressBrotliAsync,
+} from './compression.ts'
 import type { AggregatedInput } from './converter.ts'
 import {
   detectBinaryFormat,
   detectJsonFormat,
   toUndetectedFormatError,
 } from './detect.ts'
-import type { FormatRejection } from './detect.ts'
+import type { DetectedInput, FormatRejection } from './detect.ts'
 import { formatAggregatedDiff, formatAggregatedInputs } from './format.ts'
 import {
   dataToBytes,
@@ -119,22 +125,148 @@ export const aggregateInput = (
   input: ProfileInput<ProfileData>,
   options: AggregationProfileToMdOptions,
 ): AggregatedInput[] => {
-  const { data, format, origin } = normalizeProfileInput(input)
+  const { data: rawData, format, origin } = normalizeProfileInput(input)
+
+  // Buffer an `Iterable` up front because it might be one-shot, but detection
+  // reads it several times, and strip the compression the bytes identify.
+  const data: string | Uint8Array =
+    typeof rawData === `string`
+      ? rawData
+      : decompressIdentified(dataToBytes(rawData))
 
   if (format) {
     logFormat(format, `specified`, options)
 
-    const parsed = parseAsFormat(formatToConverter[format], data)
+    const converter = formatToConverter[format]
+    let parsed
+    try {
+      parsed = parseAsFormat(converter, data)
+    } catch (error: unknown) {
+      parsed = withBrotliFallback(data, error, bytes =>
+        parseAsFormat(converter, bytes),
+      )
+    }
     return aggregateParsedInputs(parsed, options, makeContext(format, origin))
   }
 
-  // Buffer an `Iterable` up front because it might be one-shot, but we need to
-  // read it multiple times for detection.
-  const isIterable = typeof data !== `string` && !ArrayBuffer.isView(data)
-  const buffered: string | Uint8Array = isIterable
-    ? concatUint8Arrays(data)
-    : data
+  let detected
+  try {
+    detected = detectFormat(data, options)
+  } catch (error: unknown) {
+    detected = withBrotliFallback(data, error, bytes =>
+      detectFormat(bytes, options),
+    )
+  }
+  logFormat(detected.format, `detected`, options)
 
+  return aggregateParsedInputs(
+    detected.parsed,
+    options,
+    makeContext(detected.format, origin),
+  )
+}
+
+const aggregateInputAsync = async (
+  input: ProfileInput<AsyncProfileData>,
+  options: AggregationProfileToMdOptions,
+): Promise<AggregatedInput[]> => {
+  const { data: rawData, format, origin } = normalizeProfileInput(input)
+  const data = await decompressIdentifiedAsync(rawData)
+
+  if (format) {
+    logFormat(format, `specified`, options)
+
+    const converter = formatToConverter[format]
+    let parsed
+    try {
+      parsed = await parseAsFormatAsync(converter, data)
+    } catch (error: unknown) {
+      // A stream is consumed once, so only a `Blob` can be read again.
+      if (!(data instanceof Blob)) {
+        throw error
+      }
+      parsed = await withBrotliFallbackAsync(data, error, blob =>
+        parseAsFormatAsync(converter, blob),
+      )
+    }
+    return aggregateParsedInputs(parsed, options, makeContext(format, origin))
+  }
+
+  // Buffer a `ReadableStream` up front because it might be one-shot, but we
+  // need to read it multiple times for detection.
+  const buffered: Blob | Uint8Array =
+    data instanceof Blob ? data : await streamToUint8Array(data)
+
+  let detected
+  try {
+    detected = await detectFormatAsync(buffered, options)
+  } catch (error: unknown) {
+    detected = await withBrotliFallbackAsync(
+      buffered instanceof Blob ? buffered : new Blob([buffered]),
+      error,
+      blob => detectFormatAsync(blob, options),
+    )
+  }
+  logFormat(detected.format, `detected`, options)
+
+  return aggregateParsedInputs(
+    detected.parsed,
+    options,
+    makeContext(detected.format, origin),
+  )
+}
+
+/**
+ * Retries a conversion that failed on {@link data} on its brotli decoding,
+ * and rethrows the original failure when the bytes are not brotli or the
+ * retry fails too.
+ *
+ * Brotli has no magic bytes to identify it by, and a decoder accepts some
+ * bytes that are not brotli, so it is tried only once the bytes convert to
+ * nothing as they are.
+ */
+const withBrotliFallback = <Result>(
+  data: string | Uint8Array,
+  failure: unknown,
+  attempt: (bytes: Uint8Array) => Result,
+): Result => {
+  const brotli =
+    typeof data === `string` ? undefined : tryDecompressBrotli(data)
+  if (brotli === undefined) {
+    throw failure
+  }
+  try {
+    return attempt(decompressIdentified(brotli))
+  } catch {
+    throw failure
+  }
+}
+
+const withBrotliFallbackAsync = async <Result>(
+  data: Blob,
+  failure: unknown,
+  attempt: (data: Blob) => Promise<Result>,
+): Promise<Result> => {
+  const brotli = await tryDecompressBrotliAsync(data)
+  if (brotli === undefined) {
+    throw failure
+  }
+  try {
+    return await attempt(brotli)
+  } catch {
+    throw failure
+  }
+}
+
+/**
+ * Detects the format of buffered data and parses it.
+ *
+ * @throws a `FormatDetectError` when no format accepts the data.
+ */
+const detectFormat = (
+  buffered: string | Uint8Array,
+  options: AggregationProfileToMdOptions,
+): DetectedInput => {
   let json: unknown
   let jsonError: unknown
   if (maybeJson(buffered)) {
@@ -156,33 +288,13 @@ export const aggregateInput = (
   if (!detected) {
     throw toUndetectedFormatError(rejections, jsonError)
   }
-  logFormat(detected.format, `detected`, options)
-
-  return aggregateParsedInputs(
-    detected.parsed,
-    options,
-    makeContext(detected.format, origin),
-  )
+  return detected
 }
 
-const aggregateInputAsync = async (
-  input: ProfileInput<AsyncProfileData>,
+const detectFormatAsync = async (
+  buffered: Blob | Uint8Array,
   options: AggregationProfileToMdOptions,
-): Promise<AggregatedInput[]> => {
-  const { data, format, origin } = normalizeProfileInput(input)
-
-  if (format) {
-    logFormat(format, `specified`, options)
-
-    const parsed = await parseAsFormatAsync(formatToConverter[format], data)
-    return aggregateParsedInputs(parsed, options, makeContext(format, origin))
-  }
-
-  // Buffer a `ReadableStream` up front because it might be one-shot, but we
-  // need to read it multiple times for detection.
-  const buffered: Blob | Uint8Array =
-    data instanceof Blob ? data : await streamToUint8Array(data)
-
+): Promise<DetectedInput> => {
   let json: unknown
   let jsonError: unknown
   const couldBeJson =
@@ -222,13 +334,7 @@ const aggregateInputAsync = async (
   if (!detected) {
     throw toUndetectedFormatError(rejections, jsonError)
   }
-  logFormat(detected.format, `detected`, options)
-
-  return aggregateParsedInputs(
-    detected.parsed,
-    options,
-    makeContext(detected.format, origin),
-  )
+  return detected
 }
 
 const logFormat = (

--- a/src/formats/memray/index.test.ts
+++ b/src/formats/memray/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { chunk, streamOf } from '../../helpers/testing.ts'
-import { diffProfiles } from '../../index.ts'
+import { diffProfiles, profileToMd, profileToMdAsync } from '../../index.ts'
 import {
   selfSizeTables,
   totalSizeTables,
@@ -13,7 +13,7 @@ import {
   rankingTables,
   summaryLines,
 } from '../../testing.ts'
-import { convertBytesToMd, convertToMdAsync } from '../testing.ts'
+import { convertBytesToMd } from '../testing.ts'
 import { memrayConverter } from './index.ts'
 import { parseMemray } from './parse.ts'
 import {
@@ -67,9 +67,8 @@ const PEAK = `Peak memory profile`
 const LEAKED = `Leaked memory profile`
 
 describe(`matches`, () => {
-  test(`accepts a capture, compressed or not`, () => {
+  test(`accepts a capture`, () => {
     expect(memrayConverter.matches(risesThenFalls)).toBe(true)
-    expect(memrayConverter.matches(asLz4Frame(risesThenFalls))).toBe(true)
   })
 
   test(`rejects bytes that aren't a capture`, () => {
@@ -79,12 +78,6 @@ describe(`matches`, () => {
     )
     expect(
       memrayConverter.matches(new TextEncoder().encode(`{"json": true}`)),
-    ).toBe(false)
-  })
-
-  test(`rejects an LZ4 file that isn't a capture`, () => {
-    expect(
-      memrayConverter.matches(asLz4Frame(new TextEncoder().encode(`hello`))),
     ).toBe(false)
   })
 
@@ -833,12 +826,24 @@ describe(`convert`, () => {
     expect(rankingTables(md, `Self size`, `Improvements`)).toEqual([])
   })
 
+  // `memray run` writes every capture as an LZ4 frame, which the pipeline
+  // strips before the converter sees the bytes.
+  test(`converts a compressed capture`, () => {
+    const md = profileToMd(asLz4Frame(risesThenFalls), { baseURL: `/app` })
+
+    expect(summaryLines(md)).toEqual([
+      `Held 4\u00A0KiB over 2 allocations (2\u00A0KiB per allocation).`,
+      `Leaked 1.5\u00A0KiB over 2 allocations (768\u00A0B per allocation).`,
+    ])
+  })
+
   test(`converts a compressed capture from a stream`, async () => {
-    const compressed = asLz4Frame(risesThenFalls)
-    const md = await convertToMdAsync(
-      memrayConverter,
-      streamOf(...chunk(compressed, 7)),
-      options(),
+    const md = await profileToMdAsync(
+      {
+        data: streamOf(...chunk(asLz4Frame(risesThenFalls), 7)),
+        format: `memray`,
+      },
+      { baseURL: `/app` },
     )
 
     expect(summaryLines(md)).toEqual([

--- a/src/formats/memray/matches.ts
+++ b/src/formats/memray/matches.ts
@@ -1,29 +1,6 @@
 import { startsWith } from '../../helpers/bytes.ts'
-import { decompressLz4Frame, isLz4Frame } from '../../helpers/lz4.ts'
 import { MEMRAY_MAGIC } from './parse.ts'
 
-/**
- * Whether the bytes are a memray capture.
- *
- * `memray run` compresses its captures unless it is passed `--no-compress`,
- * so the magic is behind an LZ4 frame and only decompressing reaches it. Just
- * enough of the frame is decompressed to read the magic, so an LZ4 file of
- * anything else costs little to reject.
- */
-export const matchesMemray = (bytes: Uint8Array): boolean => {
-  if (startsWith(bytes, MEMRAY_MAGIC)) {
-    return true
-  }
-  if (!isLz4Frame(bytes)) {
-    return false
-  }
-
-  try {
-    return startsWith(
-      decompressLz4Frame(bytes, MEMRAY_MAGIC.length),
-      MEMRAY_MAGIC,
-    )
-  } catch {
-    return false
-  }
-}
+/** Whether the bytes are a memray capture. */
+export const matchesMemray = (bytes: Uint8Array): boolean =>
+  startsWith(bytes, MEMRAY_MAGIC)

--- a/src/formats/memray/parse.ts
+++ b/src/formats/memray/parse.ts
@@ -1,5 +1,4 @@
 import { HASH_SEED, HashInterner, mixHash } from '../../helpers/intern.ts'
-import { decompressLz4Frame, isLz4Frame } from '../../helpers/lz4.ts'
 import type {
   CallStackProfile,
   Observation,
@@ -37,8 +36,7 @@ import { FormatParseError } from '../error.ts'
  * @see https://github.com/bloomberg/memray/tree/main/src/memray/_memray
  */
 export const parseMemray = (input: Uint8Array): CallStackProfile[] => {
-  const bytes = isLz4Frame(input) ? decompress(input) : input
-  const reader = new ByteReader(bytes)
+  const reader = new ByteReader(input)
   const header = readHeader(reader)
 
   const capture = new Capture(header)
@@ -51,18 +49,10 @@ export const parseMemray = (input: Uint8Array): CallStackProfile[] => {
     // when it was reached.
     const recordsOffset = reader.offset
     const peakOrdinal = new Capture(header).findPeakOrdinal(reader)
-    capture.replay(new ByteReader(bytes, recordsOffset), peakOrdinal)
+    capture.replay(new ByteReader(input, recordsOffset), peakOrdinal)
   }
 
   return capture.toProfiles()
-}
-
-const decompress = (input: Uint8Array): Uint8Array => {
-  try {
-    return decompressLz4Frame(input)
-  } catch (error) {
-    throw new FormatParseError(`invalid LZ4 compression`, { cause: error })
-  }
 }
 
 /** The magic every memray capture begins with: `memray` and a null byte. */

--- a/src/formats/testing.ts
+++ b/src/formats/testing.ts
@@ -1,6 +1,5 @@
 import { readFileSync, statSync } from 'node:fs'
 import path from 'node:path'
-import { gunzipSync } from 'node:zlib'
 import { expect, inject } from 'vitest'
 import { parseExampleFilename } from '../cli/examples.ts'
 import type { NormalizedProfileToMdOptions } from '../options.ts'
@@ -43,14 +42,11 @@ export const inputPath = (filename?: string): string =>
   )
 
 /**
- * Reads an input, transparently gunzipping it like the CLI's input handling
- * does, since the programmatic API expects already-decompressed bytes. Real
- * pprof captures are gzipped; everything else is stored uncompressed.
+ * Reads an input as committed. The pipeline strips the compression some are
+ * committed in (gzipped pprof captures, LZ4 memray captures).
  */
-export const readInput = (filename: string): Buffer => {
-  const data = readFileSync(inputPath(filename))
-  return data[0] === 0x1f && data[1] === 0x8b ? gunzipSync(data) : data
-}
+export const readInput = (filename: string): Buffer =>
+  readFileSync(inputPath(filename))
 
 /**
  * The lines auto-detecting a committed input logs, given the Markdown it

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,35 +1,45 @@
 import terser from '@rollup/plugin-terser'
 import treeShakeable from 'rollup-plugin-tree-shakeable'
 import { defineConfig } from 'tsdown/config'
+import type { UserConfig } from 'tsdown/config'
+
+/**
+ * The library bundle's settings, shared by its two platforms.
+ *
+ * A platform selects the `#compression` implementation in `package.json`'s
+ * `imports`: the `node` build decodes with `node:zlib`, and the `neutral` build
+ * with `DecompressionStream`.
+ */
+const library = {
+  entry: `src/index.ts`,
+  sourcemap: `inline`,
+  dts: false,
+  publint: true,
+  minify: false,
+  plugins: [
+    terser({
+      // Assume modern JavaScript
+      ecma: 2020,
+      module: true,
+      toplevel: true,
+      // Run multiple times
+      compress: {
+        passes: 3,
+      },
+      // Mangle underscore prefixed properties
+      mangle: {
+        properties: {
+          regex: `^_[^_]+`,
+        },
+      },
+    }),
+    treeShakeable(),
+  ],
+} satisfies UserConfig
 
 export default defineConfig([
-  {
-    entry: `src/index.ts`,
-    platform: `neutral`,
-    sourcemap: `inline`,
-    dts: false,
-    publint: true,
-    minify: false,
-    plugins: [
-      terser({
-        // Assume modern JavaScript
-        ecma: 2020,
-        module: true,
-        toplevel: true,
-        // Run multiple times
-        compress: {
-          passes: 3,
-        },
-        // Mangle underscore prefixed properties
-        mangle: {
-          properties: {
-            regex: `^_[^_]+`,
-          },
-        },
-      }),
-      treeShakeable(),
-    ],
-  },
+  { ...library, platform: `neutral` },
+  { ...library, platform: `node`, outDir: `dist/node` },
   {
     entry: `src/index.ts`,
     dts: { emitDtsOnly: true },


### PR DESCRIPTION
The CLI stripped gzip and brotli and the memray converter stripped LZ4, so the API accepted an LZ4 memray capture but not a gzipped pprof profile. A compression module ahead of format detection now strips gzip and LZ4 by their magic bytes, and tries brotli only once the bytes convert to nothing as they are, keeping the original failure when that fails too, because a brotli decoder accepts some bytes that are not brotli (an uncompressed pprof profile decodes to nothing).

The `#compression` import resolves to a Node runtime that decodes with `node:zlib`, synchronously and as a stream, or to a web runtime that decodes with `DecompressionStream`, where the sync API cannot decompress gzip and brotli decodes only where the runtime accepts the format. The package publishes a bundle per runtime through conditional exports. A gzipped `Blob` or stream streams through the decoder instead of being read into memory.